### PR TITLE
Add createcachetable command to initial-data.sh

### DIFF
--- a/initial-data.sh
+++ b/initial-data.sh
@@ -11,9 +11,11 @@ set -e
 
 # Import Data
 import_data(){
-    echo 'Creating DB Tables...'
+    echo 'Running Django migrations...'
     ./cfgov/manage.py migrate
-    echo 'Loading Initial Data...'
+    echo 'Creating any necessary Django database cache tables...'
+    ./cfgov/manage.py createcachetable
+    echo 'Running initial_data script to configure Wagtail admin...'
     ./cfgov/manage.py runscript initial_data
 }
 


### PR DESCRIPTION
This commits modifies the initial-data.sh script so that it calls [the Django createcachetable command](https://docs.djangoproject.com/en/1.11/ref/django-admin/#createcachetable).

When running either with production settings OR when one of the database caches is enabled via environment variables, this command needs to be called manually in order to create the necessary tables. This doesn't happen as part of the normal migrate command.

The Apache-in-Docker setup uses production settings which enables one of these caches, so this command is necessary for that to work right.

If the tables already exist, or if database caching isn't enabled, this command is a no-op.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: