### PR TITLE
Fix download on rural or underserved tool

### DIFF
--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -295,7 +295,7 @@ home price, down payment, and more can affect mortgage interest rates.
                         </p>
 
                         <div class="o-table o-table-wrapper__scrolling">
-                            <table>
+                            <table class="rout-results-table">
                                 <thead>
                                     <tr>
                                         <th width="31.5%">Address Entered</th>
@@ -328,7 +328,7 @@ home price, down payment, and more can affect mortgage interest rates.
                         <p class="col-8">These properties <strong>cannot</strong> be counted as rural or underserved.</p>
 
                         <div class="o-table o-table-wrapper__scrolling">
-                            <table>
+                            <table class="rout-results-table">
                                 <thead>
                                     <tr>
                                         <th width="31.5%">Address Entered</th>
@@ -364,7 +364,7 @@ home price, down payment, and more can affect mortgage interest rates.
                         </p>
 
                         <div class="o-table o-table-wrapper__scrolling">
-                            <table>
+                            <table class="rout-results-table">
                                 <thead>
                                     <tr>
                                         <th width="31.5%">Address Entered</th>
@@ -400,7 +400,7 @@ home price, down payment, and more can affect mortgage interest rates.
                         </p>
 
                         <div class="o-table o-table-wrapper__scrolling">
-                            <table>
+                            <table class="rout-results-table">
                                 <thead>
                                     <tr>
                                         <th width="31.5%">Address Entered</th>

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -400,7 +400,7 @@ function generateCSV() {
   }
 
   // loop through each row
-  [].slice.call( DT.getEls( 'table tbody tr td' ) )
+  [].slice.call( DT.getEls( '.rout-results-table tbody tr td' ) )
     .forEach( _loopHandler );
 
   return theCSV;

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -400,7 +400,7 @@ function generateCSV() {
   }
 
   // loop through each row
-  [].slice.call( DT.getEls( '.table tbody tr td' ) )
+  [].slice.call( DT.getEls( 'table tbody tr td' ) )
     .forEach( _loopHandler );
 
   return theCSV;


### PR DESCRIPTION
## Changes

- Uses the `table` tag rather than the `.table` class for the download selector. Looks like this was changed in the move to wagtail.

## Testing

1. Pull branch, build.
2. Enter an address, hit "Check addresses"
3. Click "Download results"

The resulting file should be populated with data. Following these steps on cf.gov will result in a file with only headers.