### PR TITLE
YES tool — Light cleanup and tweaks

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/goals/goal.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals/goal.html
@@ -25,7 +25,7 @@
   ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}
 
-{% macro renderTextarea(value) -%}
+{% macro render(value) -%}
 
 {%- set id = get_unique_id('textarea_', '_') ~ slugify( value.label ) -%}
 {%- set ht_id = get_unique_id('textarea_ht_', '_') ~ slugify( value.label ) -%}

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -1,7 +1,6 @@
 import { checkDom, setInitFlag } from '../../../js/modules/util/atomic-helpers';
 import {
   routeSelector,
-  updateDaysPerWeekAction,
   updateTransportationAction
 } from './reducers/route-option-reducer';
 import inputView from './views/input';
@@ -13,82 +12,6 @@ const CLASSES = Object.freeze( {
   TRANSPORTATION_CHECKBOX: 'a-yes-route-mode',
   QUESTION_INPUT: 'a-yes-question'
 } );
-
-const actionMap = Object.freeze( {
-  daysPerWeek: updateDaysPerWeekAction
-} );
-
-/**
- * Map of the fields this form manages that are hidden or shown conditionally,
- * and the predicate functions that determine the field's state
- */
-const toggleableFields = {
-  daysPerWeek: state => state.transportation === 'Drive' || state.isCostPerDay
-};
-
-/**
- * Hide an input and clear its value
- * @param {HTMLElement} node dom element to be toggled
- */
-function hideToggleableField( node ) {
-  if ( !node ) return;
-  // need to add an action to update the store somewhere
-  node.value = '';
-  node.classList.add( 'u-hidden' );
-}
-
-/**
- ** Show an input
- * @param {HTMLElement} node dom element to be toggled
- */
-function showToggleableField( node ) {
-  node.classList.remove( 'u-hidden' );
-}
-
-/**
- *
- * @param {HTMLElement} node the node to be updated
- * @param {boolean} flag indicates if node is hidden or shown
- */
-function updateNode( node, flag ) {
-  if ( flag ) {
-    showToggleableField( node );
-  } else {
-    hideToggleableField( node );
-  }
-}
-
-/**
- * Determine if value in store has changed since last state update
- * @param {*} lastValue the old value of the state item
- * @param {*} currentValue the new value of the state item
- * @returns {boolean} Whether the value has changed
- */
-function checkHasStateChanged( lastValue, currentValue ) {
-  return lastValue !== currentValue || ( !lastValue && !currentValue );
-}
-
-/**
- * Updates togglebale inputs this view controls
- * @param {object} inputs node names with ref to dom node as value
- * @param {*} prevState previous state of the app
- * @param {*} state current state of the app
- */
-function updateVisibleInputs( inputs, prevState, state ) {
-  for ( const name in toggleableFields ) {
-    if ( toggleableFields.hasOwnProperty( name ) ) {
-      const predicate = toggleableFields[name];
-      const stateHasChanged = checkHasStateChanged(
-        prevState[name],
-        state[name]
-      );
-
-      if ( stateHasChanged ) {
-        updateNode( inputs[name], predicate( state ) );
-      }
-    }
-  }
-}
 
 /**
  * RouteOptionFormView
@@ -112,36 +35,6 @@ function RouteOptionFormView( element, {
   const _transportationOptionEls = toArray(
     _dom.querySelectorAll( `.${ CLASSES.TRANSPORTATION_CHECKBOX }` )
   );
-  const _textInputEls = toArray(
-    _dom.querySelectorAll( `.${ CLASSES.QUESTION_INPUT }` )
-  );
-  const _inputMap = _textInputEls.reduce( ( memo, node ) => {
-    const maybeNode = node.tagName === 'INPUT' ? node : node.querySelector( 'input' );
-
-    if ( !maybeNode ) {
-      return memo;
-    }
-
-    memo[maybeNode.getAttribute( 'data-js-name' )] = maybeNode;
-
-    return memo;
-  }, {} );
-
-  /**
-   * Updates form state from child input text nodes
-   * @param {object} updateObject object with DOM event and field name
-   */
-  function _setQuestionResponse( { name, event } ) {
-    const action = actionMap[name];
-    const { target: { value }} = event;
-
-    if ( action ) {
-      store.dispatch( action( {
-        routeIndex,
-        value
-      } ) );
-    }
-  }
 
   /**
    * Updates state from child input radio nodes
@@ -167,24 +60,11 @@ function RouteOptionFormView( element, {
     );
   }
 
-  /**
-   * Initialize input nodes this form view manages
-   */
-  function _initQuestions() {
-    _textInputEls.forEach( node => inputView( node, {
-      events: { input: _setQuestionResponse }
-    } )
-      .init()
-    );
-  }
-
-  const boundUpdate = updateVisibleInputs.bind( null, _inputMap );
-
   return {
     init() {
       if ( setInitFlag( _dom ) ) {
         _initRouteOptions();
-        _initQuestions();
+
         transitTimeView(
           _dom.querySelector( `.${ transitTimeView.CLASSES.CONTAINER }` ),
           { store, routeIndex }
@@ -206,22 +86,12 @@ function RouteOptionFormView( element, {
 
         detailsView.init();
 
-        const currentState = routeSelector(
-          store.getState().routes, routeIndex
-        );
-
-        boundUpdate( currentState, currentState );
-
-        store.subscribe( ( prevState, nextState ) => {
+        store.subscribe( ( _, nextState ) => {
           const currentRouteState = routeSelector(
             nextState.routes,
             routeIndex
           );
 
-          boundUpdate(
-            routeSelector( prevState.routes, routeIndex ),
-            currentRouteState
-          );
           detailsView.render( {
             budget: nextState.budget,
             route: currentRouteState

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
@@ -59,8 +59,8 @@ function daysPerWeekView( element, { store, routeIndex } ) {
    * @param {object} state The current state of the app.
    */
   function _onStateUpdate( prevState, state ) {
-    const prevRouteState = routeSelector( prevState, routeIndex );
-    const routeState = routeSelector( state, routeIndex );
+    const prevRouteState = routeSelector( prevState.routes, routeIndex );
+    const routeState = routeSelector( state.routes, routeIndex );
 
     if ( routeState.transportation === 'Drive' ) {
       _dom.classList.remove( 'u-hidden' );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/miles.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/miles.js
@@ -68,8 +68,8 @@ function milesView( element, { store, routeIndex } ) {
    * @param {object} state The current state of the app.
    */
   function _onStateUpdate( prevState, state ) {
-    const routeState = routeSelector( state, routeIndex );
-    const prevRouteState = routeSelector( prevState, routeIndex );
+    const routeState = routeSelector( state.routes, routeIndex );
+    const prevRouteState = routeSelector( prevState.routes, routeIndex );
 
     if ( routeState.transportation === 'Drive' ) {
       _dom.classList.remove( 'u-hidden' );

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
@@ -93,21 +93,9 @@ describe( 'routeOptionFormView', () => {
     expect( costViewInit ).toHaveBeenCalled();
     expect( detailsInit ).toHaveBeenCalled();
     expect( daysViewInit ).toHaveBeenCalled();
+    expect( milesViewInit ).toHaveBeenCalled();
   } );
 
-  it( 'dispatches an action to update `daysPerWeek` input', () => {
-    const daysPerWeekEl = document.querySelector( 'input[name="daysPerWeek"]' );
-    const value = '4';
-
-    daysPerWeekEl.value = value;
-
-    simulateEvent( 'input', daysPerWeekEl );
-
-    const mock = store.dispatch.mock;
-
-    expect( mock.calls.length ).toBe( 1 );
-    expect( mock.calls[0][0] ).toEqual( updateDaysPerWeekAction( { routeIndex: 0, value } ) );
-  } );
 
   it( 'dispatches an action to update `transportation` with checkbox selection', () => {
     const radioEl = document.querySelectorAll( 'input[name="transpo"]' )[0];
@@ -118,13 +106,5 @@ describe( 'routeOptionFormView', () => {
 
     expect( mock.calls.length ).toBe( 1 );
     expect( mock.calls[0][0] ).toEqual( updateTransportationAction( { routeIndex: 0, value: radioEl.value } ) );
-  } );
-
-  describe( 'conditional fields', () => {
-    it( 'hides conditional fields on init', () => {
-      const daysPerWeekEl = document.querySelector( 'input[name="daysPerWeek"]' );
-
-      expect( daysPerWeekEl.classList.contains( 'u-hidden' ) ).toBeTruthy();
-    } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
@@ -97,12 +97,14 @@ describe( 'DaysPerWeekView', () => {
   describe( 'on state update', () => {
     it( 'removes u-hidden class when transportation mode is drive', () => {
       const state = {
-        routes: [ {
-          transportation: 'Drive'
-        } ]
+        routes: {
+          routes: [ {
+            transportation: 'Drive'
+          } ]
+        }
       };
 
-      store.subscriber()( { routes: [ {} ]}, state );
+      store.subscriber()( { routes: { routes: [ {} ]} }, state );
 
       expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
     } );
@@ -111,14 +113,18 @@ describe( 'DaysPerWeekView', () => {
       const days = '2';
       const checked = 'checked';
       const prevState = {
-        routes: [ {
-          daysPerWeek: days
-        } ]
+        routes: {
+          routes: [ {
+            daysPerWeek: days
+          } ]
+        }
       };
       const state = {
-        routes: [ {
-          transportation: 'Walk'
-        } ]
+        routes: {
+          routes: [ {
+            transportation: 'Walk'
+          } ]
+        }
       };
 
       it( 'clears the form inputs', () => {
@@ -138,14 +144,14 @@ describe( 'DaysPerWeekView', () => {
         const subscriberFn = store.subscriber();
         subscriberFn( prevState, state );
 
-        const classes = dom.classList.toString();
+        expect( dom.classList.contains( 'u-hidden' ) ).toBeTruthy();
 
-        expect( classes.match( /u\-hidden/g ).length ).toBe( 1 );
-
-        subscriberFn( { routes: [ {} ]}, {
-          routes: [ {
-            transportation: 'Drive'
-          } ]
+        subscriberFn( { routes: { routes: [ {} ]} }, {
+          routes: {
+            routes: [ {
+              transportation: 'Drive'
+            } ]
+          }
         } );
 
         expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
@@ -153,7 +159,6 @@ describe( 'DaysPerWeekView', () => {
         subscriberFn( prevState, state );
 
         expect( dom.classList.contains( 'u-hidden' ) ).toBeTruthy();
-        expect( dom.classList.toString().match( /u\-hidden/g ).length ).toBe( 1 );
       } );
 
       it( 'dispatches the correct action when daysPerWeek is filled in and transportation method is not drive', () => {

--- a/test/unit_tests/apps/youth-employment-success/js/views/miles-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/miles-spec.js
@@ -82,12 +82,14 @@ describe( 'milesView', () => {
   describe( 'on state update', () => {
     it( 'removes u-hidden class when transportation mode is Drive', () => {
       const state = {
-        routes: [ {
-          transportation: 'Drive'
-        } ]
+        routes: {
+          routes: [ {
+            transportation: 'Drive'
+          } ]
+        }
       };
 
-      store.subscriber()( { routes: [ {} ]}, state );
+      store.subscriber()( { routes: { routes: [ {} ]} }, state );
 
       expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
     } );
@@ -96,14 +98,18 @@ describe( 'milesView', () => {
       const miles = '12';
       const checked = true;
       const prevState = {
-        routes: [ {
-          miles: miles
-        } ]
+        routes: {
+            routes: [ {
+            miles: miles
+          } ]
+        }
       };
       const state = {
-        routes: [ {
-          transportation: 'Walk'
-        } ]
+        routes: {
+            routes: [ {
+            transportation: 'Walk'
+          } ]
+        }
       };
 
       it( 'clears the form inputs', () => {
@@ -123,10 +129,12 @@ describe( 'milesView', () => {
         const subscriberFn = store.subscriber();
         subscriberFn( prevState, state );
 
-        subscriberFn( { routes: [ {} ]}, {
-          routes: [ {
-            transportation: 'Drive'
-          } ]
+        subscriberFn( { routes: { routes: [ {} ]} }, {
+          routes: {
+            routes: [ {
+              transportation: 'Drive'
+            } ]
+          }
         } );
 
         expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
@@ -149,9 +157,11 @@ describe( 'milesView', () => {
       it( 'dispatches the correct action when not sure is selected and transportation method is not drive', () => {
         const mock = store.dispatch.mock;
         store.subscriber()( {
-          routes: [ {
-            actionPlanItems: [ PLAN_TYPES.MILES ]
-          } ]
+          routes: {
+            routes: [ {
+              actionPlanItems: [ PLAN_TYPES.MILES ]
+            } ]
+          }
         }, state );
 
         expect( mock.calls.length ).toBe( 1 );


### PR DESCRIPTION
Due to a bit of PR churn, I needed to clean up code I had mistakenly left in some previously work.

## Testing

1. Specs should pass.
2. Tool should load in browser


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
