### PR TITLE
Remove September 2019 CCDB feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -714,9 +714,6 @@ FLAGS = {
 
     # Release of prepaid agreements database search
     'PREPAID_AGREEMENTS_SEARCH': [],
-
-    # Used to hide CCDB landing page updates prior to public launch.
-    'CCDB_SEPT_2019_UPDATES':  [],
 }
 
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -710,13 +710,13 @@ FLAGS = {
     'BETA_EXTERNAL_TESTING': [],
 
     # Used to hide new youth employment success pages prior to public launch.
-    'YOUTH_EMPLOYMENT_SUCCESS':  [],
+    'YOUTH_EMPLOYMENT_SUCCESS': [],
 
     # Release of prepaid agreements database search
     'PREPAID_AGREEMENTS_SEARCH': [],
 
     # Used to hide CCDB landing page updates prior to public launch.
-    'CCDB_SEPT_2019_UPDATES':  [],
+    'CCDB_CONTENT_UPDATES': [],
 }
 
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -714,6 +714,9 @@ FLAGS = {
 
     # Release of prepaid agreements database search
     'PREPAID_AGREEMENTS_SEARCH': [],
+
+    # Used to hide CCDB landing page updates prior to public launch.
+    'CCDB_SEPT_2019_UPDATES':  [],
 }
 
 

--- a/cfgov/legacy/templates/complaint/complaint-landing.html
+++ b/cfgov/legacy/templates/complaint/complaint-landing.html
@@ -35,18 +35,13 @@
     <div class="hero_wrapper wrapper wrapper__match-content">
       <div class="hero_text">
         <h1 class="hero_heading">Consumer Complaint Database</h1>
-        {% if ccdb_sept_2019_updates %}
         <p class="hero_subhead">This database is a collection of complaints about consumer financial products and services that we sent to companies for response.</p>
-        {% else %}
-        <p class="hero_subhead">Each week we send thousands of consumers’ complaints about financial products and services to companies for response. Those complaints are published here after the company responds or after 15 days, whichever comes first. By adding their voice, consumers help improve the financial marketplace.</p>
-        {% endif %}
       </div>
       <div class="hero_image" style="background-image:url({% static 'complaint/img/hero.png' %})"></div>
     </div>
   </section>
   <div class="wrapper wrapper__match-content content_wrapper">
     <div class="content_full">
-      {% if ccdb_sept_2019_updates %}
       <div class="block block__bg block__flush-bottom block__border-top block__border-bottom">
         <div class="content-l">
           <div class="content-l_col content-l_col-2-3">
@@ -175,114 +170,6 @@
           </div>
         </div>
       </div>
-      {% else %}
-      <div class="block">
-        <div class="section-one ccdb-landing_section content-l">
-          <div class="content-l_col content-l_col-1-3">
-            <img class="isocon" alt="Consumer narratives" src="{% static 'complaint/img/read.png' %}">
-            <p>Consumers have let us know they want to share their complaint descriptions so others can learn from their experience.</p>
-            <div class="btn-holder">
-              <p><a href="/data-research/consumer-complaints/search/?has_narrative=true" target="_blank" rel="noopener noreferrer" class="btn">Read consumer narratives</a></p>
-            </div>
-          </div>
-          <div class="content-l_col content-l_col-1-3">
-            <img class="isocon" alt="Complaint data" src="{% static 'complaint/img/view.png' %}">
-            <p>View, sort, and filter data right in your browser.</p>
-            <div class="btn-holder">
-              <p><a href="/data-research/consumer-complaints/search/" target="_blank" rel="noopener noreferrer" class="btn">View complaint data</a></p>
-            </div>
-          </div>
-          <div class="content-l_col content-l_col-1-3">
-            <img class="isocon" alt="Download data and access the API" src="{% static 'complaint/img/download.png' %}">
-            <p>All complaint data we publish is freely available for anyone to use, analyze, and build on.</p>
-            <div class="btn-holder">
-              <p><a href="#download-the-data" class="btn">Download options and API</a></p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="block block__border-top block__border-bottom block__padded-top block__padded-bottom block__flush-bottom">
-        <div class="section-two ccdb-landing_section content-l">
-          <div class="content-l_col content-l_col-2-3">
-            <h2>How one complaint can help millions</h2>
-            <div class="db-numbers callouts-small">
-              <p class="callout"><span class="numeric-callout percent-timely">97%</span> of complaints sent to companies get timely responses</p>
-            </div>
-            <p>By submitting a complaint, consumers can be heard by financial companies, get help with their own issues, and help others avoid similar ones. Every complaint provides insight into problems that people are experiencing,  helping us identify inappropriate practices and allowing us to stop them before they become major issues. The result: better outcomes for consumers, and a better financial marketplace for everyone.</p>
-            <p class="have-an-issue"><strong>Have an issue with a financial product or service? Add your voice. <a href="/complaint/">Submit a complaint</a>.</strong></p>
-          </div>
-          <div class="content-l_col content-l_col-1-3 db-numbers callouts-large">
-            <p class="callout"><span class="numeric-callout percent-timely">97%</span> of complaints sent to companies get timely responses</p>
-          </div>
-        </div>
-      </div>
-      <div class="block block__bg ccdb-landing_section block__flush-top block__flush-bottom">
-        <div class="content-l">
-          <div class="content-l_col content-l_col-2-3">
-            <h3>
-              Recent changes to the Consumer Complaint Database
-            </h3>
-            <p>
-              In April 2017 we updated the form consumers use to submit complaints. The changes include making some plain language improvements and reorganizing how products, sub-products, issues, and sub-issues are grouped.
-            </p>
-            <p>
-              The Consumer Complaint Database shows the consumer’s original product, sub-product, issue, and sub-issue selections consistent with the options available on the form at the time the consumer submitted the complaint.
-            </p>
-            <ul class="m-list m-list__links">
-              <li class="m-list_item">
-                <a class="a-link a-link__icon" href="https://files.consumerfinance.gov/f/documents/201704_cfpb_Summary_of_Product_and_Sub-product_Changes.pdf">
-                  <span class="a-link_text">Learn more about complaint form changes to products and sub-products</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"/><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"/></svg>
-                </a>
-              </li>
-              <li class="m-list_item">
-                <a class="a-link a-link__icon" href="https://files.consumerfinance.gov/f/documents/201704_cfpb_Consumer_Complaint_Form_Product_and_Issue_Options.pdf">
-                  <span class="a-link_text">View full list of complaint form products, sub-products, issues, and sub-issues</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"/><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"/></svg>
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="block block__border-top block__padded-top block__flush-top">
-        <div class="section-four ccdb-landing_section">
-          <h2>About the data</h2>
-          <div class="content-l">
-            <div class="content-l_col content-l_col-2-3">
-              <p>The Consumer Complaint Database is a collection of complaints on a range of consumer financial products and services, sent to companies for response. We don’t verify all the facts alleged in these complaints, but we take steps to confirm a commercial relationship between the consumer and the company.
-                <span class="publication-criteria">
-                  <a class="a-link a-link__icon" href="https://files.consumerfinance.gov/f/201303_cfpb_Final-Policy-Statement-Disclosure-of-Consumer-Complaint-Data.pdf">
-                    <span class="a-link_text">See publication criteria</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"/><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"/></svg>
-                  </a>
-                </span>
-              </p>
-              <p>Since we started accepting complaints in July 2011, we’ve helped consumers connect with financial companies to understand issues with their mortgages, fix errors on their credit reports, stop harassment from debt collectors, and get direct responses about problems with their credit cards, checking and savings accounts, student loans, and more. We analyze the data to identify trends and problems in the marketplace to help us do a better job supervising companies, enforcing federal consumer financial laws and writing rules and regulations. We publish reports on complaints and share information with state and federal agencies.</p>
-              <ul class="m-list m-list__links">
-                <li class="m-list_item">
-                  <a class="a-link" href="/complaint/data-use/#reports">
-                    <span class="a-link_text">
-                      View reports
-                    </span>
-                  </a>
-                </li>
-              </ul>
-              <p>The database generally updates daily, and contains certain information for each complaint, including the source of the complaint, the date of submission, and the company the complaint was sent to for response. The database also includes information about the actions taken by the company in response to the complaint, such as, whether the company’s response was timely and how the company responded. If the consumer opts to share it and after we take steps to remove personal information, we publish the consumer’s description of what happened. Companies also have the option to select a public response. Company level information should be considered in context of company size and/or market share. Complaints referred to other regulators, such as complaints about depository institutions with less than $10 billion in assets, are not published in the Consumer Complaint Database.</p>
-              <ul class="m-list m-list__links">
-                <li class="m-list_item">
-                  <a class="a-link" href="/complaint/data-use/">
-                    <span class="a-link_text">
-                      More on how we collect and use the data
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-      {% endif %}
       <div class="block block__border-top block__padded-top block__flush-top">
         <div class="section-five ccdb-landing_section">
           <h2 id="download-the-data">Download the data</h2>

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -40,7 +40,7 @@ class ComplaintLandingView(TemplateView):
 
         context.update({
             'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
-            'ccdb_sept_2019_updates': flag_enabled('CCDB_SEPT_2019_UPDATES'),
+            'ccdb_content_updates': flag_enabled('CCDB_CONTENT_UPDATES'),
         })
 
         return context

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -39,7 +39,8 @@ class ComplaintLandingView(TemplateView):
             context.update(self.is_ccdb_out_of_date(ccdb_status_json))
 
         context.update({
-            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES')
+            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
+            'ccdb_sept_2019_updates': flag_enabled('CCDB_SEPT_2019_UPDATES'),
         })
 
         return context

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -39,8 +39,7 @@ class ComplaintLandingView(TemplateView):
             context.update(self.is_ccdb_out_of_date(ccdb_status_json))
 
         context.update({
-            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
-            'ccdb_sept_2019_updates': flag_enabled('CCDB_SEPT_2019_UPDATES'),
+            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES')
         })
 
         return context


### PR DESCRIPTION
The September 2019 CCDB feature flag was only needed to prevent content from going live before the go-live date. That date has now passed, so the flag is no longer needed.

## Removals

- Removed the feature-flagged parts of `complaint-landing.html` 

## Changes

- Renamed the CCDB landing page feature flag to be more generic 

## Testing

1. Visit http://localhost:8000/data-research/consumer-complaints/ and make sure it matches exactly what's live at https://www.consumerfinance.gov/data-research/consumer-complaints/
2. Put some content behind the newly named `CCDB_CONTENT_UPDATES` feature flag in the landing page template
3. With the feature flag disabled, visit http://localhost:8000/data-research/consumer-complaints/ and make sure the content doesn't appear
4. Enable the `CCDB_CONTENT_UPDATES` flag, visit http://localhost:8000/data-research/consumer-complaints/ again, and make sure the feature flagged content now appears

## Screenshots

![ccdb-not-flagged](https://user-images.githubusercontent.com/1862695/66596317-a93e3d80-eb6a-11e9-83e0-2fc06860d795.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing