### PR TITLE
Prepaid: disclaimer and breadcrumb

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -14,7 +14,7 @@
 
     {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
     {% set breadcrumb_items = [{
-        'href': '/data-research/prepaid-accounts/search-agreements/',
+        'href': breadcrumb,
         'title': 'Prepaid Product Agreements Database'
     }]%}
     {{ breadcrumbs.render(breadcrumb_items) }}
@@ -121,16 +121,26 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
+{% if support_text %}
 <div class="block block__flush-top">
-<header class="m-slug-header">
-  <h2 class="a-heading">
-      Database disclaimer
-  </h2>
-</header>
-<p>We will display the prepaid agreements in this database as the respective issuers submitted them. The CFPB is not responsible for the content of the agreements, including any discrepancies between an agreement as presented in this database and the agreement as offered to the public, or for any omissions or other errors in the agreement as submitted by the issuer.</p>
-<p>The agreements on file will have general terms and conditions, pricing, and fee information. They are not specific to an individual's account information.</p>
-<p>If you have questions about the agreements themselves, contact the prepaid issuer directly.</p>
+    <header class="m-slug-header">
+      <h2 class="a-heading">
+          {{ support_text.sidefoot_heading | safe }}
+      </h2>
+    </header>
+    {{ support_text.text | safe }}
 </div>
+{% endif %}
+{% if disclaimer_text %}
+<div class="block">
+    <header class="m-slug-header">
+      <h2 class="a-heading">
+          {{ disclaimer_text.sidefoot_heading | safe }}
+      </h2>
+    </header>
+    {{ disclaimer_text.text | safe }}
+</div>
+{% endif %}
 {%- endblock %}
 
 {% block javascript scoped %}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -14,7 +14,7 @@
 
     {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
     {% set breadcrumb_items = [{
-        'href': breadcrumb,
+        'href': search_page_url,
         'title': 'Prepaid Product Agreements Database'
     }]%}
     {{ breadcrumbs.render(breadcrumb_items) }}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -165,13 +165,22 @@
             </div>
         {% endif %}
     </div>
-
+    {% if disclaimer_text or support_text %}
     <div class="database-disclaimer">
         <div class="o-well">
-            <h4>Database disclaimer</h4>
-            <p>We will display the prepaid agreements in this database as the respective issuers submitted them. The CFPB is not responsible for the content of the agreements, including any discrepancies between an agreement as presented in this database and the agreement as offered to the public, or for any omissions or other errors in the agreement as submitted by the issuer.</p>
-            <p>The agreements on file will have general terms and conditions, pricing, and fee information. They are not specific to an individual's account information.</p>
-            <p>If you have questions about the agreements themselves, contact the prepaid issuer directly.</p>
+            {% if disclaimer_text %}
+            <div class="block block__sub block__flush-top">
+                <h4>{{ disclaimer_text.sidefoot_heading | safe }}</h4>
+                {{ disclaimer_text.text | safe }}
+            </div>
+            {% endif %}
+            {% if support_text %}
+            <div class="block block__sub block__flush-bottom">
+                <h4>{{ support_text.sidefoot_heading | safe }}</h4>
+                {{ support_text.text | safe }}
+            </div>
+            {% endif %}
         </div>
     </div>
+    {% endif %}
 </div>

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -10,9 +10,10 @@ from prepaid_agreements.models import PrepaidProduct
 from v1.models.snippets import ReusableText
 
 
-DISCLAIMER_SNIPPET_TITLE = 'Prepaid agreements database disclaimer'
-SUPPORT_SNIPPET_TITLE = 'Prepaid agreements support and inquiries'
-
+DISCLAIMER_TEXT = ReusableText.objects.filter(
+    title='Prepaid agreements database disclaimer').first()
+SUPPORT_TEXT = ReusableText.objects.filter(
+    title='Prepaid agreements support and inquiries').first()
 
 def validate_page_number(request, paginator):
     """
@@ -122,10 +123,6 @@ def index(request):
     paginator = Paginator(products.all(), 20)
     page_number = validate_page_number(request, paginator)
     page = paginator.page(page_number)
-    disclaimer_text = ReusableText.objects.filter(
-        title=DISCLAIMER_SNIPPET_TITLE).first()
-    support_text = ReusableText.objects.filter(
-        title=SUPPORT_SNIPPET_TITLE).first()
 
     return render(request, 'prepaid_agreements/index.html', {
         'current_page': page_number,
@@ -138,8 +135,8 @@ def index(request):
         'active_filters': available_filters,
         'valid_filters': valid_filters,
         'search_field': search_field,
-        'disclaimer_text': disclaimer_text,
-        'support_text': support_text
+        'disclaimer_text': DISCLAIMER_TEXT,
+        'support_text': SUPPORT_TEXT
     })
 
 
@@ -160,14 +157,9 @@ def get_detail_page_breadcrumb(request):
 
 
 def detail(request, product_id):
-    disclaimer_text = ReusableText.objects.filter(
-        title=DISCLAIMER_SNIPPET_TITLE).first()
-    support_text = ReusableText.objects.filter(
-        title=SUPPORT_SNIPPET_TITLE).first()
-
     return render(request, 'prepaid_agreements/detail.html', {
         'product': get_object_or_404(PrepaidProduct, pk=product_id),
-        'breadcrumb': get_detail_page_breadcrumb(request),
-        'disclaimer_text': disclaimer_text,
-        'support_text': support_text
+        'search_page_url': get_detail_page_breadcrumb(request),
+        'disclaimer_text': DISCLAIMER_TEXT,
+        'support_text': SUPPORT_TEXT
     })

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -10,12 +10,6 @@ from prepaid_agreements.models import PrepaidProduct
 from v1.models.snippets import ReusableText
 
 
-DISCLAIMER_TEXT = ReusableText.objects.filter(
-    title='Prepaid agreements database disclaimer').first()
-SUPPORT_TEXT = ReusableText.objects.filter(
-    title='Prepaid agreements support and inquiries').first()
-
-
 def validate_page_number(request, paginator):
     """
     A utility for parsing a pagination request,
@@ -90,6 +84,16 @@ def filter_products(filters, products):
     return products
 
 
+def get_disclaimer_text():
+    return ReusableText.objects.filter(
+        title='Prepaid agreements database disclaimer').first()
+
+
+def get_support_text():
+    return ReusableText.objects.filter(
+        title='Prepaid agreements support and inquiries').first()
+
+
 def index(request):
     params = dict(request.GET.iterlists())
     available_filters = {}
@@ -136,8 +140,8 @@ def index(request):
         'active_filters': available_filters,
         'valid_filters': valid_filters,
         'search_field': search_field,
-        'disclaimer_text': DISCLAIMER_TEXT,
-        'support_text': SUPPORT_TEXT
+        'disclaimer_text': get_disclaimer_text(),
+        'support_text': get_support_text()
     })
 
 
@@ -161,6 +165,6 @@ def detail(request, product_id):
     return render(request, 'prepaid_agreements/detail.html', {
         'product': get_object_or_404(PrepaidProduct, pk=product_id),
         'search_page_url': get_detail_page_breadcrumb(request),
-        'disclaimer_text': DISCLAIMER_TEXT,
-        'support_text': SUPPORT_TEXT
+        'disclaimer_text': get_disclaimer_text(),
+        'support_text': get_support_text()
     })

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -15,6 +15,7 @@ DISCLAIMER_TEXT = ReusableText.objects.filter(
 SUPPORT_TEXT = ReusableText.objects.filter(
     title='Prepaid agreements support and inquiries').first()
 
+
 def validate_page_number(request, paginator):
     """
     A utility for parsing a pagination request,


### PR DESCRIPTION
Updates to prepaid search.

## Additions

- Preserve query string in breadcrumb link from detail to search page.

## Changes

- Pull prepaid disclaimer text from two reusable text snippets.

## Testing

1. Check out branch
2. Navigate to [prepaid search](http://localhost:8000/data-research/prepaid-accounts/search-agreements/) and verify that disclaimer text appears below results
3. Click on link to detail page for first search result. Verify that disclaimer text appears in sidebar.
4. Click breadcrumb on detail page and ensure that it links back to search page.
5. On search page, select and apply a filter. When page reloads, navigate to first result's detail page.
6. Click breadcrumb on detail page and ensure that it links back to search page with selected filter still applied.

## Screenshots

### Disclaimer on search page

<img width="805" alt="Screen Shot 2019-09-13 at 12 47 49 PM" src="https://user-images.githubusercontent.com/778171/64890545-c68ff280-d624-11e9-8da5-7a58cd7463d1.png">

### Disclaimer on detail page
<img width="1231" alt="Screen Shot 2019-09-13 at 12 48 11 PM" src="https://user-images.githubusercontent.com/778171/64890537-c09a1180-d624-11e9-9c3a-0ac40a1a8ce9.png">
