### PR TITLE
YES Tool - Adds input sanitization

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/budget-form.html
+++ b/cfgov/jinja2/v1/youth_employment_success/budget-form.html
@@ -21,7 +21,8 @@
                    name="money-earned"
                    class="a-text-input o-yes-budget-earned"
                    disabled
-                   placeholder="$">
+                   placeholder="$"
+                   pattern="\D+">
           </div>
         </div>
         <div class="u-mobile-reorder__first">
@@ -57,7 +58,8 @@
                    name="money-spent" 
                    class="a-text-input o-yes-budget-spent"
                    disabled=""
-                   placeholder="$">
+                   placeholder="$"
+                   pattern="\D+">
           </div>
         
           <div class="u-mobile-reorder__second">

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
@@ -19,7 +19,8 @@
                class="a-text-input u-w50pct a-average-cost"
                name="yes-average-cost"
                id="yes-average-cost"
-               placeholder="$">
+               placeholder="$"
+               pattern="\D+">
       </div>
       <div class="content-l_col u-mt5 a-yes-inline-radio">
         {{

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
@@ -11,7 +11,8 @@
         'size': '1-4',
         'type': 'text',
         'value': '',
-        'disabled': true
+        'disabled': true,
+        'pattern': "\D+"
       })
     }}
     {{

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/input.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/input.html
@@ -27,6 +27,8 @@
 
   class:         Optional CSS classes to apply to the element
 
+  pattern:       Optional HTML5 validation regexp
+
   ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}
 
@@ -55,7 +57,8 @@
           {{ 'required' if value.required else '' }}
           {{ 'disabled' if value.disabled else ''}}
           {{ 'aria-describedby="' ~ ht_id ~ '"' if value.helperText else '' }}
-          {{ 'placeholder="' ~ value.placeholder ~ '"' if value.placeholder else '' }}>
+          {{ 'placeholder="' ~ value.placeholder ~ '"' if value.placeholder else '' }}
+          {{ 'pattern=' ~ value.pattern ~ '' if value.pattern else ''}}>
    </input>
 </div>
 

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
@@ -12,7 +12,8 @@
         'size': '1-4',
         'type': 'text',
         'value': '',
-        'disabled': true
+        'disabled': true,
+        'pattern': "\D+"
       })
     }}
     {{ 

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
@@ -13,13 +13,23 @@
             <label for="yes-transit-time-hours" class="a-label a-label__heading">
               Hours
             </label>
-            <input type="text" id="yes-transit-time-hours" name="transitTimeHours" class="a-text-input u-mt0 u-w50pct js-yes-hours" disabled>
+            <input type="text"
+                   id="yes-transit-time-hours"
+                   name="transitTimeHours"
+                   class="a-text-input u-mt0 u-w50pct js-yes-hours"
+                   disabled
+                   pattern="\D+">
           </div>
           <div class="content-l_col content-l_col-1-2 u-mt0 js-transit-minutes">
             <label for="yes-transit-time-minutes" class="a-label a-label__heading">
               Minutes
             </label>
-            <input type="text" id="yes-transit-time-minutes" name="transitTimeMinutes" class="a-text-input u-mt0 u-w50pct js-yes-minutes" disabled>
+            <input type="text"
+                   id="yes-transit-time-minutes"
+                   name="transitTimeMinutes"
+                   class="a-text-input u-mt0 u-w50pct js-yes-minutes"
+                   disabled
+                   pattern="\D+">
           </div>
         </div>
       </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -113,6 +113,11 @@ textarea {
   border-style: solid !important;
   border-width: 1px !important;
 }
+
+input:-moz-ui-invalid {
+  // Required to stop FF from validating the `placeholder` attribute
+  box-shadow: none;
+}
 /** /ELEMENT-SPECIFIC **/
 
 /**

--- a/cfgov/unprocessed/apps/youth-employment-success/js/budget-form-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/budget-form-view.js
@@ -39,9 +39,8 @@ function BudgetFormView( element, { store } ) {
    *  the state with the event target's value
    */
   function _handleInput( action ) {
-    return ( { event } ) => {
-      const amount = event.currentTarget.value;
-      store.dispatch( action( amount ) );
+    return ( { _, value } ) => {
+      store.dispatch( action( value ) );
     };
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
@@ -61,10 +61,10 @@ function averageCostView( element, { store, routeIndex, todoNotification } ) {
    * @param {object} updateObject.event The emitted DOM event
    * @param {string} updateObject.name The name of the field the event was emitted from
    */
-  function _handleAverageCostUpdate( { event } ) {
+  function _handleAverageCostUpdate( { event, value } ) {
     store.dispatch( updateAverageCostAction( {
       routeIndex,
-      value: event.target.value
+      value
     } ) );
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
@@ -31,10 +31,10 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
    * for their selected transportation option
    * @param {object} param0 The emitted DOM event
    */
-  function _handleDaysUpdate( { event } ) {
+  function _handleDaysUpdate( { event, value } ) {
     store.dispatch( updateDaysPerWeekAction( {
       routeIndex,
-      value: event.target.value
+      value
     } ) );
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
@@ -59,6 +59,26 @@ function inputView( element, props = {} ) {
   }
 
   /**
+   * Strip invalid data from text inputs if the `pattern` attribute is present.
+   * @param {Object} target The node's JS object
+   * @returns {String} The sanitized input
+   */
+  function _sanitizeTextInput( target ) {
+    if ( _finalProps.type === 'text' ) {
+      if ( target.getAttribute( 'pattern' ) ) {
+        const pattern = new RegExp( target.getAttribute( 'pattern' ), 'g' );
+        const sanitized = target.value.replace( pattern, '' );
+
+        target.value = sanitized;
+
+        return sanitized;
+      }
+    }
+
+    return target.value;
+  }
+
+  /**
    *
    * @param {Function} handler event handler passed in through props
    * @returns {Function} A function that accepts an event and updates
@@ -67,8 +87,9 @@ function inputView( element, props = {} ) {
   const eventHandler = handler => event => {
     const { target } = event;
     const fieldName = target.getAttribute( 'data-js-name' ) || target.name;
+    const value = _sanitizeTextInput( target );
 
-    return handler( { name: fieldName, event } );
+    return handler( { name: fieldName, event, value } );
   };
 
   /**

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/miles.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/miles.js
@@ -40,10 +40,10 @@ function milesView( element, { store, routeIndex, todoNotification } ) {
    * @param {object} updateObject.event The emitted DOM event
    * @param {string} updateObject.name The name of the field the event was emitted from
    */
-  function _handleUpdateMiles( { event } ) {
+  function _handleUpdateMiles( { event, value } ) {
     store.dispatch( updateMilesAction( {
       routeIndex,
-      value: event.target.value
+      value
     } ) );
   }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
@@ -44,13 +44,13 @@ function transitTimeView( element, { store, routeIndex, todoNotification } ) {
    * Updates form state from child input text nodes
    * @param {object} updateObject object with DOM event and field name
    */
-  function _setResponse( { name, event } ) {
+  function _setResponse( { name, event, value } ) {
     const method = _actionMap[name];
     const type = event.target.type;
-    const value = type === 'checkbox' ? event.target.checked : event.target.value;
+    const finalValue = type === 'checkbox' ? event.target.checked : value;
 
     if ( type === 'checkbox' ) {
-      if ( value ) {
+      if ( finalValue ) {
         todoNotification.show( NOT_SURE_MESSAGE );
       } else {
         todoNotification.hide();
@@ -59,7 +59,7 @@ function transitTimeView( element, { store, routeIndex, todoNotification } ) {
 
     if ( method ) {
       store.dispatch( method( {
-        routeIndex, value } ) );
+        routeIndex, value: finalValue } ) );
     }
   }
 

--- a/test/unit_tests/apps/youth-employment-success/js/input-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/input-view-spec.js
@@ -9,7 +9,6 @@ const HTML = `
 
 describe( 'InputView', () => {
   let view;
-  let docAlias;
 
   beforeEach( () => {
     document.body.innerHTML = HTML;
@@ -40,7 +39,8 @@ describe( 'InputView', () => {
     const fakeInput = 'hey';
     const mockHandler = jest.fn();
     const events = {
-      change: mockHandler
+      change: mockHandler,
+      blur: mockHandler
     };
     let eventTarget;
     let view;
@@ -69,6 +69,58 @@ describe( 'InputView', () => {
       simulateEvent( 'change', eventTarget, { target: { value: fakeInput }} );
 
       expect( mockHandler.mock.calls.length ).toBe( 1 );
+    } );
+
+    describe( 'sanitizing data', () => {
+      it( 'removes data that does not match the pattern when pattern attribute is present', () => {
+        document.body.innerHTML = `
+          <input type="text" pattern="\\D+">
+        `;
+
+        const input = document.querySelector( 'input' );
+        inputView( input, { events } ).init();
+
+        input.value = '-122';
+
+        simulateEvent( 'blur', input );
+
+        expect( input.value ).toBe( '122' );
+        expect( mockHandler.mock.calls[0][0].value ).toBe( '122' );
+      } );
+
+      it( 'returns the original value if the type of input is not text', () => {
+        document.body.innerHTML = `
+          <input type="number">
+        `;
+
+        const input = document.querySelector( 'input' );
+
+        inputView( input, { events, type: 'number' } ).init();
+
+        input.value = 12;
+
+        simulateEvent( 'blur', input );
+
+        expect( input.value ).toBe( '12' );
+        expect( mockHandler.mock.calls[0][0].value ).toBe( '12' );
+      } );
+
+      it( 'returns the original value if input is text but there is no pattern', () => {
+        document.body.innerHTML = `
+          <input type="text">
+        `;
+
+        const input = document.querySelector( 'input' );
+
+        inputView( input, { events } ).init();
+
+        input.value = '-1';
+
+        simulateEvent( 'blur', input );
+
+        expect( input.value ).toBe( '-1' );
+        expect( mockHandler.mock.calls[0][0].value ).toBe( '-1' );
+      } );
     } );
   } );
 } );


### PR DESCRIPTION
So that the user doesn't enter invalid characters and get confused when calculations don't reflect
the input, sanitize all data numeric input to strip out any non-digit characters.

## Additions

- Adds input sanitization to text inputs with a `pattern` attribute

## Testing

1. Specs
2. Entering anything other than numbers into any of the text inputs should display only numbers. With no javascript, the fields will still be disabled

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
