### PR TITLE
YES tool — Hides review plan choice headings on wait option

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -1,6 +1,6 @@
 {% import 'alert.html' as alert with context %}
 
-<div class="block block__sub js-yes-plans-review">
+<div class="block block__sub">
   <h2>Your plan to get to work</h2>
   <h3>Your to-do list</h3>
   <ul>
@@ -15,40 +15,46 @@
     <ul class="js-review-todo"></ul>
   </div>
   <div class="block block__sub">
-    <p class="h3">Your first choice is <span class="js-transportation-option"></span></p>
-    <div class="content-l content-l_col-2-3 block block__sub-micro js-route-incomplete u-mt0">
+    <div class="js-review-choice-heading">
+      <p class="h3">Your first choice is <span class="js-transportation-option"></span></p>
+    </div>
+    <div class="content-l content-l_col-2-3 js-route-incomplete u-mt0">
       {{
         alert.render({
           'background': true,
+          'class': 'block block__sub-micro',
           'fill': 'warning',
           'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you.',
           'visible': true
         })
       }}
     </div>
-    <div class="block block__sub-micro">
+    <div class="block block__sub-micro block__flush-bottom">
       {% with show_todos=false %}
         {% include "route-details.html" %}
       {% endwith %}
     </div>
     <div class="content_line"></div>
   </div>
-  <div class="js-option-2 block block__sub">
-    <p class="h3">Another possible option: <span class="js-transportation-option"></span></p>
-    <p class="u-mb0">
-      <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
-    </p>
+  <div class="js-option-2 block">
+    <div class="js-review-choice-heading">
+      <p class="h3">Another possible option: <span class="js-transportation-option"></span></p>
+      <p class="u-mb0">
+        <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
+      </p>
+    </div>
     <div class="content-l content-l_col-2-3 js-route-incomplete">
       {{
         alert.render({
           'background': true,
+          'class': 'block block__sub-micro',
           'fill': 'warning',
           'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you.',
           'visible': true
         })
       }}
     </div>
-    <div class="block block__sub-micro">
+    <div class="block block__sub-micro block__flush-bottom">
       {% with show_todos=false %}
         {% include "route-details.html" %}
       {% endwith %}

--- a/cfgov/jinja2/v1/youth_employment_success/route-details.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-details.html
@@ -1,7 +1,7 @@
 {% import 'alert.html' as alert with context %}
 {% import 'line-item.html' as line_item with context %}
 
-<div class="content-l block block__sub u-mb0 yes-route-details">
+<div class="content-l u-mb0 yes-route-details">
   <div class="content-l_col content-l_col-1">
     <p class="h5 u-mt0 u-mb0">
       Totals for <span class="js-transportation-type"></span>
@@ -26,14 +26,14 @@
   
     <div class="content_line-bold"></div>
   
-    <div class="block block__sub-micro">
+    <div class="block block__sub-micro block__flush-bottom">
       {{
         line_item.render({
           'label': 'Total left in your budget after <span class="js-transportation-type"></span>',
           'target': 'js-budget-left'
         })
       }}
-      <div class="content-l">
+      <div class="content-l block block__sub-micro block__flush-top">
         <div class="content-l_col content-l_col-1">
           <div class="js-route-complete">
             {{
@@ -44,23 +44,23 @@
             }}
           </div>
           <div class="js-route-incomplete">
-              {{
-                alert.render({
-                  'fill': 'warning',
-                  'content': 'To see if this option fits your budget, complete the items in your to-do list and enter the missing amounts above.',
-                  'visible': true
-                })
-              }}
-            </div>
-            <div class="js-route-oob block block__sub-micro">
-              {{
-                alert.render({
-                  'content': 'This option is out of budget. Talk to your caseworker about ways you might be able to rethink your budget so this can be an option for you.',
-                  'fill': 'danger'
-                })
-              }}
-            </div>
+            {{
+              alert.render({
+                'fill': 'warning',
+                'content': 'To see if this option fits your budget, complete the items in your to-do list and enter the missing amounts above.',
+                'visible': true
+              })
+            }}
           </div>
+          <div class="js-route-oob">
+            {{
+              alert.render({
+                'content': 'This option is out of budget. Talk to your caseworker about ways you might be able to rethink your budget so this can be an option for you.',
+                'fill': 'danger'
+              })
+            }}
+          </div>
+        </div>
       </div>
     </div>
 
@@ -79,7 +79,7 @@
     </div>
     
     {% if show_todos %}
-    <div class="content-l">
+    <div class="content-l block block__sub-micro">
       <div class="content-l_col content-l_col-1">
         <span class="h5">Your to-do list</span>
         <div class="content_line-bold"></div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-option.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-option.html
@@ -8,7 +8,7 @@
   'hide_cue_label': false,
   'is_bordered': false
 } %}
-<div class="block block__sub-micro">
+<div class="block block__sub-micro block__flush-bottom">
   {% call() expandable(expandable_settings) %}
     {% with id=id %}
       {% include "route-option-form.html" %}

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/choice-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/choice-reducer.js
@@ -8,6 +8,8 @@ const updateRouteChoiceAction = actionCreator(
   TYPES.UPDATE_ROUTE_OPTION_CHOICE
 );
 
+const isWaiting = state => state.routeChoice === 'wait';
+
 function choiceReducer( state = initialState, action ) {
   switch ( action.type ) {
     case TYPES.UPDATE_ROUTE_OPTION_CHOICE: {
@@ -20,6 +22,7 @@ function choiceReducer( state = initialState, action ) {
 }
 
 export {
+  isWaiting,
   updateRouteChoiceAction
 };
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
@@ -1,11 +1,13 @@
 import { checkDom, setInitFlag } from '../../../../../js/modules/util/atomic-helpers';
 import { toArray, toggleCFNotification } from '../../util';
 import { getPlanItem } from '../../data/todo-items';
+import { isWaiting } from '../../reducers/choice-reducer';
 import { todoListSelector } from '../../reducers/route-option-reducer';
 import transportationMap from '../../data/transportation-map';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'js-yes-plans-review',
+  CHOICE_HEADING: 'js-review-choice-heading',
   TRANSPORTATION_TYPE: 'js-transportation-option',
   DETAILS: 'yes-route-details',
   TODO: 'js-review-todo',
@@ -42,6 +44,10 @@ function reviewDetailsView( element, { store, routeDetailsView } ) {
   const _transportationTypeEls = toArray(
     _dom.querySelectorAll( `.${ CLASSES.TRANSPORTATION_TYPE }` )
   );
+  const _reviewChoiceHeadingEls = toArray(
+    _dom.querySelectorAll( `.${ CLASSES.CHOICE_HEADING }` )
+  );
+
   const _detailsViews = [];
 
   /**
@@ -92,6 +98,12 @@ function reviewDetailsView( element, { store, routeDetailsView } ) {
       const todos = todoListSelector( state.routes, index );
       toggleCFNotification( el, todos.length );
     } );
+
+    if ( isWaiting( state ) ) {
+      _reviewChoiceHeadingEls.forEach( el => el.classList.add( 'u-hidden' ) );
+    } else {
+      _reviewChoiceHeadingEls.forEach( el => el.classList.remove( 'u-hidden' ) );
+    }
   }
 
   /**

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
@@ -3,8 +3,10 @@ import mockStore from '../../../../../mocks/store';
 import { toArray } from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
 import { PLAN_TYPES } from '../../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items';
 
+const CLASSES = reviewDetailsView.CLASSES;
+
 const HTML = `
-<div class="js-yes-plans-review">
+<div class="${CLASSES.CONTAINER}">
   <h2>Your plan to get to work</h2>
   <h3>Your to-do list</h3>
   <ul>
@@ -19,7 +21,7 @@ const HTML = `
     <ul class="js-review-todo"></ul>
   </div>
   <div class="block block__sub">
-    <p class="h3">Your first choice is <span class="js-transportation-option"></span></p>
+    <p class="h3 ${ CLASSES.CHOICE_HEADING }">Your first choice is <span class="js-transportation-option"></span></p>
     <div class="js-route-incomplete">
       <div class="m-notification"></div>
     </div>
@@ -27,8 +29,10 @@ const HTML = `
     <div class="content_line"></div>
   </div>
   <div class="block block__sub">
-    <p class="h3">Another option you compared: <span class="js-transportation-option"></span></p>
-    <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
+    <div class="${ CLASSES.CHOICE_HEADING }">
+      <p class="h3">Another option you compared: <span class="js-transportation-option"></span></p>
+      <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
+    </div>
     <div class="yes-route-details"></div>
     <div class="content_line"></div>
   </div>
@@ -99,24 +103,24 @@ describe( 'reviewDetailsView', () => {
       expect( todoLists[1].children.length ).toBe( 0 );
     } );
 
-    it('hides the todo lists when there are no todos', () => {
+    it( 'hides the todo lists when there are no todos', () => {
       const noTodoState = {
         budget,
         routes: {
-          routes: [{
+          routes: [ {
             transportation: 'Drive'
-          }]
+          } ]
         }
       };
 
-      store.subscriber()({}, noTodoState);
+      store.subscriber()( {}, noTodoState );
 
       const todoEls = toArray(
-        el.querySelectorAll(`.${reviewDetailsView.CLASSES.TODO}`)
+        el.querySelectorAll( `.${ reviewDetailsView.CLASSES.TODO }` )
       );
 
-      todoEls.forEach(node => expect(node.parentNode.classList.contains('u-hidden') ).toBeTruthy());
-    });
+      todoEls.forEach( node => expect( node.parentNode.classList.contains( 'u-hidden' ) ).toBeTruthy() );
+    } );
 
     it( 'toggles the todo notification el when there are todo list items', () => {
       const notification = document.querySelector( '.m-notification' );
@@ -126,6 +130,22 @@ describe( 'reviewDetailsView', () => {
       store.subscriber()( {}, state );
 
       expect( notification.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
+    } );
+
+    it( 'hides the `Possible Option` headings when the user selects the `wait` choice', () => {
+      const state = {
+        budget,
+        routes: { routes: []},
+        routeChoice: 'wait'
+      };
+
+      store.subscriber()( {}, state );
+
+      const choiceHeadings = toArray( el.querySelectorAll( `.${ CLASSES.CHOICE_HEADING }` ) );
+
+      choiceHeadings.forEach( ch => {
+        expect(ch.classList.contains( 'u-hidden' )).toBeTruthy();
+      });
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -95,7 +95,7 @@ describe( 'routeDetailsView', () => {
       view.render( nextState );
 
       const budgetEl = document.querySelector( `.${ CLASSES.BUDGET }` );
-      const expectedBudget = String(nextState.budget.earned - nextState.budget.spent);
+      const expectedBudget = String( nextState.budget.earned - nextState.budget.spent );
 
       expect( budgetEl.textContent ).toBe( expectedBudget );
     } );
@@ -249,13 +249,13 @@ describe( 'routeDetailsView', () => {
       expect( notification.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
     } );
 
-    it('displays a complete alert message when the data is valid and the option is in budget', () => {
-      view.render(nextState);
+    it( 'displays a complete alert message when the data is valid and the option is in budget', () => {
+      view.render( nextState );
 
       let completeAlert = document.querySelector( `.${ CLASSES.COMPLETE_ALERT }` );
-      let notification = completeAlert.querySelector('.m-notification');
+      let notification = completeAlert.querySelector( '.m-notification' );
 
-      expect(notification.classList.contains('m-notification__visible')).toBeFalsy();
+      expect( notification.classList.contains( 'm-notification__visible' ) ).toBeFalsy();
 
       const state = {
         budget: { earned: '10000', spent: '10' },
@@ -265,12 +265,12 @@ describe( 'routeDetailsView', () => {
         }
       };
 
-      view.render(state);
+      view.render( state );
 
       completeAlert = document.querySelector( `.${ CLASSES.COMPLETE_ALERT }` );
-      notification = completeAlert.querySelector('.m-notification');
+      notification = completeAlert.querySelector( '.m-notification' );
 
-      expect(notification.classList.contains('m-notification__visible')).toBeTruthy();
-    });
+      expect( notification.classList.contains( 'm-notification__visible' ) ).toBeTruthy();
+    } );
   } );
 } );


### PR DESCRIPTION
When the user selects the `I want to complete items in my to-do list before deciding` option in the review choice section, hide the 'Primary option' and 'Possible option' headings.

## Additions

- User will only see plan details section when they elect to complete todo list
items before making a decision

## Changes

- Fixes spacing issues in details plans

## Testing

1. Unit tests
2. Select a mode of transportation for both route options.
  * In the review choice section, choose the `wait` option
  * The displayed plans should just show the todo lists (if they exist) and the route option detail breakdown
 
## Screenshots
![Screen Shot 2019-10-05 at 10 02 29 AM](https://user-images.githubusercontent.com/1421848/66258212-3d696880-e757-11e9-8ee3-71389c62fb8d.png)


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
