### PR TITLE
YES Tool - Adds view for managing goals section form controls

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/goals.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals.html
@@ -1,5 +1,5 @@
 {% from "goals/goal.html" import renderTextarea with context %}
-{% from 'atoms/radio-button.html' import render with context %}
+{% from 'atoms/radio-button.html' import render as renderRadio with context %}
 {% set labels = ['3 to 6 months', '6 to 9 months', '9 months to 1 year', '1 year or more'] %}
 
 <h1 class="h1">Planning how you’ll get to work</h1>
@@ -28,12 +28,13 @@
 <p class="lead-paragraph">
   Now let’s think through your long-term goal. Figuring out your long-term goal may help you figure out the best way to get to work now while you’re working towards this goal. 
 </p>
-<form class="block u-mt35">
+<form class="block u-mt35 js-yes-goals">
   <div class="block__sub">
     {{
       renderTextarea ({
+        'fieldClass': 'js-long-term-goal',
         'helperText': 'For example, saving up for an annual bus pass in the next few months or saving up to buy a car in the next year.',
-        'label': "What’s your long-term goal?",
+        'label': 'What’s your long-term goal?',
         'labelClass': "h3",
         'required': true
       })
@@ -42,6 +43,7 @@
   <div class="block__sub">
     {{
       renderTextarea ({
+        'fieldClass': 'js-goal-importance',
         'helperText': 'This goal could help you save money, in the case of an annual bus pass, or maybe it’s a more reliable option, such as having your own car instead of relying on rides.',
         'label': "Why is this goal important to you?",
         'labelClass': "h3",
@@ -60,7 +62,7 @@
     {% for label in labels | batch(2) %}
       <div class="block__sub-micro">
         {{
-          render({
+          renderRadio({
             'class': 'content-l content-l_col-1-2 m-form-field__lg-target',
             'name':  "yes-goal-timeline-option",
             'label': label[0],
@@ -70,7 +72,7 @@
   
         {% if label[1] %}
           {{
-            render({
+            renderRadio({
               'class': 'content-l_col-1-2 m-form-field__lg-target',
               'name': "yes-goal-timeline-option",
               'label': label[1],
@@ -85,6 +87,7 @@
   <div class="block__sub">
     {{
       renderTextarea ({
+        'fieldClass': 'js-goal-steps',
         'helperText': 'Now work backwards — what are some steps you can take to achieve your goal by this time? Make sure your steps are realistic and specific. For example, my first step is “Over the next six months, I’ll take the bus instead of using a rideshare in order to save money. I am trying to save $400 during this time to put towards a car down payment.”',
         'label': "What are some steps you could take to reach your goal?",
         'labelClass': "h3",

--- a/cfgov/jinja2/v1/youth_employment_success/goals.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals.html
@@ -1,5 +1,5 @@
-{% from "goals/goal.html" import renderTextarea with context %}
-{% from 'atoms/radio-button.html' import render as renderRadio with context %}
+{% import "goals/goal.html" as textarea with context %}
+{% import 'atoms/radio-button.html' as radio_button with context %}
 {% set labels = ['3 to 6 months', '6 to 9 months', '9 months to 1 year', '1 year or more'] %}
 
 <h1 class="h1">Planning how you’ll get to work</h1>
@@ -31,7 +31,7 @@
 <form class="block u-mt35 js-yes-goals">
   <div class="block__sub">
     {{
-      renderTextarea ({
+      textarea.render({
         'fieldClass': 'js-long-term-goal',
         'helperText': 'For example, saving up for an annual bus pass in the next few months or saving up to buy a car in the next year.',
         'label': 'What’s your long-term goal?',
@@ -43,7 +43,7 @@
   </div>
   <div class="block__sub">
     {{
-      renderTextarea ({
+      textarea.render({
         'fieldClass': 'js-goal-importance',
         'helperText': 'This goal could help you save money, in the case of an annual bus pass, or maybe it’s a more reliable option, such as having your own car instead of relying on rides.',
         'label': "Why is this goal important to you?",
@@ -64,7 +64,7 @@
     {% for label in labels | batch(2) %}
       <div class="block__sub-micro">
         {{
-          renderRadio({
+          radio_button.render({
             'class': 'content-l content-l_col-1-2 m-form-field__lg-target',
             'name':  "goalTimeline",
             'label': label[0],
@@ -74,7 +74,7 @@
   
         {% if label[1] %}
           {{
-            renderRadio({
+            radio_button.render({
               'class': 'content-l_col-1-2 m-form-field__lg-target',
               'name': "goalTimeline",
               'label': label[1],
@@ -88,7 +88,7 @@
   </div>
   <div class="block__sub">
     {{
-      renderTextarea ({
+      textarea.render({
         'fieldClass': 'js-goal-steps',
         'helperText': 'Now work backwards — what are some steps you can take to achieve your goal by this time? Make sure your steps are realistic and specific. For example, my first step is “Over the next six months, I’ll take the bus instead of using a rideshare in order to save money. I am trying to save $400 during this time to put towards a car down payment.”',
         'label': "What are some steps you could take to reach your goal?",

--- a/cfgov/jinja2/v1/youth_employment_success/goals.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals.html
@@ -36,6 +36,7 @@
         'helperText': 'For example, saving up for an annual bus pass in the next few months or saving up to buy a car in the next year.',
         'label': 'What’s your long-term goal?',
         'labelClass': "h3",
+        'name': 'longTermGoal',
         'required': true
       })
     }}
@@ -47,6 +48,7 @@
         'helperText': 'This goal could help you save money, in the case of an annual bus pass, or maybe it’s a more reliable option, such as having your own car instead of relying on rides.',
         'label': "Why is this goal important to you?",
         'labelClass': "h3",
+        'name': 'goalImportance',
         'required': true
       })
     }}
@@ -64,7 +66,7 @@
         {{
           renderRadio({
             'class': 'content-l content-l_col-1-2 m-form-field__lg-target',
-            'name':  "yes-goal-timeline-option",
+            'name':  "goalTimeline",
             'label': label[0],
             'value': label[0]
           })
@@ -74,7 +76,7 @@
           {{
             renderRadio({
               'class': 'content-l_col-1-2 m-form-field__lg-target',
-              'name': "yes-goal-timeline-option",
+              'name': "goalTimeline",
               'label': label[1],
               'value': label[1]
             })
@@ -91,6 +93,7 @@
         'helperText': 'Now work backwards — what are some steps you can take to achieve your goal by this time? Make sure your steps are realistic and specific. For example, my first step is “Over the next six months, I’ll take the bus instead of using a rideshare in order to save money. I am trying to save $400 during this time to put towards a car down payment.”',
         'label': "What are some steps you could take to reach your goal?",
         'labelClass': "h3",
+        'name': 'goalSteps',
         'required': true
       })
     }}

--- a/cfgov/jinja2/v1/youth_employment_success/goals/goal.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals/goal.html
@@ -16,6 +16,12 @@
 
   disabled:    Whether the field is disabled. Defaults to false.
 
+  rows:        The vertical space the textarea should occupy.
+
+  cols:        The horizontal space the textarea should occupy.
+
+  fieldClass:  Classes to control appearace and / or provide JavaScript hooks.
+
   ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}
 
@@ -26,6 +32,7 @@
 {%- set label_class = value.labelClass if value.labelClass else '' -%}
 {%- set rows = value.rows if value.rows else '6' -%}
 {%- set cols = value.cols if value.cols else '80' -%}
+{%- set field_class = value.fieldClass if value.fieldClass else '' -%}
 
 <div class="form-l_col form-l_col-1">
    <label for="{{ id }}" class="a-label {{ label_class }} u-mb0">
@@ -39,7 +46,7 @@
       <small>{{ value.helperText | safe }}</small>
     </p>
    {%- endif -%}
-   <textarea class="content-l_col-2-3"
+   <textarea class="content-l_col-2-3 {{ field_class }}"
              id="{{ id }}"
              {%- if value.name -%} name="{{ value.name }}" {%- endif -%}
              {{ 'required' if value.required else '' }}

--- a/cfgov/jinja2/v1/youth_employment_success/goals/goal.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals/goal.html
@@ -20,7 +20,7 @@
 
   cols:        The horizontal space the textarea should occupy.
 
-  fieldClass:  Classes to control appearace and / or provide JavaScript hooks.
+  fieldClass:  Classes to control appearance and / or provide JavaScript hooks.
 
   ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}

--- a/cfgov/unprocessed/apps/youth-employment-success/js/budget-form-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/budget-form-view.js
@@ -3,7 +3,7 @@ import {
   updateEarnedAction,
   updateSpentAction
 } from './reducers/budget-reducer';
-import inputView from './input-view';
+import inputView from './views/input';
 import money from './money';
 
 const CLASSES = Object.freeze( {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -5,6 +5,7 @@ import createRoute from './route.js';
 import averageCostView from './views/average-cost';
 import daysPerWeekView from './views/days-per-week';
 import milesView from './views/miles';
+import goalsView from './views/goals';
 import routeOptionFormView from './route-option-view';
 import routeOptionToggleView from './route-option-toggle-view';
 import routeDetailsView from './views/route-details';
@@ -21,6 +22,11 @@ const BUDGET_CLASSES = budgetFormView.CLASSES;
 const OPTION_CLASSES = routeOptionFormView.CLASSES;
 const OPTION_TOGGLE_CLASSES = routeOptionToggleView.CLASSES;
 const DETAILS_CLASSES = routeDetailsView.CLASSES;
+const GOALS_CLASSES = goalsView.CLASSES; 
+
+const goalsViewEl = document.querySelector(` .${GOALS_CLASSES.CONTAINER}` );
+const goalsFormView = goalsView( goalsViewEl, { store });
+goalsFormView.init();
 
 const budgetFormEl = document.querySelector( `.${ BUDGET_CLASSES.FORM }` );
 const budgetForm = budgetFormView( budgetFormEl, { store } );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -22,10 +22,10 @@ const BUDGET_CLASSES = budgetFormView.CLASSES;
 const OPTION_CLASSES = routeOptionFormView.CLASSES;
 const OPTION_TOGGLE_CLASSES = routeOptionToggleView.CLASSES;
 const DETAILS_CLASSES = routeDetailsView.CLASSES;
-const GOALS_CLASSES = goalsView.CLASSES; 
+const GOALS_CLASSES = goalsView.CLASSES;
 
-const goalsViewEl = document.querySelector(` .${GOALS_CLASSES.CONTAINER}` );
-const goalsFormView = goalsView( goalsViewEl, { store });
+const goalsViewEl = document.querySelector( ` .${ GOALS_CLASSES.CONTAINER }` );
+const goalsFormView = goalsView( goalsViewEl, { store } );
 goalsFormView.init();
 
 const budgetFormEl = document.querySelector( `.${ BUDGET_CLASSES.FORM }` );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer.js
@@ -49,7 +49,7 @@ const updateGoalTimelineAction = actionCreator(
  */
 function updateGoal( state, action ) {
   return assign( state, {
-    longTermGoal: action.data.value
+    longTermGoal: action.data
   } );
 }
 
@@ -61,7 +61,7 @@ function updateGoal( state, action ) {
  */
 function updateImportance( state, action ) {
   return assign( state, {
-    goalImportance: action.data.value
+    goalImportance: action.data
   } );
 }
 
@@ -73,7 +73,7 @@ function updateImportance( state, action ) {
  */
 function updateSteps( state, action ) {
   return assign( state, {
-    goalSteps: action.data.value
+    goalSteps: action.data
   } );
 }
 
@@ -101,6 +101,7 @@ function updateTimeline( state, action ) {
 function goalReducer( state = initialState, action ) {
   if ( handlers.hasOwnProperty( action.type ) ) {
     const handler = handlers[action.type];
+
     return handler( state, action );
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer.js
@@ -49,7 +49,7 @@ const updateGoalTimelineAction = actionCreator(
  */
 function updateGoal( state, action ) {
   return assign( state, {
-    longTermGoal: action.data
+    longTermGoal: action.data.value
   } );
 }
 
@@ -61,7 +61,7 @@ function updateGoal( state, action ) {
  */
 function updateImportance( state, action ) {
   return assign( state, {
-    goalImportance: action.data
+    goalImportance: action.data.value
   } );
 }
 
@@ -73,7 +73,7 @@ function updateImportance( state, action ) {
  */
 function updateSteps( state, action ) {
   return assign( state, {
-    goalSteps: action.data
+    goalSteps: action.data.value
   } );
 }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -194,7 +194,7 @@ function routeOptionReducer( state = initialState, action ) {
         {
           daysPerWeek: '',
           actionPlanItems: updateActionPlan(
-            state, 
+            state,
             action.data.routeIndex,
             PLAN_TYPES.DAYS,
             false

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -4,7 +4,7 @@ import {
   updateDaysPerWeekAction,
   updateTransportationAction
 } from './reducers/route-option-reducer';
-import inputView from './input-view';
+import inputView from './views/input';
 import { toArray } from './util';
 import transitTimeView from './views/transit-time';
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/store.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/store.js
@@ -1,6 +1,7 @@
 import YesStore from './yes-store';
 import budgetReducer from './reducers/budget-reducer';
 import { combineReducers } from './util';
+import goalReducer from './reducers/goal-reducer';
 import routeOptionReducer from './reducers/route-option-reducer';
 
 /**
@@ -11,6 +12,7 @@ function configureStore() {
   return new YesStore(
     combineReducers( {
       budget: budgetReducer,
+      goals: goalReducer,
       routes: routeOptionReducer
     } )
   );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
@@ -7,7 +7,7 @@ import {
   updateIsMonthlyCostAction
 } from '../reducers/route-option-reducer';
 import { toArray } from '../util';
-import inputView from '../input-view';
+import inputView from './input';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'm-yes-average-cost',

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
@@ -5,7 +5,7 @@ import {
   updateDaysPerWeekAction,
   updateDaysToActionPlan
 } from '../reducers/route-option-reducer';
-import inputView from '../input-view';
+import inputView from './input';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'm-yes-days-per-week'

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
@@ -51,7 +51,7 @@ function goalsView(element, { store }) {
         events: {
           blur: _handleUpdateGoals
         }
-      });
+      }).init();
     });
 
     toArray(
@@ -62,7 +62,7 @@ function goalsView(element, { store }) {
           click: _handleTimelineUpdate
         },
         type: 'radio'
-      });
+      }).init();
     });
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
@@ -1,11 +1,11 @@
 import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
-import { toArray } from '../util';
 import {
   updateGoalAction,
   updateGoalImportanceAction,
   updateGoalStepsAction,
   updateGoalTimelineAction
 } from '../reducers/goal-reducer';
+import { toArray } from '../util';
 import inputView from './input';
 
 const CLASSES = {
@@ -13,70 +13,81 @@ const CLASSES = {
   LONG_TERM_GOAL: 'js-long-term-goal',
   GOAL_IMPORTANCE: 'js-goal-importance',
   GOAL_STEPS: 'js-goal-steps',
-  GOAL_TIMELINE: 'a-radio',
+  GOAL_TIMELINE: 'a-radio'
 };
 
 const GOALS_TO_ACTIONS = {
-  'longTermGoal': updateGoalAction, 
-  'goalImportance': updateGoalImportanceAction,
-  'goalSteps':  updateGoalStepsAction
+  longTermGoal: updateGoalAction,
+  goalImportance: updateGoalImportanceAction,
+  goalSteps:  updateGoalStepsAction
 };
 
-function goalsView(element, { store }) {
-  const _dom = checkDom(element, CLASSES.CONTAINER);
+function goalsView( element, { store } ) {
+  const _dom = checkDom( element, CLASSES.CONTAINER );
 
-  function _handleUpdateGoals({ name, event }) {
+  /**
+  * Dispatch to the store the value of the last blurred goals section textarea node.
+  * @param {object} updateObject The data returned from the InputView's event handler function
+  * @param {object} updateObject.event The emitted DOM event
+  * @param {string} updateObject.name The name of the field the event was emitted from
+  */
+  function _handleUpdateGoals( { name, event } ) {
     const method = GOALS_TO_ACTIONS[name];
 
-    if (method) {
+    if ( method ) {
       store.dispatch( method( {
         value: event.target.value
-      }))
+      } ) );
     }
   }
 
-  function _handleTimelineUpdate({ event }) {
-    store.dispatch(updateGoalTimelineAction({
+  /**
+  * Dispatch to the store which timeline radio button the user has selected.
+  * @param {object} updateObject The data returned from the InputView's event handler function
+  * @param {object} updateObject.event The emitted DOM event
+  * @param {string} updateObject.name The name of the field the event was emitted from
+  */
+  function _handleTimelineUpdate( { event } ) {
+    store.dispatch( updateGoalTimelineAction( {
       value: event.target.value
-    }));
+    } ) );
   }
 
+  /**
+   * Initialize form control views
+   */
   function _initInputs() {
     [
       CLASSES.LONG_TERM_GOAL,
       CLASSES.GOAL_IMPORTANCE,
-      CLASSES.GOAL_STEPS,
-    ].forEach(klass => {
-      inputView(_dom.querySelector(`.${klass}`), {
+      CLASSES.GOAL_STEPS
+    ].forEach( klass => {
+      inputView( _dom.querySelector( `.${ klass }` ), {
         events: {
           blur: _handleUpdateGoals
         }
-      }).init();
-    });
+      } ).init();
+    } );
 
     toArray(
-      _dom.querySelectorAll(`.${CLASSES.GOAL_TIMELINE}`)
-    ).forEach(radio => {
-      inputView(radio, {
+      _dom.querySelectorAll( `.${ CLASSES.GOAL_TIMELINE }` )
+    ).forEach( radio => {
+      inputView( radio, {
         events: {
           click: _handleTimelineUpdate
         },
         type: 'radio'
-      }).init();
-    });
+      } ).init();
+    } );
   }
 
   return {
     init() {
-      if (setInitFlag(_dom)) {
+      if ( setInitFlag( _dom ) ) {
         _initInputs();
-
-        store.subscribe(() => {
-          console.log(store.getState())
-        })
       }
     }
-  }
+  };
 }
 
 goalsView.CLASSES = CLASSES;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
@@ -22,6 +22,17 @@ const GOALS_TO_ACTIONS = {
   goalSteps:  updateGoalStepsAction
 };
 
+/**
+ * GoalsView
+ * @class
+ *
+ * @classdesc View managing form controls in the prelimiary goals section
+ *
+ * @param {HTMLNode} element The root DOM element for this view
+ * @param {Object} props Additional properties to be supplied to the view
+ * @params {Object} props.store The app state store
+ * @returns {Object} The view's public methods
+ */
 function goalsView( element, { store } ) {
   const _dom = checkDom( element, CLASSES.CONTAINER );
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/goals.js
@@ -1,0 +1,84 @@
+import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
+import { toArray } from '../util';
+import {
+  updateGoalAction,
+  updateGoalImportanceAction,
+  updateGoalStepsAction,
+  updateGoalTimelineAction
+} from '../reducers/goal-reducer';
+import inputView from './input';
+
+const CLASSES = {
+  CONTAINER: 'js-yes-goals',
+  LONG_TERM_GOAL: 'js-long-term-goal',
+  GOAL_IMPORTANCE: 'js-goal-importance',
+  GOAL_STEPS: 'js-goal-steps',
+  GOAL_TIMELINE: 'a-radio',
+};
+
+const GOALS_TO_ACTIONS = {
+  'longTermGoal': updateGoalAction, 
+  'goalImportance': updateGoalImportanceAction,
+  'goalSteps':  updateGoalStepsAction
+};
+
+function goalsView(element, { store }) {
+  const _dom = checkDom(element, CLASSES.CONTAINER);
+
+  function _handleUpdateGoals({ name, event }) {
+    const method = GOALS_TO_ACTIONS[name];
+
+    if (method) {
+      store.dispatch( method( {
+        value: event.target.value
+      }))
+    }
+  }
+
+  function _handleTimelineUpdate({ event }) {
+    store.dispatch(updateGoalTimelineAction({
+      value: event.target.value
+    }));
+  }
+
+  function _initInputs() {
+    [
+      CLASSES.LONG_TERM_GOAL,
+      CLASSES.GOAL_IMPORTANCE,
+      CLASSES.GOAL_STEPS,
+    ].forEach(klass => {
+      inputView(_dom.querySelector(`.${klass}`), {
+        events: {
+          blur: _handleUpdateGoals
+        }
+      });
+    });
+
+    toArray(
+      _dom.querySelectorAll(`.${CLASSES.GOAL_TIMELINE}`)
+    ).forEach(radio => {
+      inputView(radio, {
+        events: {
+          click: _handleTimelineUpdate
+        },
+        type: 'radio'
+      });
+    });
+  }
+
+  return {
+    init() {
+      if (setInitFlag(_dom)) {
+        _initInputs();
+
+        store.subscribe(() => {
+          console.log(store.getState())
+        })
+      }
+    }
+  }
+}
+
+goalsView.CLASSES = CLASSES;
+
+export default goalsView;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
@@ -6,7 +6,12 @@ const defaultProps = {
 };
 const NODE_MISSING_ERROR = 'InputView expects to be initialized with an input node matching the supplied `type` prop';
 
-function isInputNode(element) {
+/**
+ * 
+ * @param {HTMLElement} element The element being tested for input or textarea node status
+ * @returns {Boolean} Whether or not the node is an input or textarea node
+ */
+function isInputNode( element ) {
   if (
     element instanceof HTMLInputElement ||
     element instanceof HTMLTextAreaElement
@@ -25,7 +30,7 @@ function isInputNode(element) {
  * @returns {node} The final dom node for this view
  */
 function resolve( element, type ) {
-  if ( isInputNode(element) ) {
+  if ( isInputNode( element ) ) {
     return element;
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
@@ -1,10 +1,21 @@
-import { assign, entries } from './util';
-import { setInitFlag } from '../../../js/modules/util/atomic-helpers';
+import { assign, entries } from '../util';
+import { setInitFlag } from '../../../../js/modules/util/atomic-helpers';
 
 const defaultProps = {
   type: 'text'
 };
 const NODE_MISSING_ERROR = 'InputView expects to be initialized with an input node matching the supplied `type` prop';
+
+function isInputNode(element) {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 /**
  * Get the correct DOM node this view controls
@@ -14,7 +25,7 @@ const NODE_MISSING_ERROR = 'InputView expects to be initialized with an input no
  * @returns {node} The final dom node for this view
  */
 function resolve( element, type ) {
-  if ( element instanceof HTMLInputElement ) {
+  if ( isInputNode(element) ) {
     return element;
   }
 
@@ -32,7 +43,7 @@ function resolve( element, type ) {
  * @param {Object} props Properties the view should be initialized with
  * @returns {Object} The view's public methods
  */
-function InputView( element, props = {} ) {
+function inputView( element, props = {} ) {
   const _finalProps = assign( {}, defaultProps, props );
   const _dom = resolve( element, _finalProps.type );
 
@@ -99,4 +110,4 @@ function InputView( element, props = {} ) {
 }
 
 export { NODE_MISSING_ERROR };
-export default InputView;
+export default inputView;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
@@ -7,7 +7,7 @@ const defaultProps = {
 const NODE_MISSING_ERROR = 'InputView expects to be initialized with an input node matching the supplied `type` prop';
 
 /**
- * 
+ *
  * @param {HTMLElement} element The element being tested for input or textarea node status
  * @returns {Boolean} Whether or not the node is an input or textarea node
  */

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/miles.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/miles.js
@@ -6,7 +6,7 @@ import {
   updateMilesAction,
   updateMilesToActionPlan
 } from '../reducers/route-option-reducer';
-import inputView from '../input-view';
+import inputView from './input';
 import { PLAN_TYPES } from '../data/todo-items';
 
 const CLASSES = Object.freeze( {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
@@ -4,7 +4,7 @@ import {
   updateTransitTimeHoursAction,
   updateTransitTimeMinutesAction
 } from '../reducers/route-option-reducer';
-import inputView from '../input-view';
+import inputView from './input';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'm-yes-transit-time'

--- a/test/unit_tests/apps/youth-employment-success/js/input-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/input-view-spec.js
@@ -1,4 +1,4 @@
-import inputView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/input-view';
+import inputView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/input';
 import { simulateEvent } from '../../../../util/simulate-event';
 
 const HTML = `

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -213,7 +213,7 @@ describe( 'routeOptionReducer', () => {
       expect( actionPlanItems.length ).toBe( 1 );
       expect( actionPlanItems[0] ).toBeDefined();
       expect( actionPlanItems[0] ).toBe( PLAN_TYPES.DAYS_PER_WEEK );
-    });
+    } );
 
     it( 'reduces the .updateMilesToActionPlan action', () => {
       const state = routeOptionReducer(
@@ -306,22 +306,22 @@ describe( 'routeOptionReducer', () => {
         addRouteOptionAction( createRoute( route ) )
       );
 
-      let currRoute = routeSelector(state, routeIndex);
+      let currRoute = routeSelector( state, routeIndex );
 
       expect( currRoute.daysPerWeek ).toBe( route.daysPerWeek );
       expect( currRoute.actionPlanItems ).toBe( route.actionPlanItems );
-      expect(currRoute.actionPlanItems[0]).toBeDefined();
+      expect( currRoute.actionPlanItems[0] ).toBeDefined();
 
       state = routeOptionReducer(
         state,
         clearDaysPerWeekAction( { routeIndex } )
       );
 
-      currRoute = routeSelector(state, routeIndex);
+      currRoute = routeSelector( state, routeIndex );
 
       expect( currRoute.daysPerWeek ).toBe( '' );
       expect( currRoute.actionPlanItems.length ).toBe( 0 );
-    });
+    } );
 
     it( 'reduces the .clearMilesAction', () => {
       const routeIndex = 0;
@@ -334,7 +334,7 @@ describe( 'routeOptionReducer', () => {
         addRouteOptionAction( route )
       );
 
-      let currRoute = routeSelector(state, routeIndex);
+      let currRoute = routeSelector( state, routeIndex );
 
       expect( currRoute.miles ).toBe( route.miles );
       expect( currRoute.actionPlanItems ).toBe( route.actionPlanItems );
@@ -344,9 +344,9 @@ describe( 'routeOptionReducer', () => {
         state,
         clearMilesAction( { routeIndex } )
       );
-      
-      currRoute = routeSelector(state, routeIndex);
-      
+
+      currRoute = routeSelector( state, routeIndex );
+
       expect( currRoute.miles ).toBe( '' );
       expect( currRoute.actionPlanItems.length ).toBe( 0 );
     } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/goals-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/goals-spec.js
@@ -1,0 +1,108 @@
+import { simulateEvent } from '../../../../../util/simulate-event';
+import goalsView from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/goals';
+import {
+  updateGoalAction,
+  updateGoalImportanceAction,
+  updateGoalStepsAction,
+  updateGoalTimelineAction
+} from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/goal-reducer';
+
+const HTML = `
+  <form class="js-yes-goals">
+    <input type="radio" name="goalTimeline" class="a-radio" value="3 to 6 months">
+    <input type="radio" name="goalTimeline" class="a-radio">
+    <input type="radio" name="goalTimeline" class="a-radio">
+    <input type="radio" name="goalTimeline" class="a-radio">
+    <textarea name="longTermGoal" class="js-long-term-goal"></textarea>
+    <textarea name="goalImportance" class="js-goal-importance"></textarea>
+    <textarea name="goalSteps" class="js-goal-steps"></textarea>
+  </form>
+`;
+
+describe( 'goalsView', () => {
+  const CLASSES = goalsView.CLASSES;
+  const dispatch = jest.fn();
+  const mockStore = () => ( {
+    dispatch,
+    subscribe() { return {}; }
+  } );
+  let view;
+  let store;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML;
+    store = mockStore();
+    view = goalsView( document.querySelector( `.${ CLASSES.CONTAINER }` ), { store } );
+    view.init();
+  } );
+
+  afterEach( () => {
+    dispatch.mockReset();
+    view = null;
+  } );
+
+  it( 'dispatches the correct event when the long term goal field is blurred', () => {
+    const ltgEl = document.querySelector( `.${ CLASSES.LONG_TERM_GOAL }` );
+    const goal = 'my goal';
+    const mock = store.dispatch.mock;
+
+    ltgEl.value = goal;
+
+    simulateEvent( 'blur', ltgEl );
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateGoalAction( {
+        value: goal
+      } )
+    );
+  } );
+
+  it( 'dispatches the correct event when the goal importance field is blurred', () => {
+    const importanceEl = document.querySelector( `.${ CLASSES.GOAL_IMPORTANCE }` );
+    const goal = 'my goal';
+    const mock = store.dispatch.mock;
+
+    importanceEl.value = goal;
+
+    simulateEvent( 'blur', importanceEl );
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateGoalImportanceAction( {
+        value: goal
+      } )
+    );
+  } );
+
+  it( 'dispatches the correct event when the goal steps field is blurred', () => {
+    const stepsEl = document.querySelector( `.${ CLASSES.GOAL_STEPS }` );
+    const goal = 'my goal';
+    const mock = store.dispatch.mock;
+
+    stepsEl.value = goal;
+
+    simulateEvent( 'blur', stepsEl );
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateGoalStepsAction( {
+        value: goal
+      } )
+    );
+  } );
+
+  it( 'dispatches the correct event when a radio timeline button is selected', () => {
+    const shortTimelineEl = document.querySelectorAll( '.a-radio' )[0];
+    const mock = store.dispatch.mock;
+
+    simulateEvent( 'click', shortTimelineEl );
+
+    expect( mock.calls.length ).toBe( 1 );
+    expect( mock.calls[0][0] ).toEqual(
+      updateGoalTimelineAction( {
+        value: shortTimelineEl.value
+      } )
+    );
+  } );
+} );


### PR DESCRIPTION
So that the application can store a reference to the user's answers to our questions related to a user's long-term transportation goals, adds a view to update the `goalReducer` when the user interacts with the form controls in this section.

## Additions

- View + specs for goals section
 
## Removals

-

## Changes

-

## Testing

1. Unit tests

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
