### PR TITLE
YES tool — Map primary route choice to plan review

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -15,7 +15,7 @@
     <ul class="js-review-todo"></ul>
   </div>
   <div class="block block__sub">
-    <p class="h3">Your first choice is <span class="js-transportation-type"></span></p>
+    <p class="h3">Your first choice is <span class="js-transportation-option"></span></p>
     <div class="content-l content-l_col-2-3 block block__sub u-mt0">
       {{
         alert.render({
@@ -35,7 +35,7 @@
     <div class="content_line"></div>
   </div>
   <div class="js-option-2 block block__sub">
-    <p class="h3">Another possible option: <span class="js-transportation-type"></span></p>
+    <p class="h3">Another possible option: <span class="js-transportation-option"></span></p>
     <p class="u-mb0">
       <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
     </p>

--- a/cfgov/unprocessed/apps/youth-employment-success/js/data/transportation-map.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/data/transportation-map.js
@@ -11,7 +11,7 @@ const transportationMap = Object.freeze( {
   'Drive': 'driving',
   'Bike': 'biking',
   'Public transit': 'public transit',
-  'Get droppped off': 'getting dropped off'
+  'Get dropped off': 'getting dropped off'
 } );
 
 export { transportation };

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/choice.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/choice.js
@@ -75,7 +75,7 @@ function reviewChoiceView( element, { store } ) {
       if ( route ) {
         const label = el.querySelector( 'label' );
         const friendlyOption = transportationMap[route.transportation];
-        const nextLabel = `Option ${index + 1}: ${friendlyOption}`;
+        const nextLabel = `Option ${ index + 1 }: ${ friendlyOption }`;
         label.textContent = nextLabel;
       }
     } );
@@ -171,8 +171,8 @@ function reviewChoiceView( element, { store } ) {
         /**
          * NOTE: Although these are set to disabled in the template, we need to manually disable them again;
          * all form controls are enabled once JS is detected. These fields are a special
-         * case in that they are the only form controls which are only available once
-         * all other inputs in the tool have received valid data from the user.
+         * case in that they are the only form controls which are conditionally available,
+         * based on valid data being input by the user.
         */
         _disableChoices();
         _initInputs();

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
@@ -1,10 +1,12 @@
 import { checkDom, setInitFlag } from '../../../../../js/modules/util/atomic-helpers';
-import { routeSelector, todoListSelector } from '../../reducers/route-option-reducer';
 import { toArray, toggleCFNotification } from '../../util';
 import { getPlanItem } from '../../data/todo-items';
+import { todoListSelector } from '../../reducers/route-option-reducer';
+import transportationMap from '../../data/transportation-map';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'js-yes-plans-review',
+  TRANSPORTATION_TYPE: 'js-transportation-option',
   DETAILS: 'yes-route-details',
   TODO: 'js-review-todo',
   ALERT: 'js-route-incomplete'
@@ -37,6 +39,9 @@ function reviewDetailsView( element, { store, routeDetailsView } ) {
   const _notificationEls = toArray(
     _dom.querySelectorAll( `.${ CLASSES.ALERT }` )
   );
+  const _transportationTypeEls = toArray(
+    _dom.querySelectorAll( `.${ CLASSES.TRANSPORTATION_TYPE }` )
+  );
   const _detailsViews = [];
 
   /**
@@ -45,23 +50,35 @@ function reviewDetailsView( element, { store, routeDetailsView } ) {
    * @param {Object} state The current application state
    */
   function _handleStateUpdate( _, state ) {
-    _detailsViews.forEach( ( view, index ) => {
-      const currentRoute = routeSelector(
-        state.routes,
-        index
-      );
+    const otherRoutes = state.routes.routes.slice();
+    const preferredRoute = otherRoutes.splice( state.routeChoice );
+    const routes = preferredRoute.concat( otherRoutes );
 
-      if ( Object.keys( currentRoute ).length ) {
+    _detailsViews.forEach( ( view, index ) => {
+      const route = routes[index] || {};
+
+      if ( Object.keys( route ).length ) {
+        const transporationDesc = transportationMap[route.transportation];
+        _transportationTypeEls[index].textContent = transporationDesc;
+
         view.render( {
           budget: state.budget,
-          route: currentRoute
+          route
         } );
       }
     } );
 
     _todoEls.forEach( ( el, index ) => {
       const fragment = document.createDocumentFragment();
-      todoListSelector( state.routes, index ).forEach( todo => {
+      const todos = todoListSelector( state.routes, index );
+
+      if ( todos.length ) {
+        el.parentNode.classList.remove( 'u-hidden' );
+      } else {
+        el.parentNode.classList.add( 'u-hidden' );
+      }
+
+      todos.forEach( todo => {
         const item = document.createElement( 'li' );
         item.textContent = getPlanItem( todo );
         fragment.appendChild( item );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -16,7 +16,8 @@ const CLASSES = {
   TIME_MINUTES: 'js-time-minutes',
   TODO_ITEMS: 'js-todo-items',
   INCOMPLETE_ALERT: 'js-route-incomplete',
-  OOB_ALERT: 'js-route-oob'
+  OOB_ALERT: 'js-route-oob',
+  COMPLETE_ALERT: 'js-route-complete'
 };
 
 /**
@@ -201,6 +202,7 @@ function routeDetailsView( element ) {
   const _todoEl = _dom.querySelector( `.${ CLASSES.TODO_ITEMS }` );
   const _incAlertEl = _dom.querySelector( `.${ CLASSES.INCOMPLETE_ALERT }` );
   const _oobAlertEl = _dom.querySelector( `.${ CLASSES.OOB_ALERT }` );
+  const _completeAlertEl = _dom.querySelector( `.${ CLASSES.COMPLETE_ALERT }` );
 
   return {
     init() {
@@ -226,6 +228,10 @@ function routeDetailsView( element ) {
       updateDom( _todoEl, updateTodoList( route.actionPlanItems ) );
       toggleCFNotification( _oobAlertEl, nextRemainingBudget < 0 );
       toggleCFNotification( _incAlertEl, !validate( dataToValidate ) );
+      toggleCFNotification(
+        _completeAlertEl,
+        validate( dataToValidate ) && nextRemainingBudget >= 0
+      );
     }
   };
 }

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
@@ -40,10 +40,10 @@ describe( 'routeOptionFormView', () => {
   const daysViewInit = jest.fn();
   const milesViewInit = jest.fn();
   const transitViewInit = jest.fn();
-  const detailsView = () => ({
+  const detailsView = () => ( {
     init: detailsInit,
     render: detailsRender
-  });
+  } );
   detailsView.CLASSES = routeDetailsView.CLASSES;
   const costEstimateView = () => ( {
     init: costEstimateInit,

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
@@ -19,7 +19,7 @@ const HTML = `
     <ul class="js-review-todo"></ul>
   </div>
   <div class="block block__sub">
-    <p class="h3">Your first choice is <span class="js-transportation-type"></span></p>
+    <p class="h3">Your first choice is <span class="js-transportation-option"></span></p>
     <div class="js-route-incomplete">
       <div class="m-notification"></div>
     </div>
@@ -27,7 +27,7 @@ const HTML = `
     <div class="content_line"></div>
   </div>
   <div class="block block__sub">
-    <p class="h3">Another option you compared: <span class="js-transportation-type"></span></p>
+    <p class="h3">Another option you compared: <span class="js-transportation-option"></span></p>
     <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
     <div class="yes-route-details"></div>
     <div class="content_line"></div>
@@ -42,12 +42,13 @@ describe( 'reviewDetailsView', () => {
     init: initMock,
     render: renderMock
   } );
+  let el;
   let store;
   let view;
 
   beforeEach( () => {
     document.body.innerHTML = HTML;
-    const el = document.querySelector( `.${ reviewDetailsView.CLASSES.CONTAINER }` );
+    el = document.querySelector( `.${ reviewDetailsView.CLASSES.CONTAINER }` );
     store = mockStore();
     view = reviewDetailsView( el, { store, routeDetailsView } );
     view.init();
@@ -68,15 +69,19 @@ describe( 'reviewDetailsView', () => {
   } );
 
   describe( 'on state update', () => {
+    const budget = { earned: 1, spent: 1 };
+    const actionPlanRoute = { transportation: 'Walk', actionPlanItems: [ PLAN_TYPES.MILES ]};
+
     const state = {
-      budget: { earned: 1, spent: 1 },
+      budget,
       routes: {
         routes: [
-          { transportation: 'Walk', actionPlanItems: [ PLAN_TYPES.MILES ]},
+          actionPlanRoute,
           { transportation: 'Drive' }
         ]
       }
     };
+
     it( 'renders the details views', () => {
       store.subscriber()( {}, state );
 
@@ -93,6 +98,25 @@ describe( 'reviewDetailsView', () => {
       expect( todoLists[0].children.length ).toBe( 1 );
       expect( todoLists[1].children.length ).toBe( 0 );
     } );
+
+    it('hides the todo lists when there are no todos', () => {
+      const noTodoState = {
+        budget,
+        routes: {
+          routes: [{
+            transportation: 'Drive'
+          }]
+        }
+      };
+
+      store.subscriber()({}, noTodoState);
+
+      const todoEls = toArray(
+        el.querySelectorAll(`.${reviewDetailsView.CLASSES.TODO}`)
+      );
+
+      todoEls.forEach(node => expect(node.parentNode.classList.contains('u-hidden') ).toBeTruthy());
+    });
 
     it( 'toggles the todo notification el when there are todo list items', () => {
       const notification = document.querySelector( '.m-notification' );

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -4,57 +4,33 @@ import { PLAN_TYPES } from '../../../../../../cfgov/unprocessed/apps/youth-emplo
 import transportationMap from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/data/transportation-map';
 
 const HTML = `
-  <div class="content-l content-l_col-2-3 yes-route-details">
-    <p class="h4 u-mt0">
+  <div class="yes-route-details">
+    <p>
       Totals for <span class="js-transportation-type"></span>
-    </p>
-
-    <div class="content_line-bold"></div>
-  
-    <div class="block__sub-micro">
+    </p>  
+    <div>
       <p class="content-l content-l_col-3-4">
         <b>Money left in your monthly budget</b>
       </p>
-      <p class="content-l content-l_col-1-4" style="text-align: right;">
-        <b class="content-l_col">$</b>
-        <b class="content-l_col-2-3 js-budget"></b>
+      <p class="content-l content-l_col-1-4">
+        $<b class="content-l_col-2-3 js-budget"></b>
       </p>
-      <div class="content-l content-l_col-3-4">
-        <p class="u-mb0">
-          <b>
-            Average monthly cost of <span class="js-transportation-type"></span>
-          </b>
-        </p>
-        <span class="a-label_helper">
-          <small>
-            Based on <span class="js-days-per-week"></span> days a week you will make this trip
-          </small>
+      <div>
+        Average monthly cost of <span class="js-transportation-type"></span>
+        <span>
+          Based on <span class="js-days-per-week"></span> days a week you will make this trip
         </span>
       </div>
-      <p class="content-l content-l_col-1-4" style="text-align: right;">
-        <b class="content-l_col">$</b>
-        <b class="content-l_col-2-3 js-total-cost"></b>
-      </p>
+      $<b class="content-l_col-2-3 js-total-cost"></b>
     </div>
-  
-    <div class="content_line-bold"></div>
-  
-    <div class="block__sub-micro">
-      <div class="content-l content-l_col-3-4">
-        <p class="u-mb0">
-          <b>
-            Total left in your budget after <span class="js-transportation-type"></span>
-          </b>
-        </p>
-      </div>
-      <p class="content-l content-l_col-1-4" style="text-align: right;">
-        <b class="content-l_col">$</b>
-        <b class="content-l_col-2-3 js-budget-left"></b>
-      </p>
+    <div>   
+      <b>Total left in your budget after <span class="js-transportation-type"></span></b>
+      $<b class="content-l_col-2-3 js-budget-left"></b>
       <div class="js-route-incomplete"><p class="m-notification"></p></div>
       <div class="js-route-oob"><p class="m-notification"></p></div>
+      <div class="js-route-complete"><p class="m-notification"></p></div>
     </div>
-    <div class="block__sub-micro">
+    <div>
       <p class="content-l content-l_col-1-3"><b>Total time to get to work</b></p>
       <p class="content-l content-l_col-2-3" style="text-align: right;">
         <b class="content-l_col-1-2">
@@ -65,12 +41,8 @@ const HTML = `
         </b>
       </p>
     </div>
-  
-    <div class="content-l content-l_col-2-3">
-      <span class="h4">MY TO-DO LIST</span>
-      <div class="content_line-bold"></div>
-      <ul class="block__sub-micro js-todo-items"></ul>
-    </div>
+    <span class="h4">MY TO-DO LIST</span> 
+    <ul class="block__sub-micro js-todo-items"></ul>
   </div>
 `;
 
@@ -123,8 +95,9 @@ describe( 'routeDetailsView', () => {
       view.render( nextState );
 
       const budgetEl = document.querySelector( `.${ CLASSES.BUDGET }` );
+      const expectedBudget = String(nextState.budget.earned - nextState.budget.spent);
 
-      expect( budgetEl.textContent ).toBe( nextState.budget.earned );
+      expect( budgetEl.textContent ).toBe( expectedBudget );
     } );
 
     it( 'updates its days per week value', () => {
@@ -141,7 +114,7 @@ describe( 'routeDetailsView', () => {
 
         const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
 
-        expect( totalCostEl.textContent ).toBe( '453.6' );
+        expect( totalCostEl.textContent ).toBe( '454' );
       } );
 
       it( 'correctly calculates monthly cost', () => {
@@ -176,10 +149,10 @@ describe( 'routeDetailsView', () => {
 
         const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
 
-        expect( totalCostEl.textContent ).toBe( '126' );
+        expect( totalCostEl.textContent ).toBe( '210' );
       } );
 
-      it( 'updates its total cost value to `-` if daysPerWeek are not supplied', () => {
+      it( 'updates its total cost value using a presumed 5 days per week if daysPerWeek are not supplied', () => {
         const state = {
           budget: { ...nextState.budget },
           route: {
@@ -194,7 +167,7 @@ describe( 'routeDetailsView', () => {
 
         const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
 
-        expect( totalCostEl.textContent ).toBe( '-' );
+        expect( totalCostEl.textContent ).toBe( '210' );
       } );
     } );
 
@@ -203,7 +176,7 @@ describe( 'routeDetailsView', () => {
 
       const budgetLeftEl = document.querySelector( `.${ CLASSES.BUDGET_REMAINING }` );
 
-      expect( budgetLeftEl.textContent ).toBe( '-378.60' );
+      expect( budgetLeftEl.textContent ).toBe( '-379' );
     } );
 
     it( 'updates the time in hours', () => {
@@ -256,7 +229,7 @@ describe( 'routeDetailsView', () => {
       expect( notification.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
     } );
 
-    it.only( 'displays incomplete alert message until all required fields are filled in', () => {
+    it( 'displays incomplete alert message until all required fields are filled in', () => {
       view.render( nextState );
 
       let incAlertEl = document.querySelector( `.${ CLASSES.INCOMPLETE_ALERT }` );
@@ -275,5 +248,29 @@ describe( 'routeDetailsView', () => {
       notification = incAlertEl.querySelector( '.m-notification' );
       expect( notification.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
     } );
+
+    it('displays a complete alert message when the data is valid and the option is in budget', () => {
+      view.render(nextState);
+
+      let completeAlert = document.querySelector( `.${ CLASSES.COMPLETE_ALERT }` );
+      let notification = completeAlert.querySelector('.m-notification');
+
+      expect(notification.classList.contains('m-notification__visible')).toBeFalsy();
+
+      const state = {
+        budget: { earned: '10000', spent: '10' },
+        route: {
+          ...nextState.route,
+          transportation: 'Drive'
+        }
+      };
+
+      view.render(state);
+
+      completeAlert = document.querySelector( `.${ CLASSES.COMPLETE_ALERT }` );
+      notification = completeAlert.querySelector('.m-notification');
+
+      expect(notification.classList.contains('m-notification__visible')).toBeTruthy();
+    });
   } );
 } );


### PR DESCRIPTION
Previously, the review section displayed the route details information in the order in which those routes were entered by the user, ignoring the user's choice of which route they preferred to use to get to work. Now, this choice is properly reflected in the review section.

## Additions

- Display route details in review section in user-indicated order of preference
- Display transportation type in `h3` `p` tags in review section
- Display success alert in `route-option` form when route information is complete and
option is in-budget
- Hides todo lists in review section when there are no todos.

## Testing

1. Specs pass
2. Fill in both route options
* Select a primary route
* Click `review your plan`
* Your selected plan should be the first one shown in the review section
* Choose a the second plan, the former step should hold true.

## Screenshots
![Screen Shot 2019-10-02 at 3 22 11 PM](https://user-images.githubusercontent.com/1421848/66086271-63f58c80-e528-11e9-9607-43f1d148caa4.png)

![Screen Shot 2019-10-02 at 3 22 57 PM](https://user-images.githubusercontent.com/1421848/66086309-825b8800-e528-11e9-9d72-0fd8829f3196.png)


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
