### PR TITLE
Fix line-too-long linter error

### DIFF
--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -38,8 +38,10 @@ class ComplaintLandingView(TemplateView):
             ccdb_status_json = self.get_ccdb_status_json(complaint_source)
             context.update(self.is_ccdb_out_of_date(ccdb_status_json))
 
-        context['technical_issues'] = flag_enabled('CCDB_TECHNICAL_ISSUES')
-        context['ccdb_sept_2019_updates'] = flag_enabled('CCDB_SEPT_2019_UPDATES')
+        context.update({
+            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
+            'ccdb_sept_2019_updates': flag_enabled('CCDB_SEPT_2019_UPDATES'),
+        })
 
         return context
 


### PR DESCRIPTION
#5234 inadvertently added a line of Python code that exceeds our linter standard (79 characters).

This was merged while Travis CI checks were temporarily disabled, but now that it has been re-enabled, all PRs (and master) are failing the linter checks ([for example](https://travis-ci.org/cfpb/cfgov-refresh/jobs/585836350)).

## Testing

`tox -e lint-py27`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: