### PR TITLE
YES Tool — Average cost combo field

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/route-option-form.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-option-form.html
@@ -1,7 +1,7 @@
 {% from 'atoms/radio-button.html' import render with context %}
 {% set labels = ['Walk', 'Drive', 'Bike', 'Public transit', 'Get dropped off'] %}
 
-<form class="o-yes-route-option">
+<form class="o-yes-route-option" autocomplete="new-password">
   <span class="a-label__heading u-mb0">
     <b>What type of transportation will you take?</b>
   </span>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
@@ -2,7 +2,7 @@
 {% from 'atoms/radio-button.html' import render as render_radio with context %}
 {% from 'input.html' import render as render_input with context %}
 
-<div class="content-l content-l_col-2-3 block__sub-micro a-yes-question">
+<div class="content-l content-l_col-2-3 block__sub-micro m-yes-average-cost">
   {{
     render_input({
       'data_js_name': 'averageCost',
@@ -16,7 +16,8 @@
   }}
   {{
     render_radio({
-      'name': "average-cost",
+      'class': 'a-yes-average-cost',
+      'name': 'averageCostFrequency',
       'label': "Daily",
       'value': 'daily',
       'disabled': true
@@ -24,7 +25,8 @@
   }}
   {{
     render_radio({
-      'name': "average-cost",
+      'class': 'a-yes-average-cost',
+      'name': 'averageCostFrequency',
       'label': "Monthly",
       'value': 'monthly',
       'disabled': true
@@ -34,7 +36,7 @@
     render_checkbox({
       'class': 'u-js-only block__sub-micro',
       'label': "I'm not sure, add this to my to-do list to look up later",
-      'name': "yes-miles-unsure",
+      'name': 'costToActionPlan',
       'disabled': true
      })
   }}

--- a/cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items.js
@@ -6,7 +6,7 @@ const PLAN_TYPES = Object.freeze( {
 } );
 
 const ACTION_PLAN = Object.freeze( {
-  AVERAGE_COST: 'average',
+  AVERAGE_COST: 'average cost',
   DAYS_PER_WEEK: 'days per week',
   MILES: 'miles',
   TIME: 'Look up how to estimate transit time.'

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -2,10 +2,12 @@ import Expandable from 'cf-expandables/src/Expandable';
 import { addRouteOptionAction } from './reducers/route-option-reducer';
 import budgetFormView from './budget-form-view';
 import createRoute from './route.js';
+import averageCostView from './views/average-cost';
 import routeOptionFormView from './route-option-view';
 import routeOptionToggleView from './route-option-toggle-view';
 import routeDetailsView from './views/route-details';
 import store from './store';
+import './polyfills/closest';
 
 Array.prototype.slice.call(
   document.querySelectorAll( 'input' )
@@ -30,7 +32,8 @@ const routeOptionForms = expandables.map( ( expandable, index ) => {
   return routeOptionFormView( routeOptionsEl, {
     store,
     routeIndex: index,
-    detailsView: routeDetailsView( document.querySelector( `.${ DETAILS_CLASSES.CONTAINER }` ) )
+    detailsView: routeDetailsView( document.querySelector( `.${ DETAILS_CLASSES.CONTAINER }` ) ),
+    averageCostView
   } );
 } );
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -27,7 +27,6 @@ const actionMap = Object.freeze( {
  * and the predicate functions that determine the field's state
  */
 const toggleableFields = {
-  averageCost: ( { transportation } ) => transportation && transportation !== 'Drive',
   miles: state => state.transportation === 'Drive',
   daysPerWeek: state => state.transportation === 'Drive' || state.isCostPerDay
 };
@@ -37,6 +36,7 @@ const toggleableFields = {
  * @param {HTMLElement} node dom element to be toggled
  */
 function hideToggleableField( node ) {
+  if ( !node ) return;
   // need to add an action to update the store somewhere
   node.value = '';
   node.classList.add( 'u-hidden' );
@@ -105,7 +105,12 @@ function updateVisibleInputs( inputs, prevState, state ) {
  *  The root DOM element for this view
  * @returns {Object} The view's public methods
  */
-function RouteOptionFormView( element, { store, routeIndex, detailsView } ) {
+function RouteOptionFormView( element, {
+  store,
+  routeIndex,
+  detailsView,
+  averageCostView
+} ) {
   const _dom = checkDom( element, CLASSES.FORM );
   const _transportationOptionEls = toArray(
     _dom.querySelectorAll( `.${ CLASSES.TRANSPORTATION_CHECKBOX }` )
@@ -188,6 +193,12 @@ function RouteOptionFormView( element, { store, routeIndex, detailsView } ) {
           { store, routeIndex }
         ).init();
 
+        const costView = averageCostView(
+          _dom.querySelector( `.${ averageCostView.CLASSES.CONTAINER }` ),
+          { store, routeIndex }
+        );
+
+        costView.init();
         detailsView.init();
 
         const currentState = routeSelector(

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
@@ -1,0 +1,148 @@
+import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
+import {
+  clearAverageCostAction,
+  routeSelector,
+  updateAverageCostAction,
+  updateCostToActionPlan,
+  updateIsMonthlyCostAction
+} from '../reducers/route-option-reducer';
+import { toArray } from '../util';
+import inputView from '../input-view';
+
+const CLASSES = Object.freeze( {
+  CONTAINER: 'm-yes-average-cost',
+  RADIO: 'a-radio'
+} );
+
+const COST_FREQUENCY_TYPES = {
+  DAILY: 'daily',
+  MONTHLY: 'monthly'
+};
+
+/**
+ * AverageCostView
+ * @class
+ *
+ * @classdesc View handles form elements related to the averageCost field, including the
+ * 'not sure' checkbox and daily/monthly radio buttons
+ *
+ * @param {HTMLNode} element The root DOM element for this view
+ * @returns {Object} This view's public methods
+ */
+function averageCostView( element, { store, routeIndex } ) {
+  const _dom = checkDom( element, CLASSES.CONTAINER );
+  const _averageCostEl = _dom.querySelector( 'input[type="text"]' );
+  const _radioEls = toArray( _dom.querySelectorAll( `.${ CLASSES.RADIO }` ) );
+  const _notSureEl = _dom.querySelector( 'input[type="checkbox"]' );
+
+  /**
+   * Dispatch to the store which cost-frequency radio button
+   * the user has selected.
+   * @param {object} inputData The data returned from the InputView's event handler function
+   * @param {object} inputData.event The emitted DOM event
+   * @param {string} inputData.name The name of the field the event was emitted from
+   */
+  function _handleFrequencySelection( { event } ) {
+    const type = event.target.value;
+    const costFrequencyFlag = type === COST_FREQUENCY_TYPES.MONTHLY;
+
+    store.dispatch( updateIsMonthlyCostAction( {
+      routeIndex,
+      value: costFrequencyFlag
+    } ) );
+  }
+
+  /**
+   * Dispatch to the store the estimated cost the user anticipates
+   * for their selected transportation option
+   * @param {object} inputData The data returned from the InputView's event handler function
+   * @param {object} inputData.event The emitted DOM event
+   * @param {string} inputData.name The name of the field the event was emitted from
+   */
+  function _handleAverageCostUpdate( { event } ) {
+    store.dispatch( updateAverageCostAction( {
+      routeIndex,
+      value: event.target.value
+    } ) );
+  }
+
+  /**
+   * Dispatch to the store whether or not the user has indicated they
+   * are unsure about the average cost of their selected transportation
+   * option
+   * @param {object} inputData The data returned from the InputView's event handler function
+   * @param {object} inputData.event The emitted DOM event
+   * @param {string} inputData.name The name of the field the event was emitted from
+   */
+  function _handleNotSureUpdate( { event } ) {
+    store.dispatch( updateCostToActionPlan( {
+      routeIndex,
+      value: event.target.checked
+    } ) );
+  }
+
+  /**
+   * Toggles the visibility of the form controls depending on the
+   * transportation option selected. Clears form field when toggled
+   * to prevent calculation bugs.
+   * @param {object} prevState The last state of the app.
+   * @param {object} state The current state of the app.
+   */
+  function _onStateUpdate( prevState, state ) {
+    const routeState = routeSelector( state.routes, routeIndex );
+    const prevRouteState = routeSelector( prevState.routes, routeIndex );
+
+    if ( prevRouteState.transportation !== routeState.transportation ) {
+      if ( routeState.transportation === 'Drive' ) {
+        _averageCostEl.value = '';
+        _notSureEl.checked = '';
+        _radioEls.forEach( radio => { radio.checked = ''; } );
+        _dom.classList.add( 'u-hidden' );
+        store.dispatch( clearAverageCostAction( { routeIndex } ) );
+      } else {
+        _dom.classList.remove( 'u-hidden' );
+      }
+    }
+  }
+
+  /**
+   * Initial the input elements this view manages.
+   */
+  function _initInputs() {
+    inputView( _averageCostEl, {
+      events: {
+        input: _handleAverageCostUpdate
+      }
+    } ).init();
+
+    _radioEls.forEach( node => {
+      inputView( node, {
+        events: {
+          click: _handleFrequencySelection
+        },
+        type: 'radio'
+      } ).init();
+    } );
+
+    inputView( _notSureEl, {
+      events: {
+        click: _handleNotSureUpdate
+      },
+      type: 'checkbox'
+    } ).init();
+  }
+
+  return {
+    init() {
+      if ( setInitFlag( _dom ) ) {
+        _initInputs();
+
+        store.subscribe( _onStateUpdate );
+      }
+    }
+  };
+}
+
+averageCostView.CLASSES = CLASSES;
+
+export default averageCostView;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -43,6 +43,11 @@ function updateTodoList( todos = [] ) {
   return fragment;
 }
 
+// Assuming days per week for a transportation option to be 5 days per week.
+// This could easily not be accurate as people frequently have weekend jobs,
+// multiple shifts etc, but should work for now.
+const FULL_TIME_DAYS = 5;
+
 const DEFAULT_COST_ESTIMATE = '-';
 
 // Rough estimate to account for weeks that have more or less days
@@ -77,7 +82,7 @@ function getCalculationFn( route ) {
     return monthlyCost;
   }
 
-  return calculatePerMonthCost( averageCost, daysPerWeek );
+  return calculatePerMonthCost( averageCost, FULL_TIME_DAYS );
 }
 
 /**

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -1,10 +1,13 @@
 import createRoute from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route';
 import routeOptionReducer, {
   addRouteOptionAction,
+  clearAverageCostAction,
   initialState,
   routeSelector,
   updateAverageCostAction,
+  updateCostToActionPlan,
   updateDaysPerWeekAction,
+  updateIsMonthlyCostAction,
   updateMilesAction,
   updateTimeToActionPlan,
   updateTransitTimeHoursAction,
@@ -12,6 +15,7 @@ import routeOptionReducer, {
   updateTransportationAction
 } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer';
 import { UNDEFINED } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
+import { PLAN_TYPES } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items';
 
 // Arbitrary value to ensure reducer is updating properly
 const nextValue = '15';
@@ -162,6 +166,86 @@ describe( 'routeOptionReducer', () => {
       const { actionPlanItems } = state.routes[0];
 
       expect( actionPlanItems.length ).toBe( 1 );
+      expect( actionPlanItems[0] ).toBe( PLAN_TYPES.TIME );
+    } );
+
+    it( 'reduces the .updateCostToActionPlan action', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateCostToActionPlan( {
+          routeIndex: 0,
+          value: true } )
+      );
+
+      const { actionPlanItems } = state.routes[0];
+
+      expect( actionPlanItems.length ).toBe( 1 );
+      expect( actionPlanItems[0] ).toBeDefined();
+      expect( actionPlanItems[0] ).toBe( PLAN_TYPES.AVERAGE_COST );
+    } );
+
+    it( 'reduces the .updateIsMonthlyCostAction', () => {
+      expect( initial.routes[0].isMonthlyCost ).toBe( null );
+
+      let state = routeOptionReducer(
+        initial,
+        updateIsMonthlyCostAction( {
+          routeIndex: 0,
+          value: true } )
+      );
+
+      let { isMonthlyCost } = state.routes[0];
+
+      expect( isMonthlyCost ).toBe( true );
+
+      state = routeOptionReducer(
+        initial,
+        updateIsMonthlyCostAction( {
+          routeIndex: 0,
+          value: false } )
+      );
+
+      isMonthlyCost = state.routes[0].isMonthlyCost;
+
+      expect( isMonthlyCost ).toBe( false );
+    } );
+
+    it( 'reduces non-boolean values into boolean ones', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateIsMonthlyCostAction( {
+          routeIndex: 0,
+          value: 'string' } )
+      );
+
+      const { isMonthlyCost } = state.routes[0];
+
+      expect( isMonthlyCost ).toBe( true );
+    } );
+
+    it( 'reduces the .clearAverageCostAction', () => {
+      const route = {
+        averageCost: '100',
+        isMonthlyCost: true,
+        actionPlanItems: [ PLAN_TYPES.COST ]
+      };
+      let state = routeOptionReducer(
+        UNDEFINED,
+        addRouteOptionAction( route )
+      );
+
+      expect( state.routes[0].averageCost ).toBe( route.averageCost );
+      expect( state.routes[0].isMonthlyCost ).toBe( route.isMonthlyCost );
+      expect( state.routes[0].actionPlanItems ).toBe( route.actionPlanItems );
+
+      state = routeOptionReducer(
+        state,
+        clearAverageCostAction( { routeIndex: 0 } )
+      );
+
+      expect( state.routes[0].averageCost ).toBe( '' );
+      expect( state.routes[0].isMonthlyCost ).toBe( null );
+      expect( state.routes[0].actionPlanItems.length ).toBe( 0 );
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
@@ -1,5 +1,6 @@
 import { simulateEvent } from '../../../../util/simulate-event';
 import routeOptionFormView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route-option-view';
+import averageCostView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost';
 import {
   updateAverageCostAction,
   updateDaysPerWeekAction,
@@ -12,7 +13,9 @@ let UNDEFINED;
 const HTML = `
   <form class="o-yes-route-option">
     <input type="text" name="miles" data-js-name="miles" class="a-yes-question">
-    <input type="text" name="averageCost" data-js-name="averageCost" class="a-yes-question">
+    <div class="m-yes-average-cost">
+      <input type="text" name="averageCost" data-js-name="averageCost" class="a-yes-question">
+    </div>
     <input type="text" name="daysPerWeek" data-js-name="daysPerWeek" class="a-yes-question">
     <input type="text" name="averageCost" data-js-name="averageCost" class="a-yes-question">
     <input type="radio" name="transpo" class="a-yes-route-mode" value="Bus">
@@ -31,6 +34,10 @@ describe( 'routeOptionFormView', () => {
     init: detailsInit,
     render: detailsRender
   };
+  const costViewMock = () => ({
+    init: jest.fn()
+  });
+  costViewMock.CLASSES = averageCostView.CLASSES;
   const mockStore = () => ( {
     dispatch,
     subscribe( fn ) {
@@ -58,7 +65,8 @@ describe( 'routeOptionFormView', () => {
     view = routeOptionFormView( document.querySelector( `.${ CLASSES.FORM }` ), {
       store,
       routeIndex: 0,
-      detailsView
+      detailsView,
+      averageCostView: costViewMock
     } );
     view.init();
   } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/average-cost-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/average-cost-spec.js
@@ -1,0 +1,119 @@
+import { simulateEvent } from '../../../../../util/simulate-event';
+import averageCostView from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost';
+import {
+  clearAverageCostAction,
+  updateAverageCostAction,
+  updateCostToActionPlan,
+  updateIsMonthlyCostAction
+} from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer';
+
+const HTML = `
+  <div class="content-l content-l_col-2-3 block__sub-micro m-yes-average-cost">
+      <div class="form-l_col form-l_col-1-4">
+      <label class="a-label a-label__heading u-mb0" for="input_37b566d867b4ec_what's-the-average-cost">
+          What's the average cost?</label><p id="input_ht_37b566d867b67e_what's-the-average-cost"><small>If it's free, enter 0</small></p><input id="input_37b566d867b4ec_what's-the-average-cost" name="input_37b566d867b4ec_what's-the-average-cost" type="text" value="" data-js-name="averageCost" aria-describedby="&quot;input_ht_37b566d867b67e_what's-the-average-cost&quot;" class="">
+      
+    </div>
+      <div class="m-form-field m-form-field__radio a-yes-average-cost">
+        <input class="a-radio" type="radio" value="daily" id="input_37b566d867baf2_daily" name="average-cost">
+        <label class="a-label" for="input_37b566d867baf2_daily">
+            Daily
+        </label>
+    </div>
+      <div class="m-form-field m-form-field__radio a-yes-average-cost">
+        <input class="a-radio" type="radio" value="monthly" id="input_37b566d867be3a_monthly" name="average-cost">
+        <label class="a-label" for="input_37b566d867be3a_monthly">
+            Monthly
+        </label>
+    </div>
+      <div class="m-form-field m-form-field__checkbox u-js-only block__sub-micro">
+        <input class="a-checkbox" type="checkbox" value="input_37b566d867c130_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later" id="input_37b566d867c130_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later" name="yes-miles-unsure">
+        <label class="a-label" for="input_37b566d867c130_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later">
+            <span>I'm not sure, add this to my to-do list to look up later</span>
+        </label>
+    </div>
+  </div>
+`;
+
+describe( 'averageCostView', () => {
+  const routeIndex = 0;
+  const CLASSES = averageCostView.CLASSES;
+  const dispatch = jest.fn();
+  const mockStore = () => ( {
+    dispatch,
+    subscribe() { return {}; }
+  } );
+  let store;
+  let view;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML;
+    store = mockStore();
+    view = averageCostView( document.querySelector( `.${ CLASSES.CONTAINER }` ), { store, routeIndex } );
+    view.init();
+  } );
+
+  afterEach( () => {
+    dispatch.mockReset();
+    view = null;
+    store = null;
+  } );
+
+  it( 'dispatches the correct action when average cost input changes', () => {
+    const costEl = document.querySelector( 'input[type="text"]' );
+    const cost = '12';
+
+    costEl.value = cost;
+
+    simulateEvent( 'input', costEl );
+
+    const mock = store.dispatch.mock;
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateAverageCostAction( {
+        routeIndex, value: cost
+      } )
+    );
+  } );
+
+  it( 'dispatches the correct action when a radio button is selected', () => {
+    const radioEls = document.querySelectorAll( `.${ CLASSES.RADIO }` );
+    const dailyEl = radioEls[0];
+    const monthlyEl = radioEls[1];
+
+    simulateEvent( 'click', dailyEl );
+    const mock = store.dispatch.mock;
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateIsMonthlyCostAction( {
+        routeIndex, value: false
+      } )
+    );
+
+    simulateEvent( 'click', monthlyEl );
+
+    expect( mock.calls.length ).toBe( 2 );
+    expect( mock.calls[1][0] ).toEqual(
+      updateIsMonthlyCostAction( {
+        routeIndex, value: true
+      } )
+    );
+  } );
+
+  it( 'dispatches the correct action when not sure checkbox is clicked', () => {
+    const notSureEl = document.querySelector( 'input[type="checkbox"]' );
+
+    simulateEvent( 'click', notSureEl );
+
+    const mock = store.dispatch.mock;
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateCostToActionPlan( {
+        routeIndex, value: true
+      } )
+    );
+  } );
+} );

--- a/test/unit_tests/apps/youth-employment-success/js/views/transit-time-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/transit-time-spec.js
@@ -53,7 +53,7 @@ describe( 'transitTimeView', () => {
     view = null;
   } );
 
-  it( 'dispatches the correct event when hours field is changed', () => {
+  it( 'dispatches the correct action when hours field is changed', () => {
     const hoursEl = document.querySelector( '[data-js-name="transitTimeHours"]' );
     const hours = '1';
 


### PR DESCRIPTION
Adds a view to handle the `average cost` fieldset. View controls updating the average cost input, whether or not the cost reflects a monthly or daily cost, and if the user isn't sure about the cost (thereby adding a todo to the user's action plan).

## Additions

- Updates `routeOptionReducer` to handle:
  * `averageCost` value
  * adding an average cost field to the user's todo list
  * a selector function to access the `actionPlanItems` property

- Adds JS view to manage `averageCost` inputs

## Removals

-

## Changes

- Minor updates to DOM structure
- Average cost fieldset now toggles itself, vs being toggled by the `routeOptionView` 

## Testing

1.

## Screenshots
<img width="435" alt="Screen Shot 2019-09-10 at 2 25 17 PM" src="https://user-images.githubusercontent.com/1421848/64651903-6a845e80-d3d7-11e9-9bec-0aa533e1eb5a.png">


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
