### PR TITLE
YES tool — Fixes budget calculation bugs

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/money.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/money.js
@@ -12,8 +12,9 @@ function toDollars( dollars ) {
   const safeDollars = typeof dollars === 'string' ? dollars : String( dollars );
   const matches = safeDollars.match( _dollarsToPrecisionRegexp );
   const dollarsFixed = ( matches && matches[0] ) || 0;
+  const dollarAmount = dollarsFixed * _centsPerDollar / _centsPerDollar;
 
-  return dollarsFixed * _centsPerDollar / _centsPerDollar;
+  return Math.ceil( dollarAmount );
 }
 
 const dollars = {
@@ -36,9 +37,7 @@ const dollars = {
    * @returns {Number} The difference of the two values
    */
   subtract( a, b ) {
-    const subtracted = toDollars( a ) - toDollars( b );
-
-    return subtracted % 1 ? subtracted.toFixed( 2 ) : subtracted;
+    return toDollars( a ) - toDollars( b );
   }
 };
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -106,9 +106,11 @@ function calculatePerMonthCost( dailyCost, daysPerWeek ) {
     return DEFAULT_COST_ESTIMATE;
   }
 
+  const normalizedDays = Number( daysPerWeek ) > 7 ? 7 : daysPerWeek;
+
   return money.toDollars(
     money.toDollars( dailyCost ) *
-    parseFloat( daysPerWeek ) *
+    normalizedDays *
     WEEKLY_COST_MODIFIER
   );
 }
@@ -121,7 +123,7 @@ function calculatePerMonthCost( dailyCost, daysPerWeek ) {
  */
 function updateRemainingBudget( budget, transportationEstimate ) {
   return money.subtract(
-    money.subtract( budget.earned, budget.spent ),
+    budget,
     transportationEstimate
   );
 }
@@ -223,17 +225,18 @@ function routeDetailsView( element ) {
     },
     render( { budget, route } ) {
       const costEstimate = getCalculationFn( route );
+      const remainingBudget = money.subtract( budget.earned, budget.spent );
       const dataToValidate = assign( {}, budget, route );
 
       updateDom( _transportationEl, transportationMap[route.transportation] );
-      updateDom( _budgetEl, budget.earned );
+      updateDom( _budgetEl, remainingBudget );
       updateDom( _daysPerWeekEl, route.daysPerWeek );
       updateDom( _totalCostEl, costEstimate );
       updateDom( _budgetLeftEl, updateRemainingBudget( budget, costEstimate ) );
       updateDom( _timeHoursEl, route.transitTimeHours );
       updateDom( _timeMinutesEl, route.transitTimeMinutes );
       updateDom( _todoEl, updateTodoList( route.actionPlanItems ) );
-      toggleAlert( _oobAlertEl, updateRemainingBudget( budget, costEstimate ) );
+      toggleAlert( _oobAlertEl, updateRemainingBudget( remainingBudget, costEstimate ) );
       toggleAlert( _incAlertEl, validate( dataToValidate ) ? 0 : -1 );
     }
   };

--- a/test/unit_tests/apps/youth-employment-success/js/money-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/money-spec.js
@@ -2,17 +2,17 @@ import money from '../../../../../cfgov/unprocessed/apps/youth-employment-succes
 
 describe( 'money helpers', () => {
   describe( '.toDollars', () => {
-    it( 'converts string amounts to dollars with a presicion of 2', () => {
-      expect( money.toDollars( '125.567' ) ).toEqual( 125.56 );
+    it( 'converts string amounts to dollars', () => {
+      expect( money.toDollars( '125.567' ) ).toEqual( 126 );
     } );
 
     it( 'converts numbers to string for proper matching', () => {
-      expect( money.toDollars( 125.9999 ) ).toEqual( 125.99 );
+      expect( money.toDollars( 125.9999 ) ).toEqual( 126 );
     } );
   } );
 
-  it( 'truncates entries over 2 decimal places to 2', () => {
-    expect( money.add( '1.355', '1.655' ) ).toEqual( 3 );
+  it( 'rounds calculation up to nearest whole number', () => {
+    expect( money.add( '1.355', '1.655' ) ).toEqual( 4 );
   } );
 
   it( 'treats invalid entries as zero', () => {

--- a/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
@@ -104,7 +104,7 @@ describe( 'DaysPerWeekView', () => {
         }
       };
 
-      store.subscriber()( { routes: { routes: [ {} ]} }, state );
+      store.subscriber()( { routes: { routes: [ {} ]}}, state );
 
       expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
     } );
@@ -146,7 +146,7 @@ describe( 'DaysPerWeekView', () => {
 
         expect( dom.classList.contains( 'u-hidden' ) ).toBeTruthy();
 
-        subscriberFn( { routes: { routes: [ {} ]} }, {
+        subscriberFn( { routes: { routes: [ {} ]}}, {
           routes: {
             routes: [ {
               transportation: 'Drive'

--- a/test/unit_tests/apps/youth-employment-success/js/views/miles-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/miles-spec.js
@@ -89,7 +89,7 @@ describe( 'milesView', () => {
         }
       };
 
-      store.subscriber()( { routes: { routes: [ {} ]} }, state );
+      store.subscriber()( { routes: { routes: [ {} ]}}, state );
 
       expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
     } );
@@ -99,14 +99,14 @@ describe( 'milesView', () => {
       const checked = true;
       const prevState = {
         routes: {
-            routes: [ {
+          routes: [ {
             miles: miles
           } ]
         }
       };
       const state = {
         routes: {
-            routes: [ {
+          routes: [ {
             transportation: 'Walk'
           } ]
         }
@@ -129,7 +129,7 @@ describe( 'milesView', () => {
         const subscriberFn = store.subscriber();
         subscriberFn( prevState, state );
 
-        subscriberFn( { routes: { routes: [ {} ]} }, {
+        subscriberFn( { routes: { routes: [ {} ]}}, {
           routes: {
             routes: [ {
               transportation: 'Drive'


### PR DESCRIPTION
This fixes two bugs in the route details view. We round all calculations to avoid having decimal logic and to give the user more of the feel of an estimate, rather than an exact figure. This PR also fixes a bug where the `Money left in your monthly budget` line item didn't subtract monthly expenses from money earned.

## Additions

-

## Removals

-

## Changes

- Properly display money remaining line item as monthly money earned - money
spent

- Round all calculations up to the nearest whole number

## Testing

1. In the transportation tool, fill in the budget section
2. Select `Drive` as the method of transportation
3. Fill in `miles` and days per week` fields
4. In the details section, see that money remaining is calculated correctly, and that all numbers are rounded

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
