### PR TITLE
Refactor ask search to include icon and responsive styling

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/ask-search.html
+++ b/cfgov/jinja2/v1/_includes/organisms/ask-search.html
@@ -34,19 +34,24 @@
             <h3>{{ _('Search for your question') }}</h3>
         </label>
         {% endif %}
+
         <div class="o-search-bar_input">
-            <div class="input-with-btn input-with-btn__bar">
-                <div class="input-with-btn_input
-                            {% if autocomplete %}m-autocomplete{% endif %}"
-                      data-language="{{ language }}">
-                    <input class="a-text-input"
-                           type="text"
-                           name="q"
-                           id="o-search-bar_query"
-                           value="{{ ask_query }}"
-                           placeholder="{{ placeholder }}">
+            <div class="o-form__input-w-btn">
+                <div class="o-form__input-w-btn_input-container">
+                    <div class="m-btn-inside-input
+                                input-contains-label
+                                {% if autocomplete %}m-autocomplete{% endif %}"
+                         data-language="{{ language }}">
+                        <label for="query" class="input-contains-label_before input-contains-label_before__search"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880.6 1200" class="cf-icon-svg"><path d="M860.1 879.2L645.7 664.8c90.8-136.8 76-323-44.6-443.5-137.5-137.5-360.5-137.5-498 0s-137.5 360.5 0 498c118.5 118.4 303.9 137 443.5 44.6L761 978.3c27.3 27.3 71.7 27.3 99 0s27.4-71.8.1-99.1zm-508-116.9C191.4 762 61.3 631.5 61.6 470.8c.3-160.7 130.8-290.8 291.5-290.5s290.8 130.8 290.5 291.5c-.2 118.2-71.9 224.6-181.5 269.1-34.9 14.2-72.3 21.5-110 21.4z"></path></svg></label>
+                        <input class="a-text-input"
+                               type="text"
+                               name="q"
+                               id="o-search-bar_query"
+                               value="{{ ask_query }}"
+                               placeholder="{{ placeholder }}">
+                    </div>
                 </div>
-                <div class="input-with-btn_btn">
+                <div class="o-form__input-w-btn_btn-container">
                     <button class="a-btn" type="submit">
                         {{ _('Search') }}
                     </button>

--- a/cfgov/unprocessed/css/organisms/ask-search.less
+++ b/cfgov/unprocessed/css/organisms/ask-search.less
@@ -3,10 +3,6 @@
    Ask Search organism
    ========================================================================== */
 
-.o-search-bar_input {
-    max-width: 500px;
-}
-
 // TODO: Reconcile this with the input with button in Capital Framework.
 .o-form__input-w-btn_btn-container {
 

--- a/cfgov/unprocessed/css/organisms/ask-search.less
+++ b/cfgov/unprocessed/css/organisms/ask-search.less
@@ -5,11 +5,11 @@
 
 // TODO: Reconcile this with the input with button in Capital Framework.
 .o-form__input-w-btn_btn-container {
-
     // Only attach the button to the input at tablet/desktop sizes.
     .respond-to-min( 480px, {
         border-left: 0;
-        & .a-btn {
+
+        .a-btn {
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
         }

--- a/cfgov/unprocessed/css/organisms/ask-search.less
+++ b/cfgov/unprocessed/css/organisms/ask-search.less
@@ -3,6 +3,19 @@
    Ask Search organism
    ========================================================================== */
 
-.input-with-btn__bar .input-with-btn_btn button {
-    height: 35px;
+.o-search-bar_input {
+    max-width: 500px;
+}
+
+// TODO: Reconcile this with the input with button in Capital Framework.
+.o-form__input-w-btn_btn-container {
+
+    // Only attach the button to the input at tablet/desktop sizes.
+    .respond-to-min( 480px, {
+        border-left: 0;
+        & .a-btn {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+    } );
 }

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -236,10 +236,6 @@
         padding-top: unit( 7px / @base-font-size-px, em );
     }
 
-    .o-search-bar_input {
-        max-width: 500px;
-    }
-
     .m-inset__bordered {
         border-top:4px solid @teal-60;
         border-bottom: 2px solid @teal-40;

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -236,6 +236,10 @@
         padding-top: unit( 7px / @base-font-size-px, em );
     }
 
+    .o-search-bar_input {
+        max-width: 500px;
+    }
+
     .m-inset__bordered {
         border-top:4px solid @teal-60;
         border-bottom: 2px solid @teal-40;


### PR DESCRIPTION
## Removals

- Remove `input-with-btn__bar` class that was setting input height to 35px.

##  Changes

- Refactor ask search to include icon and responsive styling

## Testing

1. Log into local Wagtail.
1. Create a new sublanding page.
1. Add a "Full width text" 
1. Add a "Well with ask search"
1. Fill in the options and Preview the page. Check at mobile and desktop.
1. Check search fields in Ask CFPB search (/ask-cfpb/) at mobile and desktop.

## Screenshots

Desktop

Before (bottom)
After (top)

<img width="495" alt="Screen Shot 2019-09-13 at 5 18 12 PM" src="https://user-images.githubusercontent.com/704760/64896096-91979600-d64c-11e9-8bdb-d1acaf3b8f57.png">

Mobile

Before (bottom)
After (top)

<img width="358" alt="Screen Shot 2019-09-13 at 5 18 20 PM" src="https://user-images.githubusercontent.com/704760/64896099-93f9f000-d64c-11e9-9794-1c26754daca8.png">
