### PR TITLE
YES too - View and specs for review choice section

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -26,12 +26,7 @@
         <button class="m-yes-route-option">Show me another option</button>
       </div>
       <div class="content_line-bold"></div>
-      {% include "review/review.html" %}
-      <div class="content_line-bold"></div>
-      {% include "review/your-plan.html" %}
-      {% include "review/your-goals.html" %}
-      {% include "review/print.html" %}
-      {% include "review/next-steps.html" %}
+      {% include "review/index.html" %}
     </section>
   </div>
 </main>

--- a/cfgov/jinja2/v1/youth_employment_success/review/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/index.html
@@ -1,0 +1,10 @@
+<div class="js-yes-review-choice">
+  {% include "review/review.html" %}
+  <div class="js-yes-plans-review">
+    <div class="content_line-bold"></div>
+    {% include "review/your-plan.html" %}
+    {% include "review/your-goals.html" %}
+    {% include "review/print.html" %}
+    {% include "review/next-steps.html" %}
+  </div>
+</div>

--- a/cfgov/jinja2/v1/youth_employment_success/review/review.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/review.html
@@ -1,4 +1,4 @@
-{% from 'atoms/radio-button.html' import render as renderRadio with context %}
+{% import 'atoms/radio-button.html' as radio_button with context %}
 
 <div class="block block__sub">
   <h2>Which way of getting to work is your first choice?</h2>
@@ -14,8 +14,8 @@
     <div class="u-w70pct">
       <div class="block block__sub-micro">
         {{
-          renderRadio({
-            'class': 'content-l content-l_col-1-2 m-form-field__lg-target',
+          radio_button.render({
+            'class': 'content-l content-l_col-1-2 m-form-field__lg-target js-yes-route-selection',
             'disabled': true,
             'name':  'yes-route-selection',
             'label': 'Option 1: -',
@@ -23,8 +23,8 @@
           })
         }}
         {{
-          renderRadio({
-            'class': 'content-l content-l_col-1-2 m-form-field__lg-target',
+          radio_button.render({
+            'class': 'content-l content-l_col-1-2 m-form-field__lg-target js-yes-route-selection',
             'disabled': true,
             'name':  'yes-route-selection',
             'label': 'Option 2: -',
@@ -34,8 +34,8 @@
       </div>
       <div class="block block__sub-micro">
         {{
-          renderRadio({
-            'class': 'content-l content-l_col-1-2 m-form-field__lg-target',
+          radio_button.render({
+            'class': 'content-l content-l_col-1-2 m-form-field__lg-target js-yes-route-selection',
             'disabled': true,
             'name':  'yes-route-selection',
             'label': 'I want to complete items in my to-do list before deciding',
@@ -45,5 +45,5 @@
       </div>
     </div>
   </div>
-  <button class="a-btn" disabled>Review your plan</button>
+  <button class="a-btn js-yes-choice-finalize" disabled>Review your plan</button>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -1,6 +1,6 @@
 {% import 'alert.html' as alert with context %}
 
-<div class="block block__sub js-option-review">
+<div class="block block__sub js-yes-plans-review">
   <h2>Your plan to get to work</h2>
   <h3>Your to-do list</h3>
   <ul>

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -14,6 +14,7 @@ import expandableView from './views/expandable';
 import store from './store';
 import transitTimeView from './views/transit-time';
 import reviewDetailsView from './views/review/details';
+import reviewChoiceView from './views/review/choice';
 
 Array.prototype.slice.call(
   document.querySelectorAll( 'input' )
@@ -47,6 +48,11 @@ const reviewDetailsEl = document.querySelector(
 reviewDetailsView( reviewDetailsEl, {
   store, routeDetailsView
 } ).init();
+
+reviewChoiceView(
+  document.querySelector( `.${ reviewChoiceView.CLASSES.CONTAINER }` ),
+  { store }
+).init();
 
 const expandables = Expandable.init();
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/choice-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/choice-reducer.js
@@ -1,0 +1,26 @@
+import { actionCreator } from '../util';
+
+const initialState = '';
+const TYPES = {
+  UPDATE_ROUTE_OPTION_CHOICE: 'UPDATE_ROUTE_OPTION_CHOICE'
+};
+const updateRouteChoiceAction = actionCreator(
+  TYPES.UPDATE_ROUTE_OPTION_CHOICE
+);
+
+function choiceReducer( state = initialState, action ) {
+  switch ( action.type ) {
+    case TYPES.UPDATE_ROUTE_OPTION_CHOICE: {
+      return action.data;
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export {
+  updateRouteChoiceAction
+};
+
+export default choiceReducer;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/store.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/store.js
@@ -3,6 +3,7 @@ import budgetReducer from './reducers/budget-reducer';
 import { combineReducers } from './util';
 import goalReducer from './reducers/goal-reducer';
 import routeOptionReducer from './reducers/route-option-reducer';
+import choiceReducer from './reducers/choice-reducer';
 
 /**
  * Function to create a new store instance
@@ -13,7 +14,8 @@ function configureStore() {
     combineReducers( {
       budget: budgetReducer,
       goals: goalReducer,
-      routes: routeOptionReducer
+      routes: routeOptionReducer,
+      routeChoice: choiceReducer
     } )
   );
 }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/choice.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/choice.js
@@ -1,0 +1,187 @@
+import { checkDom, setInitFlag } from '../../../../../js/modules/util/atomic-helpers';
+import { toArray } from '../../util';
+import { updateRouteChoiceAction } from '../../reducers/choice-reducer';
+import inputView from '../input';
+import transportationMap from '../../data/transportation-map';
+
+const CLASSES = Object.freeze( {
+  CONTAINER: 'js-yes-review-choice',
+  REVIEW_PLAN: 'js-yes-plans-review',
+  BUTTON: 'js-yes-choice-finalize',
+  CHOICE: 'js-yes-route-selection'
+} );
+
+/**
+ * ReviewChoiceView
+ *
+ * @class
+ *
+ * @classdesc View to manage form controls that allow user to select their
+ * preferred route option and review their final plan
+ *
+ * @param {HTMLElement} element The container node for this view
+ * @param {Object} props The additional properties supplied to this view
+ * @param {YesStore} props.store The public API exposed by the Store class
+ * @returns {Object} This view's public API
+ */
+function reviewChoiceView( element, { store } ) {
+  const _dom = checkDom( element, CLASSES.CONTAINER );
+  const _reviewPlanEl = _dom.querySelector( `.${ CLASSES.REVIEW_PLAN }` );
+  const _choiceBtnEls = toArray(
+    _dom.querySelectorAll( `.${ CLASSES.CHOICE }` )
+  );
+  const _choiceInputs = _choiceBtnEls.map( el => el.querySelector( 'input' ) );
+  const _reviewBtnEl = _dom.querySelector( `.${ CLASSES.BUTTON }` );
+
+  /**
+   * Allow user to interact with this view's radio button form elements
+   */
+  function _enableChoices() {
+    _choiceInputs.forEach( el => el.removeAttribute( 'disabled' ) );
+  }
+
+  /**
+   * Disable route option selection radio button
+   */
+  function _disableChoices() {
+    _choiceInputs.forEach( el => el.setAttribute( 'disabled', 'disabled' )
+    );
+  }
+
+  /**
+   * Enables the button that displays the final review plan on click
+   */
+  function _enableReviewButton() {
+    _reviewBtnEl.removeAttribute( 'disabled' );
+  }
+
+  /**
+   * Disabled the button responsible for displaying the final review plan
+   */
+  function _disableReviewButton() {
+    _reviewBtnEl.setAttribute( 'disabled', 'disabled' );
+  }
+
+  /**
+   * Sets the labels of each route selection radio button to the
+   * mode of transportation the user indicated.
+   * @param {Object} routes An array of route option objects
+   */
+  function _populateOptionLabels( routes ) {
+    _choiceBtnEls.forEach( ( el, index ) => {
+      const route = routes[index];
+
+      // Need a check here because the third option isnt tied to a route
+      if ( route ) {
+        const label = el.querySelector( 'label' );
+        const friendlyOption = transportationMap[route.transportation];
+        const nextLabel = label.textContent.replace( '-', friendlyOption );
+        label.textContent = nextLabel;
+      }
+    } );
+  }
+
+  /**
+   * Show the plan review section of the HTML. Remove the event listener since
+   * the user won't need to interact with the button again.
+   */
+  function _showReviewPlan() {
+    _reviewPlanEl.classList.remove( 'u-hidden' );
+    _reviewBtnEl.removeEventListener( 'click', _showReviewPlan );
+  }
+
+  /**
+   * Called on page load to hide the review plan
+   */
+  function _hideReviewPlan() {
+    _reviewPlanEl.classList.add( 'u-hidden' );
+  }
+
+  /**
+   * Update the app's state with the user's first choice of transportation
+   * @param {Object} updateObject Object with event information supplied by the InputView component.
+   * Used to update app state
+   * @param {Object} updateObject.event The DOM event emitted by the input node
+   */
+  function _handlePlanSelection( { event } ) {
+    store.dispatch(
+      updateRouteChoiceAction( event.target.value )
+    );
+  }
+
+  /**
+   * Initialize the form controls this view manages
+   */
+  function _initInputs() {
+    _choiceInputs.forEach( el => {
+      inputView( el, {
+        events: {
+          click: _handlePlanSelection
+        },
+        type: 'radio'
+      } ).init();
+    } );
+
+    _reviewBtnEl.addEventListener( 'click', _showReviewPlan );
+  }
+
+  /**
+   * Determines if a given route has a transportation type indicated
+   * @param {Object} route A route object
+   * @returns {Boolean} If the route has a specified mode of transportation
+   */
+  function _routeHasTransportation( route ) {
+    return route && Boolean( route.transportation );
+  }
+
+  /**
+   * Update HTML this view manages based on the current application state.
+   * @param {Object} _ The previous application state object, unused here
+   * @param {Object} state The current state of the application
+   */
+  function _handleStateUpdate( _, state ) {
+    const routes = state.routes.routes;
+    let transportationSelected = true;
+
+    for ( let i = 0; i < routes.length; i++ ) {
+      const route = routes[i];
+
+      if ( !_routeHasTransportation( route ) ) {
+        transportationSelected = false;
+      }
+    }
+
+    if ( transportationSelected ) {
+      _enableChoices();
+      _populateOptionLabels( routes );
+    }
+
+    if ( state.routeChoice ) {
+      _enableReviewButton();
+    } else {
+      _disableReviewButton();
+    }
+  }
+
+  return {
+    init() {
+      if ( setInitFlag( _dom ) ) {
+        _hideReviewPlan();
+
+        /**
+         * NOTE: Although these are set to disabled in the template, we need to manually disable them again;
+         * all form controls are enabled once JS is detected. These fields are a special
+         * case in that they are the only form controls which are only available once
+         * all other inputs in the tool have received valid data from the user.
+        */
+        _disableChoices();
+        _initInputs();
+        store.subscribe( _handleStateUpdate );
+      }
+    }
+  };
+}
+
+reviewChoiceView.CLASSES = CLASSES;
+
+export default reviewChoiceView;

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/choice-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/choice-reducer-spec.js
@@ -1,0 +1,20 @@
+import choiceReducer, {
+  updateRouteChoiceAction
+} from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/choice-reducer';
+
+let UNDEFINED;
+
+describe( 'choiceReducer', () => {
+  it( 'returns an initial state when it receives an unsupported action type', () => {
+    const state = choiceReducer( UNDEFINED, { type: null } );
+
+    expect( state ).toEqual( '' );
+  } );
+
+  it( 'reduces the .updateRouteChoiceAction', () => {
+    const selectedRouteIndex = '1';
+    const state = choiceReducer( UNDEFINED, updateRouteChoiceAction( selectedRouteIndex ) );
+
+    expect( state ).toBe( selectedRouteIndex );
+  } );
+} );

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/choice-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/choice-spec.js
@@ -1,0 +1,169 @@
+import reviewChoiceView from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/review/choice';
+import mockStore from '../../../../../mocks/store';
+import { simulateEvent } from '../../../../../../util/simulate-event';
+import { toArray } from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
+import {
+  updateRouteChoiceAction
+} from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/choice-reducer';
+import transportationMap from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/data/transportation-map';
+
+const CLASSES = reviewChoiceView.CLASSES;
+
+const HTML = `
+<div class="${ CLASSES.CONTAINER }">
+  <div class="${ CLASSES.CHOICE }">
+    <label>-</label>
+    <input type="radio" name="choice" value="0">
+  </div>
+  <div class="${ CLASSES.CHOICE }">
+    <label>-</label>
+    <input type="radio" name="choice" value="1">
+  </div>
+  <div class="${ CLASSES.CHOICE }">
+    <label>-</label>
+    <input type="radio" name="choice" value="wait">
+  </div>
+  <button class="${ CLASSES.BUTTON }" disabled></button>
+  <div class="${ CLASSES.REVIEW_PLAN }"></div>
+</div>
+`;
+
+describe( 'reviewChoiceGoal', () => {
+  let dom;
+  let choiceInputs;
+  let choiceWrappers;
+  let store;
+  let view;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML;
+    store = mockStore();
+    dom = document.querySelector( `.${ CLASSES.CONTAINER }` );
+    view = reviewChoiceView( dom, { store } );
+    view.init();
+    choiceWrappers = toArray(
+      dom.querySelectorAll( `.${ CLASSES.CHOICE }` )
+    );
+    choiceInputs = choiceWrappers.map( el => el.querySelector( 'input' ) );
+  } );
+
+  afterEach( () => {
+    store.mockReset();
+    view = null;
+    choiceInputs.length = 0;
+  } );
+
+  describe( 'on init', () => {
+    it( 'subscribes to the store', () => {
+      expect( store.subscribe.mock.calls.length ).toBe( 1 );
+    } );
+
+    it( 'hides the final plan review section', () => {
+      expect(
+        dom.querySelector( `.${ CLASSES.REVIEW_PLAN }` ).classList.contains( 'u-hidden' )
+      ).toBeTruthy();
+    } );
+
+    it( 'disables the form controls', () => {
+      const button = dom.querySelector( `.${ CLASSES.BUTTON }` );
+
+      choiceInputs.forEach( input => expect( input.getAttribute( 'disabled' ) ).toBe( 'disabled' )
+      );
+      expect( button.getAttribute( 'disabled' ) ).toBe( '' );
+    } );
+  } );
+
+  it( 'dispatches the .updateRouteChoiceAction on radio input click', () => {
+    const dispatch = store.dispatch.mock;
+    simulateEvent( 'click', choiceInputs[0] );
+
+    expect( dispatch.calls.length ).toBe( 1 );
+    expect( dispatch.calls[0][0] ).toEqual(
+      updateRouteChoiceAction( '0' )
+    );
+  } );
+
+  it( 'enables the radio buttons when tansportation modes are selected', () => {
+    const state = {
+      routes: {
+        routes: [
+          { transportation: 'Walk' }, { transportation: 'Drive' }
+        ]
+      }
+    };
+
+    store.subscriber()( {}, state );
+
+    choiceInputs.forEach( input => {
+      expect( input.getAttribute( 'disabled' ) ).toBeFalsy();
+    } );
+  } );
+
+  it( 'displays the transportation type in the button labels when modes are selected', () => {
+    const state = {
+      routes: {
+        routes: [
+          { transportation: 'Walk' }, { transportation: 'Drive' }
+        ]
+      }
+    };
+
+    store.subscriber()( {}, state );
+
+    choiceWrappers.forEach( ( wrapper, i ) => {
+      const route = state.routes.routes[i];
+
+      if ( route ) {
+        expect(
+          wrapper.querySelector( 'label' ).textContent.indexOf( transportationMap[route.transportation] ) !== -1
+        ).toBeTruthy();
+      }
+    } );
+  } );
+
+  it( 'enables the review choice button once a route choice is made', () => {
+    const state = {
+      routes: {
+        routes: [
+          { transportation: 'Walk' }, { transportation: 'Drive' }
+        ]
+      },
+      routeChoice: '0'
+    };
+
+    store.subscriber()( {}, state );
+
+    expect( dom.querySelector( `.${ CLASSES.BUTTON }` ).getAttribute( 'disabled' ) ).toBeFalsy();
+  } );
+
+  it( 'shows the rest of the review section when the review choice button is clicked', () => {
+    const state = {
+      routes: {
+        routes: [
+          { transportation: 'Walk' }, { transportation: 'Drive' }
+        ]
+      },
+      routeChoice: '0'
+    };
+
+    store.subscriber()( {}, state );
+
+    simulateEvent( 'click', dom.querySelector( `.${ CLASSES.BUTTON }` ) );
+
+    expect( dom.querySelector( `.${ CLASSES.REVIEW_PLAN }` ).classList.contains( 'u-hidden' ) ).toBeFalsy();
+  } );
+
+  it( 'does not enable the radio buttons if no transportation options are specified', () => {
+    const state = {
+      routes: {
+        routes: [
+          { miles: '12' }, { miles: '5' }
+        ]
+      }
+    };
+
+    store.subscriber()( {}, state );
+
+    choiceInputs.forEach( input => expect( input.getAttribute( 'disabled' ) ).toBeTruthy() );
+  } );
+} );


### PR DESCRIPTION
PR adds logic and user input handling around the review choice section detailed in the screenshots section

## Additions

- View to handle user input
- Reducer to supply data to application

## Changes

- The review plan is now hidden by default. It is only shown when the `Review your plan` button is clicked.

## Testing

1. Specs
2. 
* In the transportation tool, select a transportation option for both routes
* Scroll down to the `review your plan` section.
* Select one of the two radio buttons
* Click the `review your plan` button
* The remainder of the plan review section should be visible.

## Screenshots
![Screen Shot 2019-09-27 at 9 16 15 AM](https://user-images.githubusercontent.com/1421848/65790504-a1b37900-e114-11e9-9856-75b87de4c02c.png)




## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
