### PR TITLE
Reenable acceptance tests in Travis

### DIFF
--- a/travis_run.sh
+++ b/travis_run.sh
@@ -8,9 +8,7 @@ export NODE_ENV='development'
 
 echo "running $RUNTEST tests"
 if [ "$RUNTEST" == "frontend" ]; then
-    # Acceptance tests are disabled pending a webdriver update
-    # yarn run gulp test --travis --headless
-    yarn run gulp test:unit --travis --headless
+    yarn run gulp test --travis --headless
     bash <(curl -s https://codecov.io/bash) -F frontend -X coveragepy
 elif [ "$RUNTEST" == "backend" ]; then
     TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner tox


### PR DESCRIPTION
This PR reverts the changes in #5249 and reenables acceptance tests in Travis. 

This is draft pending the required webdriver release.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: