### PR TITLE
Disable acceptance tests temporarily in Travis

### DIFF
--- a/travis_run.sh
+++ b/travis_run.sh
@@ -8,7 +8,9 @@ export NODE_ENV='development'
 
 echo "running $RUNTEST tests"
 if [ "$RUNTEST" == "frontend" ]; then
-    yarn run gulp test --travis --headless
+    # Acceptance tests are disabled pending a webdriver update
+    # yarn run gulp test --travis --headless
+    yarn run gulp test:unit --travis --headless
     bash <(curl -s https://codecov.io/bash) -F frontend -X coveragepy
 elif [ "$RUNTEST" == "backend" ]; then
     TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner tox


### PR DESCRIPTION
This disables the acceptance tests that depend on WebDriver and Chrome. Once those issues are resolved we can revert this change, but this will ensure we don't have to keep disabling Travis to merge PRs.

@anselmbradford suggested running `test:unit` as a way to do this.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
