### PR TITLE
YES Tool - Add detail review view

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -1,6 +1,6 @@
-{% from 'alert.html' import render as renderAlert with context %}
+{% import 'alert.html' as alert with context %}
 
-<div class="block block__sub">
+<div class="block block__sub js-option-review">
   <h2>Your plan to get to work</h2>
   <h3>Your to-do list</h3>
   <ul>
@@ -8,47 +8,53 @@
   </ul>
   <div class="block block__sub">
     <p><b>OPTION 1: <span class="js-option-1-type"></span></b></p>
-    <ul class="js-option-1-todo"></ul>
+    <ul class="js-review-todo"></ul>
   </div>
   <div class="block block__sub">
     <p><b>OPTION 2: <span class="js-option-2-type"></span></b></p>
-    <ul class="js-option-2-todo"></ul>
+    <ul class="js-review-todo"></ul>
   </div>
-  <div class="js-option-1 block block__sub">
+  <div class="block block__sub">
     <p class="h3">Your first choice is <span class="js-transportation-type"></span></p>
-    <div class="content-l content-l_col-2-3 block block__sub">
+    <div class="content-l content-l_col-2-3">
       {{
-        renderAlert({
+        alert.render({
           'background': true,
+          'class': 'js-route-incomplete',
           'fill': 'warning',
           'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you',
           'visible': true
         })
       }}
     </div>
-    {% with show_todos=false %}
-      {% include "route-details.html" %}
-    {% endwith %}
+    <div class="block block__sub">
+      {% with show_todos=false %}
+        {% include "route-details.html" %}
+      {% endwith %}
+    </div>
     <div class="content_line"></div>
   </div>
-  <div class="js-option-2 block block__sub">
+  <div class="block block__sub">
     <p class="h3">Another option you compared: <span class="js-transportation-type"></span></p>
-    <p class="u-mb0">
+    <p>
       <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
     </p>
-    <div class="content-l content-l_col-2-3 block block__sub">
+    <div class="content-l content-l_col-2-3">
       {{
-        renderAlert({
+        alert.render({
           'background': true,
+          'class': 'js-route-incomplete',
           'fill': 'warning',
           'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you',
           'visible': true
         })
       }}
     </div>
-    {% with show_todos=false %}
-      {% include "route-details.html" %}
-    {% endwith %}
+    <div class="block block__sub">
+      {% with show_todos=false %}
+        {% include "route-details.html" %}
+      {% endwith %}
+    </div>
     <div class="content_line"></div>
   </div>
 </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -13,6 +13,7 @@ import routeDetailsView from './views/route-details';
 import expandableView from './views/expandable';
 import store from './store';
 import transitTimeView from './views/transit-time';
+import reviewDetailsView from './views/review/details';
 
 Array.prototype.slice.call(
   document.querySelectorAll( 'input' )
@@ -35,7 +36,17 @@ const budgetFormEl = document.querySelector( `.${ BUDGET_CLASSES.FORM }` );
 const budgetForm = budgetFormView( budgetFormEl, { store } );
 budgetForm.init();
 
-reviewGoalsView( document.querySelector( `.${ REVIEW_GOALS_CLASSES.CONTAINER }` ), { store } ).init();
+reviewGoalsView(
+  document.querySelector( `.${ REVIEW_GOALS_CLASSES.CONTAINER }`
+  ), { store }
+).init();
+
+const reviewDetailsEl = document.querySelector(
+  `.${ reviewDetailsView.CLASSES.CONTAINER }`
+);
+reviewDetailsView( reviewDetailsEl, {
+  store, routeDetailsView
+} ).init();
 
 const expandables = Expandable.init();
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/money.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/money.js
@@ -1,6 +1,6 @@
 const _centsPerDollar = 100;
 const _decimals = 2;
-const _dollarsToPrecisionRegexp = new RegExp( `(\\d+\\.?\\d{0,${ _decimals }})` );
+const _dollarsToPrecisionRegexp = new RegExp( `(\-?\\d+\\.?\\d{0,${ _decimals }})` );
 
 /**
  * Converts an input string into a scaled dollar value, or zero.

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -89,7 +89,7 @@ function routeSelector( state, index ) {
 function todoListSelector( state, index ) {
   const route = routeSelector( state, index );
 
-  return route.actionPlanItems;
+  return route.actionPlanItems || [];
 }
 
 /**

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -182,6 +182,29 @@ function isNumber( maybeNum ) {
   return typeof num === 'number' && num === num;
 }
 
+/**
+ * Helper function to control showing and hiding CFNotification alert nodes
+ * @param {HTMLElement} node The element in which to search for the notification,
+ * or the notification itself
+ * @param {Boolean} doShow Whether to show or hide the element
+ */
+function toggleCFNotification( node, doShow ) {
+  if ( !( node instanceof HTMLElement ) ) {
+    throw new TypeError( 'First argument must be a valid DOM node.' );
+  }
+
+  const notification = node.classList.contains( 'm-notification' ) ?
+    node : node.querySelector( '.m-notification' );
+
+  if ( notification ) {
+    if ( doShow ) {
+      notification.classList.add( 'm-notification__visible' );
+    } else {
+      notification.classList.remove( 'm-notification__visible' );
+    }
+  }
+}
+
 export {
   actionCreator,
   assign,
@@ -189,5 +212,6 @@ export {
   entries,
   isNumber,
   toArray,
+  toggleCFNotification,
   UNDEFINED
 };

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
@@ -1,0 +1,107 @@
+import { checkDom, setInitFlag } from '../../../../../js/modules/util/atomic-helpers';
+import { routeSelector, todoListSelector } from '../../reducers/route-option-reducer';
+import { toArray, toggleCFNotification } from '../../util';
+import { getPlanItem } from '../../data/todo-items';
+
+const CLASSES = Object.freeze( {
+  CONTAINER: 'js-option-review',
+  DETAILS: 'yes-route-details',
+  TODO: 'js-review-todo',
+  ALERT: 'js-route-incomplete'
+} );
+
+/**
+ * ReviewDetailsView
+ *
+ * @class
+ *
+ * @classdesc View to display details of user's route selections in the
+ * review section
+ *
+ * @param {HTMLElement} element The container node for this view
+ * @param {Object} props The additional properties supplied to this view
+ * @param {YesStore} props.store The public API exposed by the Store class
+ * @param {Function} props.routeDetailsView The child view managed by this view,
+ * duplicates the information shown in the details section of the route option
+ * form
+ * @returns {Object} This view's public API
+ */
+function reviewDetailsView( element, { store, routeDetailsView } ) {
+  const _dom = checkDom( element, CLASSES.CONTAINER );
+  const _todoEls = toArray(
+    _dom.querySelectorAll( `.${ CLASSES.TODO }` )
+  );
+  const _detailsEls = toArray(
+    _dom.querySelectorAll( `.${ CLASSES.DETAILS }` )
+  );
+  const _notificationEls = toArray(
+    _dom.querySelectorAll( `.${ CLASSES.ALERT }` )
+  );
+  const _detailsViews = [];
+
+  /**
+   * Event handler to update child views with current state
+   * @param {Object} _ The previous state value from store (unused)
+   * @param {Object} state The current application state
+   */
+  function _handleStateUpdate( _, state ) {
+    _detailsViews.forEach( ( view, index ) => {
+      const currentRoute = routeSelector(
+        state.routes,
+        index
+      );
+
+      if ( Object.keys( currentRoute ).length ) {
+        view.render( {
+          budget: state.budget,
+          route: currentRoute
+        } );
+      }
+    } );
+
+    _todoEls.forEach( ( el, index ) => {
+      const fragment = document.createDocumentFragment();
+      todoListSelector( state.routes, index ).forEach( todo => {
+        const item = document.createElement( 'li' );
+        item.textContent = getPlanItem( todo );
+        fragment.appendChild( item );
+      } );
+
+      el.innerHTML = '';
+      el.appendChild( fragment );
+    } );
+
+    _notificationEls.forEach( ( el, index ) => {
+      const todos = todoListSelector( state.routes, index );
+      toggleCFNotification( el, todos.length );
+    } );
+  }
+
+  /**
+   * Initialize the child views this view manages.
+   */
+  function _initSubviews() {
+    _detailsEls.reduce( ( memo, node ) => {
+      const view = routeDetailsView( node );
+
+      memo.push( view );
+
+      view.init();
+
+      return memo;
+    }, _detailsViews );
+  }
+
+  return {
+    init() {
+      if ( setInitFlag( _dom ) ) {
+        _initSubviews();
+        store.subscribe( _handleStateUpdate );
+      }
+    }
+  };
+}
+
+reviewDetailsView.CLASSES = CLASSES;
+
+export default reviewDetailsView;

--- a/test/unit_tests/apps/youth-employment-success/js/money-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/money-spec.js
@@ -21,5 +21,6 @@ describe( 'money helpers', () => {
 
   it( 'subtracts values', () => {
     expect( money.subtract( '100', '50' ) ).toEqual( 50 );
+    expect( money.subtract( '-50', '50' ) ).toEqual( -100 );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/util-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/util-spec.js
@@ -4,7 +4,8 @@ import {
   assign,
   combineReducers,
   entries,
-  toArray
+  toArray,
+  toggleCFNotification
 } from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
 
 const reducerStateA = {
@@ -184,6 +185,26 @@ describe( 'YES utility functions', () => {
       const array = toArray( dom.querySelectorAll( 'a' ) );
 
       expect( array.slice ).toBeDefined();
+    } );
+  } );
+
+  describe( '.toggleCFNotification', () => {
+    it( 'throws an error if not passed a dom node as its first argument', () => {
+      expect( () => toggleCFNotification( null, true ) ).toThrow();
+    } );
+
+    it( 'toggles a supplied notification', () => {
+      const HTML = '<div class="m-notification"></div>';
+      document.body.innerHTML = HTML;
+      const el = document.querySelector( '.m-notification' );
+
+      toggleCFNotification( el, true );
+
+      expect( el.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
+
+      toggleCFNotification( el, false );
+
+      expect( el.classList.contains( 'm-notification__visible' ) ).toBeFalsy();
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
@@ -1,0 +1,107 @@
+import reviewDetailsView from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/review/details';
+import mockStore from '../../../../../mocks/store';
+import { toArray } from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
+import { PLAN_TYPES } from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items';
+
+const HTML = `
+<div class="js-option-review">
+  <h2>Your plan to get to work</h2>
+  <h3>Your to-do list</h3>
+  <ul>
+    <li>Ask about bus passes, gas cards, rideshare credits, or other reduced-fare transit cards</li>
+  </ul>
+  <div class="block block__sub">
+    <p><b>OPTION 1: <span class="js-option-1-type"></span></b></p>
+    <ul class="js-review-todo"></ul>
+  </div>
+  <div class="block block__sub">
+    <p><b>OPTION 2: <span class="js-option-2-type"></span></b></p>
+    <ul class="js-review-todo"></ul>
+  </div>
+  <div class="block block__sub">
+    <p class="h3">Your first choice is <span class="js-transportation-type"></span></p>
+    <div class="js-route-incomplete">
+      <div class="m-notification"></div>
+    </div>
+    <div class="yes-route-details"></div>
+    <div class="content_line"></div>
+  </div>
+  <div class="block block__sub">
+    <p class="h3">Another option you compared: <span class="js-transportation-type"></span></p>
+    <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
+    <div class="yes-route-details"></div>
+    <div class="content_line"></div>
+  </div>
+</div>
+`;
+
+describe( 'reviewDetailsView', () => {
+  const initMock = jest.fn();
+  const renderMock = jest.fn();
+  const routeDetailsView = () => ( {
+    init: initMock,
+    render: renderMock
+  } );
+  let store;
+  let view;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML;
+    const el = document.querySelector( `.${ reviewDetailsView.CLASSES.CONTAINER }` );
+    store = mockStore();
+    view = reviewDetailsView( el, { store, routeDetailsView } );
+    view.init();
+  } );
+
+  afterEach( () => {
+    store.mockReset();
+    initMock.mockReset();
+    view = null;
+  } );
+
+  it( 'subscribes to the store on init', () => {
+    expect( store.subscribe.mock.calls.length ).toBe( 1 );
+  } );
+
+  it( 'initializes its two routeDetails subviews on init', () => {
+    expect( initMock.mock.calls.length ).toBe( 2 );
+  } );
+
+  describe( 'on state update', () => {
+    const state = {
+      budget: { earned: 1, spent: 1 },
+      routes: {
+        routes: [
+          { transportation: 'Walk', actionPlanItems: [ PLAN_TYPES.MILES ]},
+          { transportation: 'Drive' }
+        ]
+      }
+    };
+    it( 'renders the details views', () => {
+      store.subscriber()( {}, state );
+
+      expect( renderMock.mock.calls.length ).toBe( 2 );
+    } );
+
+    it( 'renders the todo lists', () => {
+      store.subscriber()( {}, state );
+
+      const todoLists = toArray(
+        document.querySelectorAll( `.${ reviewDetailsView.CLASSES.TODO }` )
+      );
+
+      expect( todoLists[0].children.length ).toBe( 1 );
+      expect( todoLists[1].children.length ).toBe( 0 );
+    } );
+
+    it( 'toggles the todo notification el when there are todo list items', () => {
+      const notification = document.querySelector( '.m-notification' );
+
+      expect( notification.classList.contains( 'm-notification__visible' ) ).toBeFalsy();
+
+      store.subscriber()( {}, state );
+
+      expect( notification.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
+    } );
+  } );
+} );


### PR DESCRIPTION
This PR adds a JS view for the details review section  — it displays the same data as the details section (minus the todo list) and shows the todo list in a separate area.

## Additions

- View to manage the above-mentioned sections

## Changes

- Fixes bug in `money` utility where  negative numbers didn't subtract properly

## Testing

1. Unit tests
2. Information entered into the transportation tool should also update the details area of the review section
3. A notification should appear when there are pending todo list items in a route.

## Screenshots
** Details **:
![Screen Shot 2019-09-26 at 2 33 36 PM](https://user-images.githubusercontent.com/1421848/65726759-ade2fc00-e06a-11e9-8e09-c91805f69f49.png)

** Notification when to-do list items **:
![Screen Shot 2019-09-26 at 2 11 11 PM](https://user-images.githubusercontent.com/1421848/65726805-cce18e00-e06a-11e9-8190-37ca0bfc0dff.png)

** Notifications without to-do list items **:
![Screen Shot 2019-09-26 at 2 10 49 PM](https://user-images.githubusercontent.com/1421848/65726780-b9362780-e06a-11e9-90e8-5c9262af152e.png)

## Notes

- Certain elements are not being shown at this point, e.g. the text after `Your first choice is` because that is controlled by user input for which there is not yet javascript code.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
