### PR TITLE
Fix naive datetime warnings in prepaid agreements tests

### DIFF
--- a/cfgov/prepaid_agreements/tests/test_models.py
+++ b/cfgov/prepaid_agreements/tests/test_models.py
@@ -1,6 +1,7 @@
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from django.test import TestCase
+from django.utils import timezone
 
 from prepaid_agreements.models import PrepaidAgreement, PrepaidProduct
 
@@ -22,18 +23,19 @@ class TestMostRecentAgreement(TestCase):
         effective_date = date(month=2, day=3, year=2019)
         self.agreement_old = PrepaidAgreement(
             effective_date=effective_date,
-            created_time=datetime.now() - timedelta(hours=1),
-            product=self.product,
-        )
-        self.agreement_older = PrepaidAgreement(
-            effective_date=effective_date,
-            created_time=datetime.now() - timedelta(hours=2),
+            created_time=timezone.now() - timedelta(hours=1),
             product=self.product,
         )
         self.agreement_old.save()
+        self.agreement_older = PrepaidAgreement(
+            effective_date=effective_date,
+            created_time=timezone.now() - timedelta(hours=2),
+            product=self.product,
+        )
+        self.agreement_older.save()
         self.agreement_new = PrepaidAgreement(
             effective_date=effective_date,
-            created_time=datetime.now(),
+            created_time=timezone.now(),
             product=self.product,
         )
         self.agreement_new.save()


### PR DESCRIPTION
The prepaid_agreements Python tests currently generate a few warnings like this:

> RuntimeWarning: DateTimeField PrepaidAgreement.created_time received a naive datetime (2019-09-13 13:33:33.192472) while time zone support is active.

See for example [this Travis log](https://travis-ci.org/cfpb/cfgov-refresh/jobs/584699066).

This change fixes the use of datetimes from naive ones to ones with time zones. It also adds what seems to be a missing model save statement, which doesn't affect the outcome of the tests.

## Testing

Run `tox`, see no warnings.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: