### PR TITLE
YES tool — FIxes bug in route-option validator

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
@@ -37,29 +37,45 @@ function isFieldInActionPlan( fieldName, routeTodoList ) {
 }
 
 /**
+ * Determine if a field has a value OR is in the user's todo list of actions.
+ * Fields in the to-do list do not require values.
+ *
+ * @param {string} fieldName The name of the field to validate
+ * @param {*} value The value of the field being validated
+ * @param {array} actionItems List of items the user has in their to-do list of actions
+ * @returns {Boolean} Whether or not the field is valid
+ */
+function valueOrActionPlan( fieldName, value, actionItems ) {
+  if ( !isFieldInActionPlan( fieldName, actionItems ) && !value ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Check if all required fields are present
  * @param {object} data The route option form data
  * @returns {Boolean} Data validity
  */
 function isRequiredValid( data ) {
-  return requiredFields.reduce( ( memo, fieldName ) => {
+  let isValid;
+
+  for ( let i = 0; i < requiredFields.length; i++ ) {
+    const fieldName = requiredFields[i];
+
     // does the data object contain the required field
     if ( data.hasOwnProperty( fieldName ) ) {
       // check if the value exists
-      if (
-        !data[fieldName] &&
-        !isFieldInActionPlan( fieldName, data.actionPlanItems )
-      ) {
-        memo = false;
-      } else {
-        memo = true;
-      }
-    } else {
-      memo = false;
+      isValid = valueOrActionPlan( fieldName, data[fieldName], data.actionPlanItems );
     }
 
-    return memo;
-  }, true );
+    if ( !isValid ) {
+      return false;
+    }
+  }
+
+  return isValid;
 }
 
 /**

--- a/test/unit_tests/apps/youth-employment-success/js/validators/route-option-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/validators/route-option-spec.js
@@ -6,7 +6,8 @@ describe( '.validate', () => {
     spent: 1,
     transitTimeMinutes: 1,
     transitTimeHours: 1,
-    transportation: 'Walk'
+    transportation: 'Walk',
+    actionPlanItems: []
   };
 
   it( 'validates data to true if all required fields are present', () => {
@@ -16,7 +17,9 @@ describe( '.validate', () => {
   it( 'validates data to false if not all required fields are present', () => {
     expect( validate( {} ) ).toBeFalsy();
     expect( validate( {
-      earned: 1
+      earned: 1,
+      spent: '',
+      actionPlanItems: []
     } ) ).toBeFalsy();
   } );
 
@@ -39,7 +42,8 @@ describe( '.validate', () => {
       transitTimeHours: 1,
       transportation: 'Drive',
       miles: 1,
-      daysPerWeek: 1
+      daysPerWeek: 1,
+      actionPlanItems: []
     };
 
     expect( validate( driveData ) ).toBeTruthy();


### PR DESCRIPTION
Previously, the warning alert dialog in the route option detail pane was disappearing when the form hadn't validated. This PR fixes a bug in the logic that treated invalid data as valid.

## Additions

-

## Removals

-

## Changes

- Uses a `for` loop to return early once a field fails validation

## Testing

1. In the browser, fill in the following form fields:
  * monthly budget
  * monthly expenses
  * select a transportation radio button
  * Select `not sure` checkbox in the `transit time` section

## Screenshots
![Screen Shot 2019-09-12 at 12 59 17 PM](https://user-images.githubusercontent.com/1421848/64816760-376bd780-d55d-11e9-98cf-a3e8dc779730.png)

## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Observe that the warning dialog disappears

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
