### PR TITLE
Save a full list of housing counselor results

### DIFF
--- a/cfgov/housing_counselor/management/commands/hud_generate_json.py
+++ b/cfgov/housing_counselor/management/commands/hud_generate_json.py
@@ -10,6 +10,7 @@ from housing_counselor.generator import generate_counselor_json
 from housing_counselor.geocoder import (
     GazetteerZipCodeFile, GeocodedZipCodeCsv, geocode_counselors
 )
+from housing_counselor.results_archiver import save_list
 
 
 logger = logging.getLogger(__name__)
@@ -24,10 +25,13 @@ class Command(BaseCommand):
                             help='CSV containing zipcode lat/lngs')
         parser.add_argument('--zipcode-gazetteer-file',
                             help='Census Gazetteer zipcode file')
+        parser.add_argument('--archive-file-name',
+                            help='Archive file output path', required=True)
 
     def handle(self, *args, **options):
         zipcode_csv_file = options['zipcode_csv_file']
         zipcode_gazetteer_file = options['zipcode_gazetteer_file']
+        archive_file_name = options['archive_file_name']
 
         if zipcode_csv_file:
             zipcodes = GeocodedZipCodeCsv.read(zipcode_csv_file)
@@ -42,6 +46,9 @@ class Command(BaseCommand):
 
         # Retrieve counselors from the HUD website.
         counselors = fetch_counselors()
+
+        # Save the full list, for archive purposes
+        save_list(counselors, archive_file_name)
 
         # Standardize formatting of counselor data.
         counselors = clean_counselors(counselors)

--- a/cfgov/housing_counselor/results_archiver.py
+++ b/cfgov/housing_counselor/results_archiver.py
@@ -1,0 +1,17 @@
+import json
+from zipfile import ZIP_DEFLATED, ZipFile
+
+
+json_file_name = 'HUD_approved_housing_counselors.json'
+
+
+# By request from stakeholders in the Office of Innovation, save a
+# list of the full results we receive from the HUD API, in case of
+# future enforcement actions.
+
+# As an MVP, we're saving the complete JSON response, zipped. As a
+# future enhancement, we could consider improving the format of the
+# data, e.g. as CSV.
+def save_list(counselors, path):
+    with ZipFile(path, 'w', ZIP_DEFLATED, allowZip64=True) as zip_file:
+        zip_file.writestr(json_file_name, json.dumps(counselors))

--- a/cfgov/housing_counselor/tests/management/test_results_archiver.py
+++ b/cfgov/housing_counselor/tests/management/test_results_archiver.py
@@ -1,0 +1,26 @@
+import json
+import os
+import shutil
+from tempfile import mkdtemp
+from unittest import TestCase
+from zipfile import ZipFile
+
+from housing_counselor.results_archiver import json_file_name, save_list
+
+
+class TestHousingCounselorResultsArchiver(TestCase):
+    def setUp(self):
+        self.temp_directory = mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_directory)
+
+    def test_save_list_creates_zip_file(self):
+        content = [
+            {"fake": 1, "housing": "counselor", "json": 2},
+            {"fake": 3, "housing": "data", "json": 4},
+        ]
+        zip_path = os.path.join(self.temp_directory, 'archive.zip')
+
+        save_list(content, zip_path)
+        with ZipFile(zip_path) as zip_file:
+            zip_content = json.loads(zip_file.read(json_file_name))
+            self.assertEqual(zip_content, content)

--- a/docs/housing-counselor-tool.md
+++ b/docs/housing-counselor-tool.md
@@ -62,9 +62,10 @@ This step calls the [`hud_generate_json`](https://github.com/cfpb/cfgov-refresh/
 which performs the following steps:
 
   1. fetch agency listings from HUD
-  2. clean the results
-  3. fill in any missing latitude and longitude values
-  4. create files of the 10 nearest results for each U.S. ZIP code
+  2. save a copy of the full results, for our records
+  3. clean the results
+  4. fill in any missing latitude and longitude values
+  5. create files of the 10 nearest results for each U.S. ZIP code
 
 
 #### Fetch agency listings
@@ -112,13 +113,20 @@ It returns thousands of results like this:
 },
 ```
 
-#### Clean the results
-
-(_in [`fetcher.py`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/housing_counselor/fetcher.py)_)
-
-We replace the `languages` value with the full language names.
+Next, we replace the `languages` value with the full language names.
 We replace the `services` value with fully spelled out service descriptions.
 Both of these mappings come from the HUD API.
+
+#### Save the results
+
+(_in [`results_archiver.py`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/housing_counselor/results_archiver.py)_)
+
+Save a copy of the full set of results as a zip file in the home directory.
+The Jenkins job then transfers the zip file to S3 as part of the `MAKE JSON` step.
+The file is saved in S3 at `/archive/{date}.zip`.
+This copy can be used as the canonical set of HUD data that day in case of an enforcement action.
+
+#### Clean the results
 
 (_in [`cleaner.py`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/housing_counselor/cleaner.py)_)
 


### PR DESCRIPTION
The Office of Innovation needs the Bureau to retain a copy of each day's list of HUD-approved housing counselors.

## Additions

- Add a step to the `hud_generate_json` management command that takes the full set of results and saves them to a .zip file.
- Add a test for this functionality
- Update public documentation of the Housing Counselor data processing

## Testing

1. `cfgov/manage.py hud_generate_json jsons --archive-file-name ./test-archive.zip`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
