### PR TITLE
YES tool — Display alert in no-js environment

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/goals.html
+++ b/cfgov/jinja2/v1/youth_employment_success/goals.html
@@ -7,7 +7,7 @@
 <p class="u-mb0">Meet Mya and Frankie. They’ll help you think about your plan.</p>
 <div class="content-l block block__sub block__flush-top">  
   <div class="content-l_col-1-2 block block__sub">
-    <img src="/static/apps/youth-employment-success/img/Mya_transportation_tool.png" alt="">
+    <img src="/static/apps/youth-employment-success/img/Mya_transportation_tool.png" alt="" class="u-hide-on-print">
     <p class="h2 u-mt15">Mya plans to bike to work</p>
     <p class="u-mt20">Mya decided to bike to work because there’s a bikeshare near her school. Bikeshares allow you to borrow a bike from different self-service bike stations around the city. Mya heads straight to work from class—some days she has time to walk, but usually she’s in a rush and biking is faster.</p>
     <p class="h3">
@@ -16,7 +16,7 @@
     <p>I want to buy an annual bikeshare membership since my school offers a special student rate and it’d be a better deal than paying per ride. The $60 annual membership works out to a little over $1 per week (over 52 weeks in a year). In order to save money for this, I will walk to work two days a week for the next few months.</p>
   </div>
   <div class="content-l_col-1-2 block block__sub">
-    <img src="/static/apps/youth-employment-success/img/Frankie_transportation_tool.png" alt="">
+    <img src="/static/apps/youth-employment-success/img/Frankie_transportation_tool.png" alt="" class="u-hide-on-print">
     <p class="h2 u-mt15">Frankie plans to take the bus</p>
     <p class="u-mt20">Frankie doesn’t live near public transportation so he usually gets a ride to the closest bus stop. The bus ride is about 25 minutes long so he leaves his house at 7:10am to allow enough time to get dropped off, ride the bus, and arrive at work before his 8am shift starts.</p>
     <p class="h3">
@@ -36,6 +36,7 @@
     <div class="block block__sub">
       {{
         textarea.render({
+          'disabled': true,
           'fieldClass': 'js-long-term-goal',
           'helperText': 'For example, your long-term goal could be saving up for an annual bus pass over the next few months or saving up to buy a car in the next year.',
           'label': 'What’s your long-term goal?',
@@ -48,6 +49,7 @@
     <div class="block block__sub">
       {{
         textarea.render({
+          'disabled': true,
           'fieldClass': 'js-goal-importance',
           'helperText': 'Maybe this goal will help you save money in the long run, or maybe it’s a more reliable option than your current way of getting to work.',
           'label': "Why is this goal important to you?",
@@ -93,6 +95,7 @@
     <div class="block block__sub">
       {{
         textarea.render({
+          'disabled': true,
           'fieldClass': 'js-goal-steps',
           'helperText': 'Now work backwards — what are some steps you could take to achieve your goal during your intended timeline? Make sure your steps are realistic and specific. For example, my first step is “Over the next six months, I’ll take the bus instead of using a rideshare in order to save money. I’m trying to save $400 over these six months to put towards a car down payment.”',
           'label': "What are some steps you could take to reach your goal?",

--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -9,11 +9,12 @@
 
 <main class="content content__1-3 yes-transit-tool" role="main">
   <div class="wrapper content_wrapper">
-    <aside class="content_sidebar content__flush-top u-hide-on-review-print">
+    <aside class="content_sidebar content__flush-top js-no-print">
       sidebar
     </aside>
     <section class="content_main">
-      <div class="u-hide-on-review-print">
+      {% include "no-js.html" %}
+      <div class="js-no-print">
         {% include "goals.html" %}      
         {% include "budget-form.html" %}
         <div class="block">
@@ -33,7 +34,7 @@
 {% endblock content %}
 
 {% block footer %}
-  <div class="u-hide-on-review-print">
+  <div class="u-hide-on-print">
     {% import 'organisms/footer.html' as o_footer with context %}
     {{ o_footer.render() }}
   </div>

--- a/cfgov/jinja2/v1/youth_employment_success/no-js.html
+++ b/cfgov/jinja2/v1/youth_employment_success/no-js.html
@@ -1,0 +1,14 @@
+<div class="block block__sub block__flush-top u-hide-on-print">
+  <div class="m-notification m-notification__error u-show-no-js">
+    {{ svg_icon('error-round') }}
+    <div class="m-notification_content">
+      <div class="h4 m-notification_message">
+        <p>
+          This tool is not supported in your browser.
+          Please try a newer browser or confirm that JavaScript is enabled.
+        </p>
+        <p>Alternatively, you can print this page and fill it out by hand.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cfgov/jinja2/v1/youth_employment_success/review/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/index.html
@@ -1,7 +1,7 @@
 <div class="js-yes-review-choice">
   {% include "review/review.html" %}
   <div class="js-yes-plans-review">
-    <div class="content_line-bold u-hide-on-review-print"></div>
+    <div class="content_line-bold js-no-print"></div>
     {% include "review/your-plan.html" %}
     {% include "review/your-goals.html" %}
     {% include "review/print.html" %}

--- a/cfgov/jinja2/v1/youth_employment_success/review/next-steps.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/next-steps.html
@@ -34,6 +34,9 @@
         }
       })
     }}
+    <p class="u-show-no-js u-show-on-print">
+      https://www.consumerfinance.gov/about-us/blog/budgeting-how-to-create-a-budget-and-stick-with-it/
+    </p>
   </div>
   <div class="block block__sub">
     {{
@@ -47,6 +50,9 @@
         }
       })
     }}
+    <p class="u-show-no-js u-show-on-print">
+      https://www.consumerfinance.gov/consumer-tools/credit-reports-and-scores/
+    </p>
   </div>
   <div class="block block__sub">
     {{
@@ -60,5 +66,8 @@
         }
       })
     }}
+    <p class="u-show-no-js u-show-on-print">
+      https://www.consumerfinance.gov/about-us/blog/guides-to-help-you-open-and-manage-your-checking-account/
+    </p>
   </div>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/review/print.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/print.html
@@ -1,4 +1,4 @@
-<div class="block block__sub u-hide-on-review-print">
+<div class="block block__sub u-js-only js-no-print">
   <p class="h3">Print your plan</p>
   <p>You can print your plan as a PDF to keep track of your options and next steps</p>
   <button class="a-btn yes-print-button">Print your plan</button>

--- a/cfgov/jinja2/v1/youth_employment_success/review/review.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/review.html
@@ -1,6 +1,6 @@
 {% import 'atoms/radio-button.html' as radio_button with context %}
 
-<div class="block block__sub u-hide-on-review-print">
+<div class="block block__sub js-no-print">
   <h2>Which way of getting to work is your first choice?</h2>
   <p>Mya decided to bike to work because it’s affordable and the bikeshare is convenient to her school and job. Frankie decided to take the bus instead of taking a rideshare to work in order to save money to hopefully buy a car in the next year.</p>
 
@@ -45,5 +45,5 @@
       </div>
     </div>
   </div>
-  <button class="a-btn a-btn__full-on-xs js-yes-choice-finalize" disabled>Review your plan</button>
+  <button class="a-btn a-btn__full-on-xs js-yes-choice-finalize u-js-only" disabled>Review your plan</button>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -22,7 +22,7 @@
       {{
         alert.render({
           'background': true,
-          'class': 'block block__sub-micro',
+          'class': 'block block__sub-micro u-js-only',
           'fill': 'warning',
           'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you.',
           'visible': true
@@ -47,7 +47,7 @@
       {{
         alert.render({
           'background': true,
-          'class': 'block block__sub-micro',
+          'class': 'block block__sub-micro u-js-only',
           'fill': 'warning',
           'content': 'You chose a plan that still has to-do list items. Completing the missing items will give you a better sense if this is the best option for you.',
           'visible': true

--- a/cfgov/jinja2/v1/youth_employment_success/route-details.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-details.html
@@ -33,7 +33,7 @@
           'target': 'js-budget-left'
         })
       }}
-      <div class="content-l block block__sub-micro block__flush-top">
+      <div class="content-l block block__sub-micro block__flush-top u-js-only">
         <div class="content-l_col content-l_col-1">
           <div class="js-route-complete">
             {{

--- a/cfgov/jinja2/v1/youth_employment_success/route-options.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-options.html
@@ -1,4 +1,4 @@
-<div class="yes-routes block block__sub u-hide-on-review-print">
+<div class="yes-routes block block__sub js-no-print">
   <div class="content-l">
     <div class="u-w75pct">
       {% for i in range(2) %}
@@ -14,7 +14,7 @@
     <div class="content-l_col content-l_col-1">
       <h2>Are there other ways you can get to work? Compare different options to help you figure out your first choice and a backup plan.</h2>
       {% include "plus-icon.html" %}
-      <button class="a-btn a-btn__link m-yes-route-option">Show me another option</button>
+      <button class="a-btn a-btn__link m-yes-route-option u-js-only">Show me another option</button>
     </div>
   </div>
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-options.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-options.html
@@ -13,8 +13,10 @@
   <div class="content-l m-yes-route-option block u-mt30">
     <div class="content-l_col content-l_col-1">
       <h2>Are there other ways you can get to work? Compare different options to help you figure out your first choice and a backup plan.</h2>
-      {% include "plus-icon.html" %}
-      <button class="a-btn a-btn__link m-yes-route-option u-js-only">Show me another option</button>
+      <div class="u-js-only">
+        {% include "plus-icon.html" %}
+        <button class="a-btn a-btn__link m-yes-route-option">Show me another option</button>
+      </div>
     </div>
   </div>
 </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -1,5 +1,12 @@
 @import (reference) '../../../css/main.less';
 
+.no-js {
+  .u-show-no-js {
+    display: block;
+    visibility: visible;
+  }
+}
+
 /**
   * Capital Framework overrides
 **/
@@ -82,6 +89,12 @@
   });
 }
 
+.m-list_link {
+  .respond-to-max(@bp-sm-min, {
+    border: 0;
+  });
+}
+
 .o-expandable_content__expanded {
   /**
    * The route option form is quite large and the current expandable `max-height`
@@ -153,7 +166,7 @@ textarea {
   });
 }
 
-.u-hide-on-review-print {
+.u-hide-on-print {
   .respond-to-print({
     display: none !important;
   });

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -1,12 +1,5 @@
 @import (reference) '../../../css/main.less';
 
-.no-js {
-  .u-show-no-js {
-    display: block;
-    visibility: visible;
-  }
-}
-
 /**
   * Capital Framework overrides
 **/
@@ -172,6 +165,12 @@ textarea {
   });
 }
 
+.u-show-on-print {
+  .respond-to-print({
+    display: block !important;
+  });
+}
+
 .u-mobile-reorder {
   .respond-to-max(@bp-sm-min, {
     display: flex;
@@ -190,6 +189,17 @@ textarea {
       order: 3;
     }
   });
+}
+
+.no-js {
+  .u-show-no-js {
+    display: block;
+    visibility: visible;
+  }
+}
+
+.u-show-no-js {
+  display: none;
 }
 
 .a-average-cost {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -1,5 +1,6 @@
 import Expandable from 'cf-expandables/src/Expandable';
 import { addRouteOptionAction } from './reducers/route-option-reducer';
+import { toArray } from './util';
 import averageCostView from './views/average-cost';
 import budgetFormView from './budget-form-view';
 import createRoute from './route.js';
@@ -18,8 +19,8 @@ import routeOptionToggleView from './route-option-toggle-view';
 import store from './store';
 import transitTimeView from './views/transit-time';
 
-Array.prototype.slice.call(
-  document.querySelectorAll( 'input' )
+toArray(
+  document.querySelectorAll( 'input, textarea' )
 ).forEach( input => {
   input.removeAttribute( 'disabled' );
 } );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/print-button.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/print-button.js
@@ -1,14 +1,19 @@
 import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
+import { toArray } from '../util';
 
 const CLASSES = {
-  BUTTON: 'yes-print-button'
+  BUTTON: 'yes-print-button',
+  NO_PRINT: 'js-no-print',
+  HIDE: 'u-hide-on-print'
 };
 
 /**
  * PrintButton
  * @class
  *
- * @classdesc Simple view for calling the system print dialog
+ * @classdesc Simple view for calling the system print dialog when the
+ * user wants to print their final plan. Toggles visibility of elements
+ * that should not be printed.
  *
  * @param {HTMLNode} element The root DOM element for this view
  * @returns {Object} The view's public methods
@@ -17,9 +22,29 @@ function printButton( element ) {
   const _dom = checkDom( element, CLASSES.BUTTON );
 
   /**
+   * When printing has finished, show all the hidden elements
+   */
+  function _onAfterPrint() {
+    toArray(
+      document.querySelectorAll( `.${ CLASSES.NO_PRINT }.${ CLASSES.HIDE }` )
+    )
+      .forEach( el => el.classList.remove( `${ CLASSES.HIDE }` ) );
+
+    window.removeEventListener( 'focus', _onAfterPrint );
+  }
+
+  /**
    * Calls the system print dialog
    */
   function _print() {
+    /* I believe we need to query each time as elements may have been
+       added to the DOM during the tool's lifecycle on the page */
+    toArray(
+      document.querySelectorAll( `.${ CLASSES.NO_PRINT }` )
+    )
+      .forEach( el => el.classList.add( `${ CLASSES.HIDE }` ) );
+
+    window.addEventListener( 'focus', _onAfterPrint );
     window.print();
   }
 

--- a/test/unit_tests/apps/youth-employment-success/js/views/print-button-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/print-button-spec.js
@@ -2,22 +2,55 @@ import { simulateEvent } from '../../../../../util/simulate-event';
 import printButton from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/print-button';
 
 const CLASSES = printButton.CLASSES;
-const HTML = `<button class="${ CLASSES.BUTTON }"></button>`;
+const HTML = `
+  <div class="${ CLASSES.NO_PRINT }"></div>
+  <button class="${ CLASSES.BUTTON }"></button>
+`;
 
 describe( 'printButtonView', () => {
   const printMock = jest.fn();
+  let addEventSpy;
+  let removeEventSpy;
   let dom;
+  let view;
 
   beforeEach( () => {
     window.print = printMock;
+    addEventSpy = jest.spyOn( window, 'addEventListener' );
+    removeEventSpy = jest.spyOn( window, 'removeEventListener' );
     document.body.innerHTML = HTML;
     dom = document.querySelector( `.${ CLASSES.BUTTON }` );
-    printButton( dom ).init();
+    view = printButton( dom );
+    view.init();
+  } );
+
+  afterEach( () => {
+    view = null;
+    printMock.mockReset();
   } );
 
   it( 'calls the system print dialog when clicked', () => {
     simulateEvent( 'click', dom );
 
     expect( printMock.mock.calls.length ).toBe( 1 );
+    expect( addEventSpy ).toHaveBeenCalled();
+
+    simulateEvent( 'focus', window );
+
+    expect( removeEventSpy ).toHaveBeenCalled();
+  } );
+
+  it( 'hides elements with the no print class on print, and shows them afterwards', () => {
+    const elToToggle = document.querySelector( `.${ CLASSES.NO_PRINT }` );
+
+    expect( elToToggle.classList.contains( CLASSES.HIDE ) ).toBeFalsy();
+
+    simulateEvent( 'click', dom );
+
+    expect( elToToggle.classList.contains( CLASSES.HIDE ) ).toBeTruthy();
+
+    simulateEvent( 'focus', window );
+
+    expect( elToToggle.classList.contains( CLASSES.HIDE ) ).toBeFalsy();
   } );
 } );


### PR DESCRIPTION
To help the user make the choice to either use a different browser or print the page, display an alert in a `no-js` env. 

## Additions

- Alert message when javascript is not detected / unsupported

## Changes

- Changes print behavior. Now, JS will run to hide all certain elements when the `print your plan` button is clicked. Otherwise, all elements not tagged to hide on print will print in a `no-js` env.

## Testing

1. When printing without JS, images, the red `danger` alert, and buttons should not appear in the print dialog box
2. When printing from the `print your plan` button, everything but the plan review section should be hidden.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
