### PR TITLE
YES tool — Add entries helper function

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/input-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/input-view.js
@@ -1,18 +1,10 @@
-import { UNDEFINED, assign } from './util';
+import { assign, entries } from './util';
 import { setInitFlag } from '../../../js/modules/util/atomic-helpers';
 
 const defaultProps = {
   type: 'text'
 };
 const NODE_MISSING_ERROR = 'InputView expects to be initialized with an input node matching the supplied `type` prop';
-
-/**
- * Noop fallback for undefined event handlers
- * @returns {undefined} undefined
- */
-function noop() {
-  return UNDEFINED;
-}
 
 /**
  * Get the correct DOM node this view controls
@@ -70,14 +62,7 @@ function InputView( element, props = {} ) {
    */
   function _bindEvents() {
     const { events = {}} = props;
-    const eventHandlers = [];
-
-    for ( const event in events ) {
-      if ( events.hasOwnProperty( event ) ) {
-        const handler = events[event] || noop;
-        eventHandlers.push( [ event, handler ] );
-      }
-    }
+    const eventHandlers = entries( events );
 
     eventHandlers.forEach( ( [ event, handler ] ) => {
       const handlerCache = _eventsMap[event] || [];
@@ -94,15 +79,7 @@ function InputView( element, props = {} ) {
    * Unbind all event handlers from the input
    */
   function _unbindEvents() {
-    const events = [];
-
-    for ( const event in _eventsMap ) {
-      if ( _eventsMap.hasOwnProperty( event ) ) {
-        const handlers = _eventsMap[event];
-
-        events.push( [ event, handlers ] );
-      }
-    }
+    const events = entries( _eventsMap );
 
     events.forEach( ( [ event, handlers ] ) => {
       handlers.forEach( handler => _dom.removeEventListener( event, handler ) );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -2,6 +2,7 @@ let UNDEFINED;
 
 const REDUCER_RETURN_ERROR = 'Reducer must return a state object';
 const INVALID_ARG_ERROR = 'The "reducers" argument must be an object, where each value is a reducer function';
+const INVALID_OBJECT_ERROR = 'The `entries` function must be passed an object as its first argument';
 
 /**
  * Helper method to generate an action creator
@@ -75,20 +76,13 @@ const processStateFromReducers = reducers => (
 };
 
 const combineReducers = reducers => {
-  if ( reducers && typeof reducers !== 'object' ) {
+  if ( !isObject( reducers ) ) {
     throw new TypeError( INVALID_ARG_ERROR );
   }
 
-  const entries = [];
+  const list = entries( reducers );
 
-  for ( const reducerName in reducers ) {
-    if ( reducers.hasOwnProperty( reducerName ) ) {
-      const reducerFunc = reducers[reducerName];
-      entries.push( [ reducerName, reducerFunc ] );
-    }
-  }
-
-  const combinedReducers = entries.reduce( ( memo, [ name, maybeFunc ] ) => {
+  const combinedReducers = list.reduce( ( memo, [ name, maybeFunc ] ) => {
     if ( typeof maybeFunc === 'function' ) {
       memo[name] = maybeFunc;
     }
@@ -127,9 +121,48 @@ function assign( output = {}, source ) {
   }, merged );
 }
 
+/**
+ * Helper function to determine if a value is an object
+ * @param {object} maybeObject Value to be verified as an object
+ * @returns {Boolean} whether or not the supplied value is an object
+ */
+function isObject( maybeObject ) {
+  return maybeObject &&
+    typeof maybeObject !== 'function' &&
+    !( maybeObject instanceof Array ) &&
+    typeof maybeObject === 'object';
+}
+
+/**
+ * Function to convert an object into an array of arrays, when the first
+ * element of each subarray corresponds to one of the object's keys, and
+ * the second element corresponds to that key's value.
+ *
+ * @param {object} object The object to be converted into an array
+ * @returns {Array} An array of arrays
+ */
+function entries( object ) {
+  if ( !isObject( object ) ) {
+    throw new Error( INVALID_OBJECT_ERROR );
+  }
+
+  const result = [];
+
+  for ( const prop in object ) {
+    if ( object.hasOwnProperty( prop ) ) {
+      const value = object[prop];
+
+      result.push( [ prop, value ] );
+    }
+  }
+
+  return result;
+}
+
 export {
   actionCreator,
   assign,
   combineReducers,
+  entries,
   UNDEFINED
 };

--- a/test/unit_tests/apps/youth-employment-success/js/util-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/util-spec.js
@@ -2,7 +2,8 @@ import {
   UNDEFINED,
   actionCreator,
   assign,
-  combineReducers
+  combineReducers,
+  entries
 } from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
 
 const reducerStateA = {
@@ -43,7 +44,7 @@ const reducerB = ( () => ( state = reducerStateB, action ) => {
 } )();
 
 describe( 'YES utility functions', () => {
-  describe( 'action', () => {
+  describe( 'actionCreator', () => {
     const actionType = 'MY_ACTION';
 
     it( 'returns a curried function', () => {
@@ -135,6 +136,29 @@ describe( 'YES utility functions', () => {
       } );
 
       expect( nextState.b ).toEqual( reducerStateB );
+    } );
+  } );
+
+  describe( '.entries', () => {
+    it( 'throws an error when it receives a value that isn\'t an object', () => {
+      const invalidArgs = [ function() { return 'a'; }, null, 1, 'bad', [] ];
+
+      invalidArgs.forEach( invalidArg => expect( () => entries( invalidArg ) ).toThrow()
+      );
+    } );
+
+    it( 'reduces an object into an array of arays form key/value pairs', () => {
+      const pet = {
+        name: 'buddy',
+        type: 'cat'
+      };
+
+      const objectEntries = entries( pet );
+
+      expect( objectEntries[0][0] ).toBe( 'name' );
+      expect( objectEntries[0][1] ).toBe( pet.name );
+      expect( objectEntries[1][0] ).toBe( 'type' );
+      expect( objectEntries[1][1] ).toBe( pet.type );
     } );
   } );
 } );


### PR DESCRIPTION
Centralizes the several instances of duplicated functionality into a single `entries` function. This allows the codebase to continue supporting IE 11 

## Additions

- Adds `entries` utility function

## Removals

- Removes duplicated `entries` behavior from views / `combineReducers`

## Changes

-

## Testing

1. Just unit tests here

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
