### PR TITLE
Make sure pages point to HTTPS instead of HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/cfpb/cfgov-refresh.png?branch=master)](https://travis-ci.org/cfpb/cfgov-refresh?branch=master)
 [![codecov](https://codecov.io/gh/cfpb/cfgov-refresh/branch/master/graph/badge.svg)](https://codecov.io/gh/cfpb/cfgov-refresh)
 
-The redesign of the [www.consumerfinance.gov](http://www.consumerfinance.gov) website.
+The redesign of the [www.consumerfinance.gov](https://www.consumerfinance.gov) website.
 This Django project includes the front-end assets and build tools,
 [Jinja templates](http://jinja.pocoo.org) for front-end rendering,
 and [Wagtail CMS](https://wagtail.io) for content administration.

--- a/cfgov/apache/conf.d/user-testing.conf
+++ b/cfgov/apache/conf.d/user-testing.conf
@@ -25,7 +25,7 @@ Alias /testing/ ${CFGOV_SANDBOX}
         <p class=\"beta-banner_desc expandable_content\" style=\"margin: 0; font-size: 1em; line-height=1.375\"> \
             Some things may not work as expected. \
             Our regular site continues to be at \
-            <a href=\"http://www.consumerfinance.gov/\">www.consumerfinance.gov</a>. \
+            <a href=\"https://www.consumerfinance.gov/\">www.consumerfinance.gov</a>. \
         </p> \
     </div> \
 </div>|i"

--- a/cfgov/hmda/templates/hmda/orange-explorer.html
+++ b/cfgov/hmda/templates/hmda/orange-explorer.html
@@ -20,7 +20,7 @@
                   |__/
 
 * hmda-explorer - v2.6.8 - 2019-03-07
-* http://consumerfinance.gov/hmda
+* https://consumerfinance.gov/hmda
 * Copyright (c) 2019 Consumer Financial Protection Bureau; Licensed Public Domain */
 
  /* ===========================================================
@@ -698,7 +698,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   <div class="top-banner">
     <div class="inner">
-      <p class="return-cfgov">Return to <a href="http://www.consumerfinance.gov/hmda">consumerfinance.gov/hmda</a></p>
+      <p class="return-cfgov">Return to <a href="https://www.consumerfinance.gov/hmda">consumerfinance.gov/hmda</a></p>
       <p class="official-website">An official website of the United States Government<img width="16" height="11" alt="US Flag" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAALCAMAAABBPP0LAAAAG1BMVEUdM7EeNLIeM7HgQCDaPh/bPh/bPx/////bPyBEby41AAAAU0lEQVR42m3OQQ7AQAgCQKDo+v8XVzft9lI4MjEClCDwssNpQ2tKrSeQqEk1cBMQDbB4BNugVYUzHe8NfQKaCun0BO9yhO3a2yb5I+a9isgoD/YND+IDPpA8kqMAAAAASUVORK5CYII="></p>
     </div>
   </div>
@@ -1690,15 +1690,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <footer role="contentinfo">
   <nav role="navigation" aria-label="Footer Menu">
     <ul class="primary">
-      <li><a href="http://www.consumerfinance.gov/">consumerfinance.gov</a>
+      <li><a href="https://www.consumerfinance.gov/">consumerfinance.gov</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/contact-us/">Contact us</a>
+      <li><a href="https://www.consumerfinance.gov/contact-us/">Contact us</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/newsroom/">Newsroom</a>
+      <li><a href="https://www.consumerfinance.gov/newsroom/">Newsroom</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/jobs/">Jobs</a>
+      <li><a href="https://www.consumerfinance.gov/jobs/">Jobs</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/open/">Open government</a>
+      <li><a href="https://www.consumerfinance.gov/open/">Open government</a>
       </li>
     </ul>
     <ul class="social">
@@ -1728,21 +1728,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </li>
     </ul>
     <ul class="tertiary">
-      <li><a href="http://www.consumerfinance.gov/privacy-policy/">Privacy policy and legal notices</a>
+      <li><a href="https://www.consumerfinance.gov/privacy-policy/">Privacy policy and legal notices</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/accessibility/">Accessibility</a>
+      <li><a href="https://www.consumerfinance.gov/accessibility/">Accessibility</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/plain-writing/">Plain writing</a>
+      <li><a href="https://www.consumerfinance.gov/plain-writing/">Plain writing</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/no-fear-act/">No FEAR Act</a>
+      <li><a href="https://www.consumerfinance.gov/no-fear-act/">No FEAR Act</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/foia/">FOIA</a>
+      <li><a href="https://www.consumerfinance.gov/foia/">FOIA</a>
       </li>
       <li><a href="http://usa.gov/">USA.gov</a>
       </li>
       <li><a href="http://www.federalreserve.gov/oig/default.htm">Office of Inspector General</a>
       </li>
-      <li><a href="http://www.consumerfinance.gov/ombudsman/">Ombudsman</a>
+      <li><a href="https://www.consumerfinance.gov/ombudsman/">Ombudsman</a>
       </li>
     </ul>
   </nav>
@@ -1763,7 +1763,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                   |__/
 
 * hmda-explorer - v2.6.8 - 2019-03-07
-* http://consumerfinance.gov/hmda
+* https://consumerfinance.gov/hmda
 * Copyright (c) 2019 Consumer Financial Protection Bureau; Licensed Public Domain */
 
  /* ===========================================================
@@ -1896,7 +1896,7 @@ k});Gc&&aa&&"function"==typeof rc&&(yb=sb(rc,d));var bd=8==Cc(G+"08")?Cc:functio
                   |__/
 
 * hmda-explorer - v2.6.8 - 2019-03-07
-* http://consumerfinance.gov/hmda
+* https://consumerfinance.gov/hmda
 * Copyright (c) 2019 Consumer Financial Protection Bureau; Licensed Public Domain */
 
  /* ===========================================================

--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -912,7 +912,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                             harbor tools is provided by the Bureau’s regulation
                                             at 1026.35(b)(2)(iv)(C) and comment 35(b)(2)(iv)-1.
                                             You may also visit the Bureau’s
-                                            <a href="http://www.consumerfinance.gov/regulatory-implementation/title-xiv/" alt="Regulation Implementation site for Title XIV rules">Regulation Implementation site for Title XIV rules</a>
+                                            <a href="https://www.consumerfinance.gov/regulatory-implementation/title-xiv/" alt="Regulation Implementation site for Title XIV rules">Regulation Implementation site for Title XIV rules</a>
                                             for additional information.
                                         </p>
                                     </div>
@@ -954,22 +954,22 @@ home price, down payment, and more can affect mortgage interest rates.
                     </header>
                     <ul class="m-list m-list__links">
                         <li class="m-list_item">
-                            <a href="http://www.consumerfinance.gov/eregulations/1026" title="Truth in Lending Act (Regulation Z)">Truth in Lending Act (Regulation Z)</a>
+                            <a href="https://www.consumerfinance.gov/eregulations/1026" title="Truth in Lending Act (Regulation Z)">Truth in Lending Act (Regulation Z)</a>
                         </li>
                         <li class="m-list_item">
-                            <a href="http://www.consumerfinance.gov/regulatory-implementation/title-xiv/" title="Title XIV Rule Implementation Site">Title XIV Rule Implementation Site</a>
+                            <a href="https://www.consumerfinance.gov/regulatory-implementation/title-xiv/" title="Title XIV Rule Implementation Site">Title XIV Rule Implementation Site</a>
                         </li>
                         <li class="m-list_item">
-                            <a href="http://www.consumerfinance.gov/regulatory-implementation/title-xiv/#resources" title="Ability to Repay / Qualified Mortgage Rule Small Entity Compliance Guide">Ability to Repay / Qualified Mortgage Rule Small Entity Compliance Guide</a>
+                            <a href="https://www.consumerfinance.gov/regulatory-implementation/title-xiv/#resources" title="Ability to Repay / Qualified Mortgage Rule Small Entity Compliance Guide">Ability to Repay / Qualified Mortgage Rule Small Entity Compliance Guide</a>
                         </li>
                         <li class="m-list_item">
-                            <a href="http://www.consumerfinance.gov/regulatory-implementation/title-xiv/#resources" title="2013 HOEPA Rule Small Entity Compliance Guide">2013 HOEPA Rule Small Entity Compliance Guide</a>
+                            <a href="https://www.consumerfinance.gov/regulatory-implementation/title-xiv/#resources" title="2013 HOEPA Rule Small Entity Compliance Guide">2013 HOEPA Rule Small Entity Compliance Guide</a>
                         </li>
                         <li class="m-list_item">
-                            <a href="http://www.consumerfinance.gov/regulatory-implementation/title-xiv/#resources" title="Higher-Priced Mortgage Loans Escrow Rule Entity Compliance Guide">Higher-Priced Mortgage Loans Escrow Rule Entity Compliance Guide</a>
+                            <a href="https://www.consumerfinance.gov/regulatory-implementation/title-xiv/#resources" title="Higher-Priced Mortgage Loans Escrow Rule Entity Compliance Guide">Higher-Priced Mortgage Loans Escrow Rule Entity Compliance Guide</a>
                         </li>
                         <li class="m-list_item">
-                            <a href="http://www.consumerfinance.gov/guidance/#compliance" title="Rural or Underserved Counties List">Rural or Underserved Counties List</a>
+                            <a href="https://www.consumerfinance.gov/guidance/#compliance" title="Rural or Underserved Counties List">Rural or Underserved Counties List</a>
                         </li>
                     </ul>
 

--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -11,7 +11,7 @@
 Hey! If you're viewing this, you should probably come work on our Technology
 & Innovation team. We're always looking for a few great designers; developers;
 data scientists; and network, infrastructure, privacy, and security pros.
-Keep an eye on our job opportunities at http://www.consumerfinance.gov/jobs/
+Keep an eye on our job opportunities at https://www.consumerfinance.gov/jobs/
 
 Also, you can see more of our code at https://github.com/cfpb
 

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -217,7 +217,7 @@ def load(source, s3=False):
     updated_programs = 0
     FAILED = []  # failed messages
     if s3:
-        s3_url = ('http://files.consumerfinance.gov.s3.amazonaws.com'
+        s3_url = ('https://files.consumerfinance.gov.s3.amazonaws.com'
                   '/pb/paying_for_college/csv/validated_program_data/{}')
         raw_data = read_in_s3(s3_url.format(source))
     else:

--- a/cfgov/paying_for_college/static/paying_for_college/feedback/css/comparison-tool.css
+++ b/cfgov/paying_for_college/static/paying_for_college/feedback/css/comparison-tool.css
@@ -3,9 +3,9 @@ In general, organization flows from the top of the page to the bottom.
 PFC = Paying for College
 
 Styles are for:
-- http://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/
-- http://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/feedback/
-- http://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/technote/
+- https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/
+- https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/feedback/
+- https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/technote/
 
 Table of Contents
 -----------------
@@ -1851,8 +1851,8 @@ label.tooltip-info {
 
 /* OTHER PAGES
 This contains styles for
-- http://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/feedback/
-- http://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/technote/
+- https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/feedback/
+- https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/technote/
 -------------------------------------------------------------------------------*/
 /* A grid only used for /paying-for-college/ and /technote/ */
 /* Clear these with .clearfix */

--- a/cfgov/paying_for_college/templates/paying_for_college/disclosure.html
+++ b/cfgov/paying_for_college/templates/paying_for_college/disclosure.html
@@ -3208,14 +3208,14 @@
                                             financial aid.</p>
                                     </div>
                                     <div>
-                                        <a href="http://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
+                                        <a href="https://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
                                         target="_blank" rel="noopener noreferrer">Student
                                         loan guide</a>
                                         <p>Choose a student loan that’s right
                                             for you.</p>
                                     </div>
                                     <div>
-                                        <a href="http://www.consumerfinance.gov/paying-for-college/manage-your-college-money/" target="_blank" rel="noopener noreferrer">Student banking guide</a>
+                                        <a href="https://www.consumerfinance.gov/paying-for-college/manage-your-college-money/" target="_blank" rel="noopener noreferrer">Student banking guide</a>
                                         <p>Manage your college money.</p>
                                     </div>
                                 </div>

--- a/cfgov/paying_for_college/templates/paying_for_college/disclosure_technote.html
+++ b/cfgov/paying_for_college/templates/paying_for_college/disclosure_technote.html
@@ -300,7 +300,7 @@
                         Parents of undergraduate students may be eligible to
                         receive a Parent PLUS loan, which is very similar to a
                         Grad PLUS loan. If your parents take out a <a
-                        href="http://www.consumerfinance.gov/askcfpb/553/what-plus-loan.html"
+                        href="https://www.consumerfinance.gov/askcfpb/553/what-plus-loan.html"
                         target="_blank" rel="noopener noreferrer">Parent PLUS</a>
                         loan to help pay for college costs, enter it in this
                         section. Since these loans are ones that someone else
@@ -755,7 +755,7 @@
                     </p>
                     <p>
                         The <a
-                        href="http://www.consumerfinance.gov/askcfpb/547/what-should-i-consider-when-deciding-how-much-borrow.html"
+                        href="https://www.consumerfinance.gov/askcfpb/547/what-should-i-consider-when-deciding-how-much-borrow.html"
                         target="_blank" rel="noopener noreferrer">general rule of thumb</a>
                         for undergraduates is that your &ldquo;debt when
                         repayment begins&rdquo; should not exceed your
@@ -1074,14 +1074,14 @@
                     </div>
                     <div>
                         <a
-                        href="http://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
+                        href="https://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
                         target="_blank" rel="noopener noreferrer">Student loan guide</a>
                         <p>
                             Choose a student loan that’s right for you.
                         </p>
                     </div>
                     <div>
-                        <a href="http://www.consumerfinance.gov/paying-for-college/manage-your-college-money/"
+                        <a href="https://www.consumerfinance.gov/paying-for-college/manage-your-college-money/"
                         target="_blank" rel="noopener noreferrer">Student banking guide</a>
                         <p>
                             Manage your college money.

--- a/cfgov/unprocessed/root/data.json
+++ b/cfgov/unprocessed/root/data.json
@@ -34,7 +34,7 @@
 
       },
 
-      "describedBy": "http://www.consumerfinance.gov/complaintdatabase/technical-documentation/#field-reference",
+      "describedBy": "https://www.consumerfinance.gov/complaintdatabase/technical-documentation/#field-reference",
 
       "description": "These are complaints we’ve received about financial products and services.",
 
@@ -64,7 +64,7 @@
 
           "@type": "dcat:Distribution",
 
-          "downloadURL": "http://data.consumerfinance.gov/api/views.json",
+          "downloadURL": "https://data.consumerfinance.gov/api/views.json",
 
           "mediaType": "application/json"
 
@@ -74,7 +74,7 @@
 
           "@type": "dcat:Distribution",
 
-          "downloadURL": "http://data.consumerfinance.gov/api/views.xml",
+          "downloadURL": "https://data.consumerfinance.gov/api/views.xml",
 
           "mediaType": "application/xml"
 
@@ -86,7 +86,7 @@
 
           "format": "API",
 
-          "accessURL": "http://data.consumerfinance.gov/api/views/s6ew-h6mp.json"
+          "accessURL": "https://data.consumerfinance.gov/api/views/s6ew-h6mp.json"
 
         }
 
@@ -122,7 +122,7 @@
 
       ],
 
-      "landingPage": "http://www.consumerfinance.gov/complaintdatabase",
+      "landingPage": "https://www.consumerfinance.gov/complaintdatabase",
 
       "modified": "2013-11-06",
 
@@ -248,7 +248,7 @@
 
       ],
 
-      "landingPage": "http://www.consumerfinance.gov/hmda/",
+      "landingPage": "https://www.consumerfinance.gov/hmda/",
 
       "modified": "2014-09-22",
 

--- a/test/unit_tests/js/organisms/MegaMenu-spec.js
+++ b/test/unit_tests/js/organisms/MegaMenu-spec.js
@@ -170,7 +170,7 @@ const HTML_SNIPPET = `
                                             <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid o-mega-menu_content-2-grid__three-col">
 
                                                 <h3 class="o-mega-menu_content-overview o-mega-menu_content-2-overview o-mega-menu_content-overview-heading o-mega-menu_content-2-overview-heading">
-                                                    <a class="o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link" href="http://content.consumerfinance.gov/data-research/">Data &amp; Research Overview</a>
+                                                    <a class="o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link" href="https://content.consumerfinance.gov/data-research/">Data &amp; Research Overview</a>
                                                 </h3>
 
                                                 <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists ">


### PR DESCRIPTION
Change http to https for www.consumerfinance.gov links

From the June crawl report, there were still a number of internal CF.gov links that point to http instead of https).

PDFs on the Consumer Advisory Board page pointed to http instead of https.