### PR TITLE
YES tool - Adds reducer for goals

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer.js
@@ -1,0 +1,118 @@
+import { actionCreator, assign } from '../util';
+
+const GOAL_TIMELINES = [
+  '3 to 6 months',
+  '6 to 9 months',
+  '9 months to 1 year',
+  '1 year or more'
+];
+
+const TYPES = {
+  UPDATE_LONG_TERM_GOAL: 'UPDATE_LONG_TERM_GOAL',
+  UPDATE_GOAL_IMPORTANCE: 'UPDATE_GOAL_IMPORTANCE',
+  UPDATE_GOAL_STEPS: 'UPDATE_GOAL_STEPS',
+  UPDATE_GOAL_TIMELINE: 'UPDATE_GOAL_TIMELINE'
+};
+
+const initialState = {
+  longTermGoal: '',
+  goalImportance: '',
+  goalSteps: '',
+  goalTimeline: ''
+};
+
+const handlers = {
+  UPDATE_LONG_TERM_GOAL: updateGoal,
+  UPDATE_GOAL_IMPORTANCE: updateImportance,
+  UPDATE_GOAL_STEPS: updateSteps,
+  UPDATE_GOAL_TIMELINE: updateTimeline
+};
+
+const updateGoalAction = actionCreator(
+  TYPES.UPDATE_LONG_TERM_GOAL
+);
+const updateGoalImportanceAction = actionCreator(
+  TYPES.UPDATE_GOAL_IMPORTANCE
+);
+const updateGoalStepsAction = actionCreator(
+  TYPES.UPDATE_GOAL_STEPS
+);
+const updateGoalTimelineAction = actionCreator(
+  TYPES.UPDATE_GOAL_TIMELINE
+);
+
+/**
+ *
+ * @param {object} state the current values for this slice of app state
+ * @param {object} action instructs reducer which state update to apply
+ * @returns {object} the updated state object
+ */
+function updateGoal( state, action ) {
+  return assign( state, {
+    longTermGoal: action.data
+  } );
+}
+
+/**
+ *
+ * @param {object} state the current values for this slice of app state
+ * @param {object} action instructs reducer which state update to apply
+ * @returns {object} the updated state object
+ */
+function updateImportance( state, action ) {
+  return assign( state, {
+    goalImportance: action.data
+  } );
+}
+
+/**
+ *
+ * @param {object} state the current values for this slice of app state
+ * @param {object} action instructs reducer which state update to apply
+ * @returns {object} the updated state object
+ */
+function updateSteps( state, action ) {
+  return assign( state, {
+    goalSteps: action.data
+  } );
+}
+
+/**
+ *
+ * @param {object} state the current values for this slice of app state
+ * @param {object} action instructs reducer which state update to apply
+ * @returns {object} the updated state object
+ */
+function updateTimeline( state, action ) {
+  const timeline = action.data;
+  const validTimeline = GOAL_TIMELINES.includes( timeline ) ? timeline : '';
+
+  return assign( state, {
+    goalTimeline: validTimeline
+  } );
+}
+
+/**
+ *
+ * @param {object} state the current values for this slice of app state
+ * @param {object} action instructs reducer which state update to apply
+ * @returns {object} the updated state object
+ */
+function goalReducer( state = initialState, action ) {
+  if ( handlers.hasOwnProperty( action.type ) ) {
+    const handler = handlers[action.type];
+    return handler( state, action );
+  }
+
+  return state;
+}
+
+export {
+  GOAL_TIMELINES,
+  initialState,
+  updateGoalAction,
+  updateGoalImportanceAction,
+  updateGoalStepsAction,
+  updateGoalTimelineAction
+};
+export default goalReducer;

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/goal-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/goal-reducer-spec.js
@@ -1,0 +1,61 @@
+import goalReducer, {
+  GOAL_TIMELINES,
+  initialState,
+  updateGoalAction,
+  updateGoalImportanceAction,
+  updateGoalStepsAction,
+  updateGoalTimelineAction
+} from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer';
+
+let UNDEFINED;
+
+describe( 'goalReducer', () => {
+  it( 'returns an initial state when it recevives an unsupported action type', () => {
+    const state = goalReducer( UNDEFINED, { type: null } );
+
+    expect( state ).toEqual( initialState );
+  } );
+
+  it( 'reduces the UPDATE_LONG_TERM_GOAL action ', () => {
+    const text = 'some text';
+    const state = goalReducer( UNDEFINED, updateGoalAction( text ) );
+
+    expect( state.longTermGoal ).toBe( text );
+  } );
+
+  it( 'reduces the UPDATE_GOAL_IMPORTANCE action ', () => {
+    const text = 'some text';
+    const state = goalReducer( UNDEFINED, updateGoalImportanceAction( text ) );
+
+    expect( state.goalImportance ).toBe( text );
+  } );
+
+  it( 'reduces the UPDATE_GOAL_STEPS action ', () => {
+    const text = 'some text';
+    const state = goalReducer( UNDEFINED, updateGoalStepsAction( text ) );
+
+    expect( state.goalSteps ).toBe( text );
+  } );
+
+  it( 'reduces the UPDATE_GOAL_TIMELINE action ', () => {
+    const value = '3 to 6 months';
+    const state = goalReducer( UNDEFINED, updateGoalTimelineAction( value ) );
+
+    expect( state.goalTimeline ).toBe( value );
+  } );
+
+  it( 'reduces the goalTimeline property to an empty string when invalid data is received', () => {
+    GOAL_TIMELINES.forEach( value => {
+      expect(
+        goalReducer( UNDEFINED, updateGoalTimelineAction( value ) ).goalTimeline
+      ).toBe( value );
+    } );
+
+    expect(
+      goalReducer( UNDEFINED, updateGoalTimelineAction( 1 ) ).goalTimeline
+    ).toBe( initialState.goalTimeline );
+    expect(
+      goalReducer( UNDEFINED, updateGoalTimelineAction( 'Text value' ) ).goalTimeline
+    ).toBe( initialState.goalTimeline );
+  } );
+} );


### PR DESCRIPTION
Adds reducer for handling goals data.

## Additions

- `goalReducer` function

## Removals

-

## Changes

-

## Testing

1. Just unit tests here

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
