### PR TITLE
YES tool — Add view for closed route option

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -7,6 +7,7 @@ import daysPerWeekView from './views/days-per-week';
 import routeOptionFormView from './route-option-view';
 import routeOptionToggleView from './route-option-toggle-view';
 import routeDetailsView from './views/route-details';
+import expandableView from './views/expandable';
 import store from './store';
 
 Array.prototype.slice.call(
@@ -25,6 +26,13 @@ const budgetForm = budgetFormView( budgetFormEl, { store } );
 budgetForm.init();
 
 const expandables = Expandable.init();
+
+expandables.forEach( expandable => {
+  expandableView( expandable.element, {
+    expandable
+  } ).init();
+} );
+
 const routeOptionForms = expandables.map( ( expandable, index ) => {
   store.dispatch( addRouteOptionAction( createRoute() ) );
 
@@ -38,8 +46,10 @@ const routeOptionForms = expandables.map( ( expandable, index ) => {
   } );
 } );
 
-/* only initialize the first form, the other gets initialized when
-  the user clicks 'add another option' button */
+/**
+ * Only initialize the first route option form, the second is initialized when
+ * the user clicks the 'add another option' button.
+*/
 routeOptionForms[0].init();
 routeOptionToggleView(
   document.querySelector( `.${ OPTION_TOGGLE_CLASSES.BUTTON }` ), {
@@ -49,7 +59,6 @@ routeOptionToggleView(
 ).init();
 
 expandables[0].element.querySelector( '.o-expandable_target' ).click();
-// target the last element, reverse is destructive
 expandables[1].element.classList.add( 'u-hidden' );
 
 window.onbeforeunload = () => {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/expandable.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/expandable.js
@@ -1,0 +1,62 @@
+import { checkDom } from '../../../../js/modules/util/atomic-helpers';
+
+const CLASSES = Object.freeze( {
+  CONTAINER: 'o-expandable'
+} );
+
+/**
+ * ExpandableView
+ * @class
+ *
+ * @classdesc Wraps an expandable object instance to allow for DOM manipulation within
+ * the route-option-form when an expandable is opened or closed
+ *
+ * @param {HTMLNode} element The root DOM element for this view
+ * @param {Object} props Additional properties to be supplied to the view
+ * @param {Object} props.expandable The expandable instance this view manages
+ * @returns {Object} The view's public methods
+ */
+function expandableView( element, { expandable } ) {
+  const _dom = checkDom( element, CLASSES.CONTAINER );
+  let initialized = false;
+  let detailsEl;
+
+  if ( !expandable ) {
+    throw new TypeError( 'An instance of an expandable is a required prop.' );
+  }
+
+  /**
+   * If the view has been initialzed and was previously opened,
+   * remove the route details node.
+   */
+  function _hideRouteDetails() {
+    if ( initialized && detailsEl ) {
+      _dom.removeChild( detailsEl );
+      detailsEl = null;
+    }
+  }
+
+  /**
+   * Append a copy of the route-details html to the closed expandable. Stores a ref to the DOM
+   * node for later removal
+   */
+  function _showRouteDetails() {
+    detailsEl = _dom.querySelector( '.yes-route-details' ).cloneNode( true );
+    detailsEl.classList.add( 'o-expandable_content' );
+    _dom.appendChild( detailsEl );
+  }
+
+  return {
+    init() {
+      if ( !initialized ) {
+        expandable.transition.addEventListener( 'expandBegin', _hideRouteDetails );
+        expandable.transition.addEventListener( 'collapseBegin', _showRouteDetails );
+        initialized = true;
+      }
+    }
+  };
+}
+
+expandableView.CLASSES = CLASSES;
+
+export default expandableView;

--- a/test/unit_tests/apps/youth-employment-success/js/views/expandable-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/expandable-spec.js
@@ -1,0 +1,63 @@
+import expandableView from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/expandable';
+import Expandable from 'cf-expandables/src/Expandable';
+
+const HTML = `
+  <div class="o-expandable">
+    <button class="o-expandable_header o-expandable_target" title="Expand content">
+      <h3 class="h4 o-expandable_header-left o-expandable_label">
+        Expandable
+      </h3>
+    </button>
+    <div class="o-expandable_content"><div class="yes-route-details"></div></div>
+  </div>
+`;
+
+describe( 'expandableView', () => {
+  let expandables;
+  let expandable;
+  let target;
+  let view;
+
+  it( 'throws an error when initialized without an expandable', () => {
+    expect( () => expandableView( document.body ) ).toThrow(TypeError);
+  } );
+
+  describe( 'proper instantiation', () => {
+    beforeEach( () => {
+      document.body.innerHTML = HTML;
+      expandables = Expandable.init();
+      expandable = expandables[0];
+      target = expandable.element.querySelector( '.o-expandable_target' );
+      view = expandableView( expandable.element, {
+        expandable
+      } );
+      view.init();
+    } );
+
+    afterEach( () => {
+      expandables.length = 0;
+      view = null;
+    } );
+
+
+    it( 'adds the route-details section as a direct child when closed', () => {
+      target.click();
+      // The expandable starts open, so click it again.
+      target.click();
+      const children = expandable.element.children;
+
+      expect( children.length ).toBe( 3 );
+      expect( children[2].outerHTML ).toBe(
+        '<div class="yes-route-details o-expandable_content"></div>'
+      );
+    } );
+
+    it( 'removes the route-details section as a direct child when re-opened', () => {
+      target.click();
+      target.click();
+      target.click();
+
+      expect( expandable.element.children.length ).toBe( 2 );
+    } );
+  } );
+} );


### PR DESCRIPTION
So the user can be reminded of what the outcome of their route option choices, display the `route-details` view to them when the `route-option-form` expandable is closed.

## Additions

- Adds a view to wrap an expandable and coordinate events between it and the DOM

## Testing

1. Specs should pass
2. In the transit tool, toggle an expandable. You should see the `route-details` view below the expandable click area.
3. Toggle the expandable again, the additional details view should be removed from the DOM.

## Todos

- [x] Add specs

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
