### PR TITLE
YES tool — Refines when daysPerWeek field is shown

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
@@ -59,18 +59,18 @@ function valueOrActionPlan( fieldName, value, actionItems ) {
  * @returns {Boolean} Data validity
  */
 function isRequiredValid( data ) {
+  const todoList = data.actionPlanItems;
   let isValid;
 
   for ( let i = 0; i < requiredFields.length; i++ ) {
     const fieldName = requiredFields[i];
-
     // does the data object contain the required field
     if ( data.hasOwnProperty( fieldName ) ) {
       // check if the value exists
       isValid = valueOrActionPlan(
         fieldName,
         data[fieldName],
-        data.actionPlanItems
+        todoList
       );
     }
 
@@ -87,10 +87,10 @@ function isRequiredValid( data ) {
  * @param {object} param0 Route data
  * @returns {Boolean} Data validity
  */
-function isValidDriveData( { miles, daysPerWeek } ) {
+function isValidDriveData( { miles, daysPerWeek, actionPlanItems } ) {
   if (
-    miles && isNumber( miles ) &&
-    daysPerWeek && isNumber( daysPerWeek )
+    valueOrActionPlan( 'miles', miles, actionPlanItems ) &&
+    valueOrActionPlan( 'daysPerWeek', daysPerWeek, actionPlanItems )
   ) {
     return true;
   }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
@@ -70,9 +70,7 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
     const prevRouteState = routeSelector( prevState.routes, routeIndex );
     const routeState = routeSelector( state.routes, routeIndex );
 
-    if ( routeState.transportation === 'Drive' ) {
-      _dom.classList.remove( 'u-hidden' );
-    } else {
+    if ( routeState.isMonthlyCost ) {
       _daysPerWeekEl.value = '';
       _notSureEl.checked = '';
       _dom.classList.add( 'u-hidden' );
@@ -82,6 +80,8 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
       if ( prevRouteState.daysPerWeek ) {
         store.dispatch( clearDaysPerWeekAction( { routeIndex } ) );
       }
+    } else {
+      _dom.classList.remove( 'u-hidden' );
     }
   }
 
@@ -107,7 +107,6 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
     init() {
       if ( setInitFlag( _dom ) ) {
         _initInputs();
-        _dom.classList.add( 'u-hidden' );
         store.subscribe( _onStateUpdate );
         todoNotification.init( _dom );
       }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -49,7 +49,7 @@ function updateTodoList( todos = [] ) {
    multiple shifts etc, but should work for now. */
 const FULL_TIME_DAYS = 5;
 
-const DEFAULT_COST_ESTIMATE = '-';
+const DEFAULT_COST_ESTIMATE = '0';
 
 // Rough estimate to account for weeks that have more or less days
 const WEEKLY_COST_MODIFIER = 4.2;

--- a/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
@@ -54,10 +54,6 @@ describe( 'DaysPerWeekView', () => {
   } );
 
   describe( 'on initialize', () => {
-    it( 'hides its container element', () => {
-      expect( dom.classList.contains( 'u-hidden' ) ).toBeTruthy();
-    } );
-
     it( 'subscribes to the store', () => {
       expect( store.subscribe ).toHaveBeenCalled();
     } );
@@ -134,7 +130,7 @@ describe( 'DaysPerWeekView', () => {
       expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
     } );
 
-    describe( 'when transportation mode is not Drive', () => {
+    describe( 'when average cost is defined as a montly cost', () => {
       const days = '2';
       const checked = 'checked';
       const prevState = {
@@ -147,7 +143,8 @@ describe( 'DaysPerWeekView', () => {
       const state = {
         routes: {
           routes: [ {
-            transportation: 'Walk'
+            transportation: 'Walk',
+            isMonthlyCost: true
           } ]
         }
       };
@@ -186,7 +183,7 @@ describe( 'DaysPerWeekView', () => {
         expect( dom.classList.contains( 'u-hidden' ) ).toBeTruthy();
       } );
 
-      it( 'dispatches the correct action when daysPerWeek is filled in and transportation method is not drive', () => {
+      it( 'dispatches the correct action when daysPerWeek is filled in', () => {
         const mock = store.dispatch.mock;
         store.subscriber()( prevState, state );
 
@@ -197,14 +194,6 @@ describe( 'DaysPerWeekView', () => {
       } );
 
       it( 'calls .remove on the todo notification component when this view is toggled', () => {
-        const state = {
-          routes: {
-            routes: [ {
-              transportation: 'Walk'
-            } ]
-          }
-        };
-
         store.subscriber()( { routes: { routes: [ {} ]}}, state );
 
         expect( todoNotification.remove.mock.calls.length ).toBe( 1 );


### PR DESCRIPTION
So that the user can correctly indicate how many days per week they expect to travel for work, always show the `daysPerWeek` field, unless the  user indicated the cost of
transportation should be calculated on a per month basis

## Additions

- Show `daysPerWeek` form controls for all transportation types

## Changes

- Properly detect if `miles` and `daysPerWeek` form controls have the to-do list checkbox selected in the route option form validator

## Testing

1. Specs pass
2. The `How many days per week will you make this trip?` form controls appear when the transportation tool is loaded.
3. The aforementioned field stays on screen when different transportation types are selected.
4. The field is removed from the screen is `per month` is selected in the `averageCost` form controls.
5. The field returns, and is cleared, if the `averageCost` form controls are hidden; either by selecting `Drive` as a method of transportation, or by choosing `per day` from the `averageCost` form controls.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
