### PR TITLE
Prevent error on export of blank Ask CFPB pages

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -74,7 +74,8 @@ def assemble_output():
             answer_schema = filter(
                 lambda item: item['type'] == 'how_to_schema' or
                 item['type'] == 'faq_schema', answer_streamfield)
-            answer = answer_schema[0].get('value').get('description')
+            if answer_schema:
+                answer = answer_schema[0].get('value').get('description')
         output['Answer'] = clean_and_strip(answer).replace('\x81', '')
         output['ShortAnswer'] = clean_and_strip(page['short_answer'])
         output['URL'] = page['url_path'].replace('/cfgov', '')


### PR DESCRIPTION
Previously, if any of the Ask CFPB answer pages was blank in the 'text', 'how_to_schema', and 'faq_schema' fields (e.g. a blank draft page), the export_ask_data command would result in a 500 error.

Allow these blank drafts to be exported along with the rest of the
pages.

## Changes

- Prevent a ` IndexError: list index out of range` when exporting a blank page by catching cases where `answer_schema` has no contents.

## Testing

1. Run this branch
2. Log in to the Wagtail admin using `admin`/`admin`
3. On the left-hand sidebar, scroll down to select the second-to-last option, "Export Ask data"
4. Press the "Download CSV" button
5. The action should complete without any python errors, and you should get a CSV file of all Ask answer pages.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: