### PR TITLE
YES tool — Set default values of transit time fields

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
@@ -16,7 +16,7 @@
         <input type="text"
                data-js-name="averageCost"
                disabled
-               class="a-text-input u-w50pct"
+               class="a-text-input u-w50pct a-average-cost"
                name="yes-average-cost"
                id="yes-average-cost"
                placeholder="$">

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
@@ -13,20 +13,20 @@
             <label for="yes-transit-time-hours" class="a-label a-label__heading">
               Hours
             </label>
-            <input type="text" id="yes-transit-time-hours" name="transitTimeHours" class="a-text-input u-mt0 u-w40pct" disabled>
+            <input type="text" id="yes-transit-time-hours" name="transitTimeHours" class="a-text-input u-mt0 u-w50pct js-yes-hours" disabled>
           </div>
           <div class="content-l_col content-l_col-1-2 u-mt0 js-transit-minutes">
             <label for="yes-transit-time-minutes" class="a-label a-label__heading">
               Minutes
             </label>
-            <input type="text" id="yes-transit-time-minutes" name="transitTimeMinutes" class="a-text-input u-mt0 u-w40pct" disabled>
+            <input type="text" id="yes-transit-time-minutes" name="transitTimeMinutes" class="a-text-input u-mt0 u-w50pct js-yes-minutes" disabled>
           </div>
         </div>
       </div>
     </div>
     {{ 
       render_checkbox({
-        'class': 'u-js-only block block__sub-micro',
+        'class': 'u-js-only block block__sub-micro js-yes-not-sure',
         'label': "I'm not sure, add this to my to-do list to look up later ",
         'disabled': true,
         'name': "timeToActionPlan"

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -179,6 +179,12 @@ textarea {
   });
 }
 
+.a-average-cost {
+  .respond-to-max(@bp-sm-min, {
+    width: 15%;
+  })
+}
+
 .a-yes-inline-radio {
   > .a-yes-average-cost-radio:first-child {
     margin-right: 1rem;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/budget-form-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/budget-form-view.js
@@ -71,7 +71,7 @@ function BudgetFormView( element, { store } ) {
    */
   function _updateTotal( { budget } ) {
     const { earned, spent } = budget;
-    const total = ( !earned && !spent ) ? '-' : money.subtract( earned, spent );
+    const total = !earned && !spent ? '-' : money.subtract( earned, spent );
 
     _moneyRemainingEl.textContent = total;
   }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -157,6 +157,40 @@ function updateRouteData( routes, routeIndex, data ) {
 }
 
 /**
+ * Detect if application should update the `transitTimeMinutes` state value
+ * @param {Object} routes the routes state object
+ * @param {Object} data The action's data
+ * @param {Number} data.routeIndex The index of the route being updated
+ * @returns {Boolean} Whether or not transitTimeMinutes is blank
+ */
+function hasTransitTimeMinutes( routes, data ) {
+  const route = routeSelector( routes, data.routeIndex );
+
+  if ( route.transitTimeMinutes === '' ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Detect if application should update the `transitTimeHours` state value
+ * @param {Object} routes the routes state object
+ * @param {Object} data The action's data
+ * @param {Number} data.routeIndex The index of the route being updated
+ * @returns {Boolean} Whether or not transitTimeHours is blank
+ */
+function hasTransitTimeHours( routes, data ) {
+  const route = routeSelector( routes, data.routeIndex );
+
+  if ( route.transitTimeHours === '' ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  *
  * @param {object} state the current values for this slice of app state
  * @param {object} action instructs reducer which state update to apply
@@ -289,14 +323,32 @@ function routeOptionReducer( state = initialState, action ) {
       } ) );
     }
     case actionTypes.UPDATE_TRANSIT_TIME_HOURS: {
-      return assign( state, updateRouteData( state.routes, data.routeIndex, {
-        transitTimeHours: data.value
-      } ) );
+      const updates = {
+        transitTimeHours: data.value || '0'
+      };
+
+      if ( !hasTransitTimeMinutes( state, data ) ) {
+        updates.transitTimeMinutes = '0';
+      }
+
+      return assign(
+        state,
+        updateRouteData( state.routes, data.routeIndex, updates )
+      );
     }
     case actionTypes.UPDATE_TRANSIT_TIME_MINUTES: {
-      return assign( state, updateRouteData( state.routes, data.routeIndex, {
-        transitTimeMinutes: data.value
-      } ) );
+      const updates = {
+        transitTimeMinutes: data.value || '0'
+      };
+
+      if ( !hasTransitTimeHours( state, data ) ) {
+        updates.transitTimeHours = '0';
+      }
+
+      return assign(
+        state,
+        updateRouteData( state.routes, data.routeIndex, updates )
+      );
     }
     case actionTypes.UPDATE_IS_MONTHLY_COST: {
       return assign( state, updateRouteData( state.routes, data.routeIndex, {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/todo-notification.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/todo-notification.js
@@ -51,7 +51,7 @@ function TodoNotification() {
   function _cloneNotification( message ) {
     clone = self.element.cloneNode( true );
     clone.querySelector( `.${ CLASSES.MESSAGE }` ).textContent = message;
-    clone.querySelector(`.${CLASSES.NOTIFICATION}`).classList.add(VISIBLE_CLASS);
+    clone.querySelector( `.${ CLASSES.NOTIFICATION }` ).classList.add( VISIBLE_CLASS );
 
     registeredNode.appendChild( clone );
   }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
@@ -110,6 +110,9 @@ function inputView( element, props = {} ) {
     },
     destroy() {
       _unbindEvents();
+    },
+    render( value ) {
+      _dom.value = value;
     }
   };
 }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
@@ -65,21 +65,15 @@ function transitTimeView( element, { store, routeIndex, todoNotification } ) {
 
   /**
    * Re-render child components when state changes
-   * @param {Object} prevState The previous application state
+   * @param {Object} _ The previous application state (unused)
    * @param {Object} state The current application state
    * @param {Object} state.routes The route objects currently stored in the application state
    */
-  function _handleStateUpdate( prevState, state ) {
-    const prevRoute = routeSelector( prevState.routes, routeIndex );
+  function _handleStateUpdate( _, state ) {
     const route = routeSelector( state.routes, routeIndex );
 
-    if ( prevRoute.transitTimeHours !== route.transitTimeHours ) {
-      _hoursView.render( route.transitTimeHours );
-    }
-
-    if ( prevRoute.transitTimeMinutes !== route.transitTimeMinutes ) {
-      _minutesView.render( route.transitTimeMinutes );
-    }
+    _hoursView.render( route.transitTimeHours );
+    _minutesView.render( route.transitTimeMinutes );
   }
 
   /**

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -153,9 +153,21 @@ describe( 'routeOptionReducer', () => {
           routeIndex: 0,
           value: nextValue } )
       );
-      const { transitTimeHours } = state.routes[0];
+      const { transitTimeHours, transitTimeMinutes } = state.routes[0];
 
       expect( transitTimeHours ).toBe( nextValue );
+      expect( transitTimeMinutes ).toBe( '0' );
+
+      const nextState = routeOptionReducer(
+        {
+          routes: [ createRoute( { transitTimeMinutes: '1' } ) ]
+        },
+        updateTransitTimeHoursAction( {
+          routeIndex: 0,
+          value: nextValue } )
+      );
+
+      expect( nextState.routes[0].transitTimeMinutes ).toBe( '1' );
     } );
 
     it( 'reduces the .updateTransitTimeMinutes action', () => {
@@ -165,9 +177,21 @@ describe( 'routeOptionReducer', () => {
           routeIndex: 0,
           value: nextValue } )
       );
-      const { transitTimeMinutes } = state.routes[0];
+      const { transitTimeMinutes, transitTimeHours } = state.routes[0];
 
       expect( transitTimeMinutes ).toBe( nextValue );
+      expect( transitTimeHours ).toBe( '0' );
+
+      const nextState = routeOptionReducer(
+        {
+          routes: [ createRoute( { transitTimeHours: '1' } ) ]
+        },
+        updateTransitTimeMinutesAction( {
+          routeIndex: 0,
+          value: nextValue } )
+      );
+
+      expect( nextState.routes[0].transitTimeHours ).toBe( '1' );
     } );
 
     it( 'reduces the .updateTimeToActionPlan action', () => {

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
@@ -6,7 +6,7 @@ import { PLAN_TYPES } from '../../../../../../../cfgov/unprocessed/apps/youth-em
 const CLASSES = reviewDetailsView.CLASSES;
 
 const HTML = `
-<div class="${CLASSES.CONTAINER}">
+<div class="${ CLASSES.CONTAINER }">
   <h2>Your plan to get to work</h2>
   <h3>Your to-do list</h3>
   <ul>
@@ -144,8 +144,8 @@ describe( 'reviewDetailsView', () => {
       const choiceHeadings = toArray( el.querySelectorAll( `.${ CLASSES.CHOICE_HEADING }` ) );
 
       choiceHeadings.forEach( ch => {
-        expect(ch.classList.contains( 'u-hidden' )).toBeTruthy();
-      });
+        expect( ch.classList.contains( 'u-hidden' ) ).toBeTruthy();
+      } );
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/transit-time-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/transit-time-spec.js
@@ -6,25 +6,21 @@ import {
   updateTransitTimeMinutesAction
 } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer';
 import TODO_FIXTURE from '../../fixtures/todo-alert';
+import mockStore from '../../../../mocks/store';
 import TodoNotificationMock from '../../mocks/todo-notification';
+
+const CLASSES = transitTimeView.CLASSES;
 
 const HTML = `
   <div class="content-l content-l_col-2-3 block__sub-micro m-yes-transit-time">
     <div class="form-l_col form-l_col-1-4">
-      <label class="a-label a-label__heading u-mb0" for="input_37ad90bd3b4790_hours">
-        Hours
-      </label>
-      <input id="input_37ad90bd3b4790_hours" name="input_37ad90bd3b4790_hours" type="text" value="" data-js-name="transitTimeHours">
+      <input class="${ CLASSES.HOURS }" type="text" value="" data-js-name="transitTimeHours">
     </div>
     <div class="form-l_col form-l_col-1-4">
-      <label class="a-label a-label__heading u-mb0" for="input_37ad90bd3b4ed4_minutes">
-        Minutes
-      </label>
-      <input id="input_37ad90bd3b4ed4_minutes" name="input_37ad90bd3b4ed4_minutes" type="text" value="" data-js-name="transitTimeMinutes">
-      
+      <input class="${ CLASSES.MINUTES }" type="text" value="" data-js-name="transitTimeMinutes">
     </div>
     <div class="m-form-field m-form-field__checkbox block__sub-micro">
-      <input class="a-checkbox" type="checkbox" value="input_37ad90bd3b546a_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later-" id="input_37ad90bd3b546a_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later-" name="timeToActionPlan">
+      <input class="a-checkbox ${ CLASSES.NOT_SURE }" type="checkbox" name="timeToActionPlan">
       <label class="a-label" for="input_37ad90bd3b546a_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later-">
         <span>I'm not sure, add this to my to-do list to look up later </span>
       </label>
@@ -38,24 +34,27 @@ describe( 'transitTimeView', () => {
   const CLASSES = transitTimeView.CLASSES;
   const todoNotification = new TodoNotificationMock();
   const dispatch = jest.fn();
-  const mockStore = () => ( {
-    dispatch,
-    subscribe() { return {}; }
-  } );
+  let el;
   let view;
   let store;
 
   beforeEach( () => {
     document.body.innerHTML = HTML;
     store = mockStore();
-    view = transitTimeView( document.querySelector( `.${ CLASSES.CONTAINER }` ), { store, routeIndex, todoNotification } );
+    el = document.querySelector( `.${ CLASSES.CONTAINER }` );
+    view = transitTimeView( el, { store, routeIndex, todoNotification } );
     view.init();
   } );
 
   afterEach( () => {
+    store.mockReset();
     todoNotification.mockReset();
     dispatch.mockReset();
     view = null;
+  } );
+
+  it( 'subscribes to the store on init', () => {
+    expect( store.subscribe.mock.calls.length ).toBe( 1 );
   } );
 
   it( 'dispatches the correct action when hours field is changed', () => {
@@ -64,7 +63,7 @@ describe( 'transitTimeView', () => {
 
     hoursEl.value = hours;
 
-    simulateEvent( 'input', hoursEl );
+    simulateEvent( 'blur', hoursEl );
 
     const mock = store.dispatch.mock;
 
@@ -82,7 +81,7 @@ describe( 'transitTimeView', () => {
 
     minutesEl.value = minutes;
 
-    simulateEvent( 'input', minutesEl );
+    simulateEvent( 'blur', minutesEl );
 
     const mock = store.dispatch.mock;
 
@@ -127,5 +126,37 @@ describe( 'transitTimeView', () => {
 
     expect( todoNotification.show.mock.calls.length ).toBe( 1 );
     expect( todoNotification.hide.mock.calls.length ).toBe( 1 );
+  } );
+
+  it( 'updates the minutes field when the current state has changed', () => {
+    const state = {
+      routes: {
+        routes: [ {
+          transitTimeMinutes: '0'
+        } ]
+      }
+    };
+    const minutesEl = el.querySelector( `.${ CLASSES.MINUTES }` );
+    minutesEl.value = '';
+
+    store.subscriber()( { routes: { routes: [ {} ]}}, state );
+
+    expect( minutesEl.value ).toBe( '0' );
+  } );
+
+  it( 'updates the hours field when the current state has changed', () => {
+    const state = {
+      routes: {
+        routes: [ {
+          transitTimeHours: '0'
+        } ]
+      }
+    };
+    const hoursEl = el.querySelector( `.${ CLASSES.HOURS }` );
+    hoursEl.value = '';
+
+    store.subscriber()( { routes: { routes: [ {} ]}}, state );
+
+    expect( hoursEl.value ).toBe( '0' );
   } );
 } );


### PR DESCRIPTION
To Improve the user's quality-of-life while interacting with the tool, fill in defaults of `0` for either `hours` or `minutes` fields in the transit time section of the form when one is present and the other is omitted.

For example, if it takes the user 45 minutes to get to work, automatically fill the `hours` field with a `0`

## Changes

- Transit time fields now update on `blur`

# Additions

- Add a zero in the `minutes` field when `hours` is filled in and `minutes` is not, and vice versa.

## Testing

1. Unit tests should pass
2. Filling in either of the two time fields fills in the other with a zero. The fields can each still be filled in normally.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
