### PR TITLE
YES Tool - Initial pass at review page print

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -9,43 +9,54 @@
 
 <main class="content content__1-3 yes-transit-tool" role="main">
   <div class="wrapper content_wrapper">
-    <aside class="content_sidebar content__flush-top">
+    <aside class="content_sidebar content__flush-top u-hide-on-review-print">
       sidebar
     </aside>
     <section class="content_main">
-      {% include "goals.html" %}      
-      {% include "budget-form.html" %}
-      <div class="yes-routes">
-        <h2>How do your transportation options fit in your budget, schedule, and lifestyle?</h2>        
-        <p class="u-mb0">
-          There are many ways you could get to work—some options are faster, cheaper, or more convenient. You’ll be able to choose a type of transportation and enter how much it costs. If you’re unsure about any of the specifics, don’t worry — you can select, “I’m not sure,” and the item will be added to your to-do list, which you’ll receive at the end of the tool. Once you finish your first option, you can compare it to other options to help you figure out the best choice for you.
-        </p>
-        <div class="content-l">
-          <div class="u-w75pct">
-            {% for i in range(2) %}
-              {% with id=i+1 %}
-                <div class="content-l_col content-l_col-1">
-                  {% include "route-option.html" %}
-                </div>
-              {% endwith %}
-            {% endfor %}
-          </div>
-        </div>  
-        <div class="content-l m-yes-route-option block u-mt30">
-          <div class="content-l_col content-l_col-1">
-            <h4>Are there other ways you can get to work? Compare different options to help you figure out your first choice and a backup plan.</h4>
-            {% include "plus-icon.html" %}
-            <button class="a-btn a-btn__link m-yes-route-option">Show me another option</button>
+      <div class="u-hide-on-review-print">
+        {% include "goals.html" %}      
+        {% include "budget-form.html" %}
+        <div class="yes-routes">
+          <h2>How do your transportation options fit in your budget, schedule, and lifestyle?</h2>        
+          <p class="u-mb0">
+            There are many ways you could get to work—some options are faster, cheaper, or more convenient. You’ll be able to choose a type of transportation and enter how much it costs. If you’re unsure about any of the specifics, don’t worry — you can select, “I’m not sure,” and the item will be added to your to-do list, which you’ll receive at the end of the tool. Once you finish your first option, you can compare it to other options to help you figure out the best choice for you.
+          </p>
+          <div class="yes-routes block block__sub u-hide-on-review-print">
+            <div class="content-l">
+              <div class="u-w75pct">
+                {% for i in range(2) %}
+                  {% with id=i+1 %}
+                    <div class="content-l_col content-l_col-1">
+                      {% include "route-option.html" %}
+                    </div>
+                  {% endwith %}
+                {% endfor %}
+              </div>
+            </div>  
+            <div class="content-l m-yes-route-option block u-mt30">
+              <div class="content-l_col content-l_col-1">
+                <h4>Are there other ways you can get to work? Compare different options to help you figure out your first choice and a backup plan.</h4>
+                {% include "plus-icon.html" %}
+                <button class="a-btn a-btn__link m-yes-route-option">Show me another option</button>
+              </div>
+            </div>
           </div>
         </div>
+        <div class="content_line-bold"></div>
       </div>
-      <div class="content_line-bold"></div>
       {% include "review/index.html" %}
     </section>
   </div>
 </main>
 
 {% endblock content %}
+
+{% block footer %}
+  <div class="u-hide-on-review-print">
+    {% import 'organisms/footer.html' as o_footer with context %}
+    {{ o_footer.render() }}
+  </div>
+{% endblock footer %}
 
 {% block javascript scoped %}
     {{ super() }}

--- a/cfgov/jinja2/v1/youth_employment_success/line-item.html
+++ b/cfgov/jinja2/v1/youth_employment_success/line-item.html
@@ -6,7 +6,7 @@
   </p>
   <div class="content-l_col content-l_col-1-3 u-align-right line-item line-item__content-r">
     <span>$</span>
-    <span class="{{ values.target }}"></span>
+    <span class="{{ values.target }}">0</span>
   </div>
 </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/youth_employment_success/review/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/index.html
@@ -1,7 +1,7 @@
 <div class="js-yes-review-choice">
   {% include "review/review.html" %}
   <div class="js-yes-plans-review">
-    <div class="content_line-bold"></div>
+    <div class="content_line-bold u-hide-on-review-print"></div>
     {% include "review/your-plan.html" %}
     {% include "review/your-goals.html" %}
     {% include "review/print.html" %}

--- a/cfgov/jinja2/v1/youth_employment_success/review/print.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/print.html
@@ -1,5 +1,5 @@
-<div class="block block__sub">
+<div class="block block__sub u-hide-on-review-print">
   <p class="h3">Print your plan</p>
-  <p>You can print your plan as a PDF to keep track of your options and next steps.</p>
-  <button class="a-btn">Print your plan</button>
+  <p>You can print your plan as a PDF to keep track of your options and next steps</p>
+  <button class="a-btn yes-print-button">Print your plan</button>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/review/review.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/review.html
@@ -1,6 +1,6 @@
 {% import 'atoms/radio-button.html' as radio_button with context %}
 
-<div class="block block__sub">
+<div class="block block__sub u-hide-on-review-print">
   <h2>Which way of getting to work is your first choice?</h2>
   <p>Mya decided to bike to work because it’s affordable and the bikeshare is convenient to her school and job. Frankie decided to take the bus instead of taking a rideshare to work in order to save money to hopefully buy a car in the next year.</p>
 

--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -16,18 +16,17 @@
   </div>
   <div class="block block__sub">
     <p class="h3">Your first choice is <span class="js-transportation-option"></span></p>
-    <div class="content-l content-l_col-2-3 block block__sub u-mt0">
+    <div class="content-l content-l_col-2-3 block block__sub-micro js-route-incomplete u-mt0">
       {{
         alert.render({
           'background': true,
-          'class': 'js-route-incomplete',
           'fill': 'warning',
-          'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you',
+          'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you.',
           'visible': true
         })
       }}
     </div>
-    <div class="block block__sub">
+    <div class="block block__sub-micro">
       {% with show_todos=false %}
         {% include "route-details.html" %}
       {% endwith %}
@@ -39,18 +38,17 @@
     <p class="u-mb0">
       <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
     </p>
-    <div class="content-l content-l_col-2-3">
+    <div class="content-l content-l_col-2-3 js-route-incomplete">
       {{
         alert.render({
           'background': true,
-          'class': 'js-route-incomplete',
           'fill': 'warning',
-          'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you',
+          'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you.',
           'visible': true
         })
       }}
     </div>
-    <div class="block block__sub">
+    <div class="block block__sub-micro">
       {% with show_todos=false %}
         {% include "route-details.html" %}
       {% endwith %}

--- a/cfgov/jinja2/v1/youth_employment_success/route-details.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-details.html
@@ -1,7 +1,7 @@
-{% from 'alert.html' import render as render_alert with context %}
-{% from 'line-item.html' import render as render_line_item with context %}
+{% import 'alert.html' as alert with context %}
+{% import 'line-item.html' as line_item with context %}
 
-<div class="content-l yes-route-details">
+<div class="content-l block block__sub u-mb0 yes-route-details">
   <div class="content-l_col content-l_col-1">
     <p class="h5 u-mt0 u-mb0">
       Totals for <span class="js-transportation-type"></span>
@@ -10,14 +10,14 @@
     <div class="content_line-bold"></div>
     <div class="block block__sub-micro u-mb0">
       {{
-        render_line_item({
+        line_item.render({
           'label': 'Money left in your monthly budget',
           'target': 'js-budget'
         })
       }}
       {{
-        render_line_item({
-          'helperText': '<small  class="a-label a-label_helper">Based on <span class="js-days-per-week"></span> days a week you will make this trip</small>',
+        line_item.render({
+          'helperText': '<br/><small class="a-label a-label_helper">Based on <span class="js-days-per-week"></span> days a week you will make this trip</small>',
           'label': 'Average monthly cost of <span class="js-transportation-type"></span>',
           'target': 'js-total-cost'
         })
@@ -28,7 +28,7 @@
   
     <div class="block block__sub-micro">
       {{
-        render_line_item({
+        line_item.render({
           'label': 'Total left in your budget after <span class="js-transportation-type"></span>',
           'target': 'js-budget-left'
         })
@@ -37,7 +37,7 @@
         <div class="content-l_col content-l_col-1">
           <div class="js-route-complete">
             {{
-              render_alert({
+              alert.render({
                 'fill': 'success',
                 'content': 'Looks good! This option fits your budget.',
               })
@@ -45,7 +45,7 @@
           </div>
           <div class="js-route-incomplete">
               {{
-                render_alert({
+                alert.render({
                   'fill': 'warning',
                   'content': 'To see if this option fits your budget, complete the items in your to-do list and enter the missing amounts above.',
                   'visible': true
@@ -54,7 +54,7 @@
             </div>
             <div class="js-route-oob block block__sub-micro">
               {{
-                render_alert({
+                alert.render({
                   'content': 'This option is out of budget. Talk to your caseworker about ways you might be able to rethink your budget so this can be an option for you.',
                   'fill': 'danger'
                 })
@@ -66,28 +66,30 @@
 
     <div class="block block__sub-micro">
       <div class="content-l">
-        <p class="content-l_col content-l_col-1-2"><b>Total time to get to work</b></p>
-        <p class="content-l_col content-l_col-1-2 u-align-right">
-          <b class="content-l_col-1-2">
+        <p class="content-l_col content-l_col-1-3"><b>Total time to get to work</b></p>
+        <p class="content-l_col content-l_col-2-3 u-align-right">
+          <span class="content-l_col-1-4">
             <span class="js-time-hours"></span> hours
-          </b>
-          <b class="content-l_col-1-2">
+          </span>
+          <span class="content-l_col-2-4">
             <span class="js-time-minutes"></span> minutes
-          </b>
+          </span>
         </p>
       </div>
     </div>
     
+    {% if show_todos %}
     <div class="content-l">
       <div class="content-l_col content-l_col-1">
         <span class="h5">Your to-do list</span>
         <div class="content_line-bold"></div>
         <div class="content-l">
           <div class="content-l_col content-l_col-2-3">
-            <ul class="block block__sub-micro js-todo-items"></ul>
+            <ul class="js-todo-items"></ul>
           </div>
         </div>
       </div>
     </div>
+    {% endif %}
   </div>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
@@ -1,48 +1,50 @@
 {% import 'atoms/checkbox.html' as checkbox with context %}
 {% import 'atoms/radio-button.html' as radio with context %}
 
-<div class="content-l content-l_col-3-4 block__sub-micro m-yes-average-cost">
-  <div class="content-l">
-    <div class="content-l_col content-l_col-1">
-      <label for="yes-average-cost" class="a-label a-label__heading h4">
-        <p class="u-mb0">What's the average cost?</p>
-        <small class="a-label_helper">
-          If it's free, enter 0
-        </small>
-      </label>
+<div class="content-l block__sub-micro m-yes-average-cost">
+  <div class="content-l_col content-l_col-3-4">
+    <div class="content-l">
+      <div class="content-l_col content-l_col-1">
+        <label for="yes-average-cost" class="a-label a-label__heading h4">
+          <p class="u-mb0">What's the average cost?</p>
+          <small class="a-label_helper">
+            If it's free, enter $0
+          </small>
+        </label>
+      </div>
+      <div class="content-l_col content-l_col-1-3 u-mt0">
+        <input type="text" data-js-name="averageCost" disabled class="a-text-input u-w50pct" name="yes-average-cost" id="yes-average-cost">
+      </div>
+      <div class="content-l_col content-l_col-1-3 u-mt5 a-yes-inline-radio">
+        {{
+          radio.render({
+            'class': 'a-yes-average-cost-radio',
+            'name': 'averageCostFrequency',
+            'label': "Per day",
+            'value': 'daily',
+            'disabled': true
+          })
+        }}
+      </div>
+      <div class="content-l_col content-l_col-1-3 u-mt5 a-yes-inline-radio">
+        {{
+          radio.render({
+            'class': 'a-yes-average-cost-radio',
+            'name': 'averageCostFrequency',
+            'label': "Per month",
+            'value': 'monthly',
+            'disabled': true
+          })
+        }}
+      </div>
     </div>
-    <div class="content-l_col content-l_col-1-3 u-mt0">
-      <input type="text" data-js-name="averageCost" disabled class="a-text-input u-w50pct" name="yes-average-cost" id="yes-average-cost">
-    </div>
-    <div class="content-l_col content-l_col-1-3 u-mt5 a-yes-inline-radio">
-      {{
-        radio.render({
-          'class': 'a-yes-average-cost-radio',
-          'name': 'averageCostFrequency',
-          'label': "Per day",
-          'value': 'daily',
-          'disabled': true
-        })
-      }}
-    </div>
-    <div class="content-l_col content-l_col-1-3 u-mt5 a-yes-inline-radio">
-      {{
-        radio.render({
-          'class': 'a-yes-average-cost-radio',
-          'name': 'averageCostFrequency',
-          'label': "Per month",
-          'value': 'monthly',
-          'disabled': true
-        })
-      }}
-    </div>
+    {{ 
+      checkbox.render({
+        'class': 'u-js-only block__sub-micro',
+        'label': "I'm not sure, add this to my to-do list to look up later",
+        'name': 'costToActionPlan',
+        'disabled': true
+      })
+    }}
   </div>
-  {{ 
-    checkbox.render({
-      'class': 'u-js-only block__sub-micro',
-      'label': "I'm not sure, add this to my to-do list to look up later",
-      'name': 'costToActionPlan',
-      'disabled': true
-    })
-  }}
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
@@ -1,23 +1,25 @@
 {% from 'atoms/checkbox.html' import render as render_checkbox with context %}
 {% from 'input.html' import render as render_input with context %}
 
-<div class="content-l content-l_col-2-3 block__sub-micro m-yes-days-per-week">
-  {{
-    render_input({
-      'data_js_name': "daysPerWeek",
-      'label': "How many days per week will you make this trip?",
-      'size': '1-4',
-      'type': 'text',
-      'value': '',
-      'disabled': true
-    })
-  }}
-  {{
-    render_checkbox({
-      'class': 'u-js-only block__sub-micro',
-      'label': "I'm not sure. Look up later",
-      'name': "yes-route-days-unsure",
-      'disabled': true
-    })
-  }}
+<div class="content-l block block__sub-micro m-yes-days-per-week">
+  <div class="content-l_col content-l_col-2-3">
+    {{
+      render_input({
+        'data_js_name': "daysPerWeek",
+        'label': "How many days per week will you make this trip?",
+        'size': '1-4',
+        'type': 'text',
+        'value': '',
+        'disabled': true
+      })
+    }}
+    {{
+      render_checkbox({
+        'class': 'u-js-only block__sub-micro',
+        'label': "I'm not sure. Look up later",
+        'name': "yes-route-days-unsure",
+        'disabled': true
+      })
+    }}
+  </div>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/driving-cost-estimate.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/driving-cost-estimate.html
@@ -1,7 +1,9 @@
-<div class="content-l content-l_col-2-3 block__sub-micro js-driving-estimate">
-  <p class="a-label a-label__heading u-mb0">Average daily cost</p>
-  <small>
-    We’ve calculated this number for you based on data from XXX about average cost per mile, which includes gas, insurance, and maintenance costs.
-  </small>
-  <p><span class="js-cost-per-mile"></span></p>
+<div class="content-l block block__sub-micro js-driving-estimate">
+  <div class="content-l_col content-l_col-1">
+    <p class="a-label a-label__heading u-mb0">Average daily cost</p>
+    <small>
+      We’ve calculated this number for you based on data from XXX about average cost per mile, which includes gas, insurance, and maintenance costs.
+    </small>
+    <p><span class="js-cost-per-mile"></span></p>
+  </div>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
@@ -1,28 +1,26 @@
 {% from 'atoms/checkbox.html' import render as render_checkbox with context %}
 {% from 'input.html' import render as render_input with context %}
 
-<div class="content-l content-l_col content-l_col-2-3 block block__sub-micro m-yes-miles">
-  <div class="content-l">
-    <div class="content-l_col content-l_col-1">
-      {{
-        render_input({
-          'data_js_name': "miles",
-          'helperText': 'This can be a rough estimate — don’t worry if it’s not exact.',
-          'label': 'How many miles do you expect to drive each day?',
-          'size': '1-4',
-          'type': 'text',
-          'value': '',
-          'disabled': true
-        })
-      }}
-    </div>
+<div class="content-l block block__sub-micro m-yes-miles">
+  <div class="content-l_col content-l_col-2-3">    
+    {{
+      render_input({
+        'data_js_name': "miles",
+        'helperText': 'This can be a rough estimate — don’t worry if it’s not exact.',
+        'label': 'How many miles do you expect to drive each day?',
+        'size': '1-4',
+        'type': 'text',
+        'value': '',
+        'disabled': true
+      })
+    }}
+    {{ 
+      render_checkbox({
+        'class': 'u-js-only block block__sub-micro',
+        'label': "I'm not sure, add this to my to-do list to look up later ",
+        'name': "yes-miles-unsure",
+        'disabled': true
+      })
+    }}
   </div>
-  {{ 
-    render_checkbox({
-      'class': 'u-js-only block block__sub-micro',
-      'label': "I'm not sure, add this to my to-do list to look up later ",
-      'name': "yes-miles-unsure",
-      'disabled': true
-     })
-  }}
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
@@ -1,34 +1,36 @@
 {% from 'atoms/checkbox.html' import render as render_checkbox with context %}
 {% from 'input.html' import render as render_input with context %}
 
-<div class="content-l content-l_col-3-4 block block__sub-micro m-yes-transit-time">
-  <p class="a-label__heading">
-    How long does it take to get to your destination?
-  </p>
-  <div class="content-l">
-    <div class="content-l_col content-l_col-1-2">
-      <div class="content-l">
-        <div class="content-l_col content-l_col-1-2 js-transit-hours">
-          <label for="yes-transit-time-hours" class="a-label a-label__heading u-mb0">
-            Hours
-          </label>
-          <input type="text" id="yes-transit-time-hours" name="transitTimeHours" class="a-text-input u-mt0 u-w50pct" disabled>
-        </div>
-        <div class="content-l_col content-l_col-1-2 u-mt0">
-          <label for="yes-transit-time-minutes" class="a-label a-label__heading u-mb0">
-            Minutes
-          </label>
-          <input type="text" id="yes-transit-time-minutes" name="transitTimeMinutes" class="a-text-input u-mt0 u-w50pct" disabled>
+<div class="content-l block block__sub-micro m-yes-transit-time">
+  <div class="content-l_col content-l_col-3-4">
+    <p class="a-label__heading">
+      How long does it take to get to your destination?
+    </p>
+    <div class="content-l">
+      <div class="content-l_col content-l_col-1-2">
+        <div class="content-l">
+          <div class="content-l_col content-l_col-1-2 js-transit-hours">
+            <label for="yes-transit-time-hours" class="a-label a-label__heading u-mb0">
+              Hours
+            </label>
+            <input type="text" id="yes-transit-time-hours" name="transitTimeHours" class="a-text-input u-mt0 u-w50pct" disabled>
+          </div>
+          <div class="content-l_col content-l_col-1-2 u-mt0">
+            <label for="yes-transit-time-minutes" class="a-label a-label__heading u-mb0">
+              Minutes
+            </label>
+            <input type="text" id="yes-transit-time-minutes" name="transitTimeMinutes" class="a-text-input u-mt0 u-w50pct" disabled>
+          </div>
         </div>
       </div>
     </div>
+    {{ 
+      render_checkbox({
+        'class': 'u-js-only block block__sub-micro',
+        'label': "I'm not sure, add this to my to-do list to look up later ",
+        'disabled': true,
+        'name': "timeToActionPlan"
+      })
+    }}
   </div>
-  {{ 
-    render_checkbox({
-      'class': 'u-js-only block block__sub-micro',
-      'label': "I'm not sure, add this to my to-do list to look up later ",
-      'disabled': true,
-      'name': "timeToActionPlan"
-     })
-  }}
 </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -1,5 +1,11 @@
 @import (reference) '../../../css/main.less';
 
+.u-hide-on-review-print {
+  .respond-to-print({
+    display: none !important;
+  });
+}
+
 /** 
 * This gets overwritten by media queries, so we need to make it important.
 */

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -1,21 +1,22 @@
 import Expandable from 'cf-expandables/src/Expandable';
 import { addRouteOptionAction } from './reducers/route-option-reducer';
+import averageCostView from './views/average-cost';
 import budgetFormView from './budget-form-view';
 import createRoute from './route.js';
-import averageCostView from './views/average-cost';
 import daysPerWeekView from './views/days-per-week';
-import milesView from './views/miles';
+import drivingCostEstimateView from './views/driving-cost-estimate';
+import expandableView from './views/expandable';
 import goalsView from './views/goals';
+import milesView from './views/miles';
+import printButton from './views/print-button';
+import reviewChoiceView from './views/review/choice';
+import reviewDetailsView from './views/review/details';
 import reviewGoalsView from './views/review/goals';
+import routeDetailsView from './views/route-details';
 import routeOptionFormView from './route-option-view';
 import routeOptionToggleView from './route-option-toggle-view';
-import routeDetailsView from './views/route-details';
-import expandableView from './views/expandable';
 import store from './store';
 import transitTimeView from './views/transit-time';
-import reviewDetailsView from './views/review/details';
-import reviewChoiceView from './views/review/choice';
-import drivingCostEstimateView from './views/driving-cost-estimate';
 
 Array.prototype.slice.call(
   document.querySelectorAll( 'input' )
@@ -92,3 +93,7 @@ routeOptionToggleView(
 
 expandables[0].element.querySelector( '.o-expandable_target' ).click();
 expandables[1].element.classList.add( 'u-hidden' );
+
+printButton(
+  document.querySelector( `.${ printButton.CLASSES.BUTTON }` )
+).init();

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/print-button.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/print-button.js
@@ -1,0 +1,37 @@
+import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
+
+const CLASSES = {
+  BUTTON: 'yes-print-button'
+};
+
+/**
+ * PrintButton
+ * @class
+ *
+ * @classdesc Simple view for calling the system print dialog
+ *
+ * @param {HTMLNode} element The root DOM element for this view
+ * @returns {Object} The view's public methods
+ */
+function printButton( element ) {
+  const _dom = checkDom( element, CLASSES.BUTTON );
+
+  /**
+   * Calls the system print dialog
+   */
+  function _print() {
+    window.print();
+  }
+
+  return {
+    init() {
+      if ( setInitFlag( _dom ) ) {
+        _dom.addEventListener( 'click', _print );
+      }
+    }
+  };
+}
+
+printButton.CLASSES = CLASSES;
+
+export default printButton;

--- a/test/unit_tests/apps/youth-employment-success/js/views/print-button-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/print-button-spec.js
@@ -1,0 +1,23 @@
+import { simulateEvent } from '../../../../../util/simulate-event';
+import printButton from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/print-button';
+
+const CLASSES = printButton.CLASSES;
+const HTML = `<button class="${ CLASSES.BUTTON }"></button>`;
+
+describe( 'printButtonView', () => {
+  const printMock = jest.fn();
+  let dom;
+
+  beforeEach( () => {
+    window.print = printMock;
+    document.body.innerHTML = HTML;
+    dom = document.querySelector( `.${ CLASSES.BUTTON }` );
+    printButton( dom ).init();
+  } );
+
+  it( 'calls the system print dialog when clicked', () => {
+    simulateEvent( 'click', dom );
+
+    expect( printMock.mock.calls.length ).toBe( 1 );
+  } );
+} );


### PR DESCRIPTION
Hides non-critical elements when user prints their review plan.

## Additions

- Class to control hiding elements irrelevant to the user's review plan

## Testing

1. Clicking the `Print your plan` button brings up the system print dialog; the user should only see the `your plan` review section.
 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
