### PR TITLE
YES tool - Address QA feedback issues around input sanitizing

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/budget-form.html
+++ b/cfgov/jinja2/v1/youth_employment_success/budget-form.html
@@ -22,7 +22,7 @@
                    class="a-text-input o-yes-budget-earned"
                    disabled
                    placeholder="$"
-                   pattern="\D+">
+                   data-sanitize="money">
           </div>
         </div>
         <div class="u-mobile-reorder__first">
@@ -59,7 +59,7 @@
                    class="a-text-input o-yes-budget-spent"
                    disabled=""
                    placeholder="$"
-                   pattern="\D+">
+                   data-sanitize="money">
           </div>
         
           <div class="u-mobile-reorder__second">

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-cost.html
@@ -15,12 +15,12 @@
       <div class="content-l_col content-l_col-1-4 u-mt0 u-br0">
         <input type="text"
                data-js-name="averageCost"
+               data-sanitize="money"
                disabled
-               class="a-text-input u-w50pct a-average-cost"
+               class="a-text-input u-w60pct a-average-cost"
                name="yes-average-cost"
                id="yes-average-cost"
-               placeholder="$"
-               pattern="\D+">
+               placeholder="$">
       </div>
       <div class="content-l_col u-mt5 a-yes-inline-radio">
         {{

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
@@ -12,7 +12,7 @@
         'type': 'text',
         'value': '',
         'disabled': true,
-        'pattern': "\D+"
+        'data_sanitize': 'number'
       })
     }}
     {{

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/input.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/input.html
@@ -8,26 +8,27 @@
 
   ==========================================================================
 
-  Description:   Builds form text field.
+  Description:        Builds form text field.
 
-  label:         Name of the field.
+  label:              Name of the field.
 
-  type:          Type of field. Will default to text, but can change to other
-                 types to take advantage of HTML5 validation.
-                 Possible fields: text, tel, email, url, number, date.
+  type:               Type of field. Will default to text, but can change to other
+                      types to take advantage of HTML5 validation.
+                      Possible fields: text, tel, email, url, number, date.
 
-  size:          The size of the field. Defaults to 1 (full-width).
-                 Possible options: 1, 1-2, 1-4
+  size:               The size of the field. Defaults to 1 (full-width).
+                      Possible options: 1, 1-2, 1-4
 
-  required:      Whether the field is required. Defaults to false.
+  required:           Whether the field is required. Defaults to false.
 
-  disabled:      Whether the field is disabled. Defaults to false.
+  disabled:           Whether the field is disabled. Defaults to false.
 
-  data_js_name:  Friendly name for JS to hook into.
+  data_js_name:       Friendly name for JS to hook into.
 
-  class:         Optional CSS classes to apply to the element
+  data_js_sanitize:   Sanitizer function to be run on the field
 
-  pattern:       Optional HTML5 validation regexp
+  class:              Optional CSS classes to apply to the element
+
 
   ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}
@@ -54,11 +55,11 @@
           type="{{ value.type }}"
           value="{{ value.value }}"
           {{ 'data-js-name=' ~ value.data_js_name ~ '' if value.data_js_name else '' }}
+          {{ 'data-sanitize=' ~ value.data_sanitize ~ '' if value.data_sanitize else ''}}
           {{ 'required' if value.required else '' }}
           {{ 'disabled' if value.disabled else ''}}
           {{ 'aria-describedby="' ~ ht_id ~ '"' if value.helperText else '' }}
-          {{ 'placeholder="' ~ value.placeholder ~ '"' if value.placeholder else '' }}
-          {{ 'pattern=' ~ value.pattern ~ '' if value.pattern else ''}}>
+          {{ 'placeholder="' ~ value.placeholder ~ '"' if value.placeholder else '' }}>
    </input>
 </div>
 

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
@@ -13,7 +13,7 @@
         'type': 'text',
         'value': '',
         'disabled': true,
-        'pattern': "\D+"
+        'data_sanitize': 'number'
       })
     }}
     {{ 

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
@@ -18,7 +18,7 @@
                    name="transitTimeHours"
                    class="a-text-input u-mt0 u-w60pct js-yes-hours"
                    disabled
-                   pattern="\D+">
+                   data-sanitize="number">
           </div>
           <div class="content-l_col content-l_col-1-4 u-mt0 js-transit-minutes">
             <label for="yes-transit-time-minutes" class="a-label a-label__heading">
@@ -29,7 +29,7 @@
                    name="transitTimeMinutes"
                    class="a-text-input u-mt0 u-w60pct js-yes-minutes"
                    disabled
-                   pattern="\D+">
+                   data-sanitize="number">
           </div>
         </div>
       </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/js/sanitizers/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/sanitizers/index.js
@@ -1,4 +1,4 @@
-const MONEY_REGEXP = /[^\d+\.{1}\d+]/;
+const MONEY_REGEXP = /[^\d+\.{1}\d+]|[\.]*$/;
 const DIGITS_ONLY_REGEXP = /\D+/;
 
 /**

--- a/cfgov/unprocessed/apps/youth-employment-success/js/sanitizers/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/sanitizers/index.js
@@ -1,0 +1,95 @@
+const MONEY_REGEXP = /[^\d+\.{1}\d+]/;
+const DIGITS_ONLY_REGEXP = /\D+/;
+
+/**
+ * Removes all leading zeros from a string with more than 1 character.
+ * @param {String} str The string to strip
+ * @returns {String} The string with leading zeros removed
+ */
+function stripLeadingZeros( str ) {
+  if ( str.length && str.length > 1 ) {
+    let index = 0;
+
+    while ( index < str.length ) {
+      const char = str[index];
+
+      if ( char !== '0' ) {
+        return str.slice( index );
+      }
+
+      index += 1;
+    }
+  }
+
+  return str;
+}
+
+/**
+ * Remove invalid characters from a string
+ * @param {RegExp} matcher A regular expression that represents the values to be stripped from a string
+ * @returns {Function} Curried function that accepts a string to be updated
+ */
+function stripInvalidChars( matcher ) {
+  return function strip( str ) {
+    const stripped = str.replace( matcher, '' );
+    return stripped;
+  };
+}
+
+/**
+ * Truncate a string to a number of places following a decimal point
+ * @param {Number} length The number of places to truncate to
+ * @returns {Function} Curried function that accepts a string to be truncated
+ */
+function truncateTo( length ) {
+  return function truncater( str ) {
+    const decimalIndex = str.indexOf( '.' );
+    const whole = str.slice( 0, decimalIndex );
+    const decimal = str.slice( decimalIndex );
+
+    if ( decimal.length > length + 1 ) {
+      return `${ whole }${ decimal.slice( 0, length + 1 ) }`;
+    }
+
+    return str;
+  };
+}
+
+const stripNonDigitChars = stripInvalidChars( new RegExp( DIGITS_ONLY_REGEXP, 'g' ) );
+const stripNonMoneyChars = stripInvalidChars( new RegExp( MONEY_REGEXP, 'g' ) );
+const truncateTo2 = truncateTo( 2 );
+
+const _moneySanitizers = [
+  stripLeadingZeros,
+  stripNonMoneyChars,
+  truncateTo2
+];
+const _numberSanitizers = [
+  stripLeadingZeros,
+  stripNonDigitChars
+];
+
+/**
+ * Sanitize a string by reducing it through the function chain in _moneySanitizers
+ * @param {String} str The string to sanitize
+ * @returns {String} The sanitized string
+ */
+function sanitizeMoney( str ) {
+  return _moneySanitizers.reduce( ( memo, sanitizer ) => sanitizer( memo ), str );
+}
+
+/**
+ * * Sanitize a string by reducing it through the function chain in _numberSanitizers
+ * @param {String} str The string to sanitize
+ * @returns {String} The sanitized string
+ */
+function sanitizeNumbers( str ) {
+  return _numberSanitizers.reduce( ( memo, sanitizer ) => sanitizer( memo ), str );
+}
+
+const sanitizeMap = {
+  money: sanitizeMoney,
+  number: sanitizeNumbers
+};
+
+export default sanitizeMap;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -205,6 +205,22 @@ function toggleCFNotification( node, doShow ) {
   }
 }
 
+/**
+ * Right-pad a string with some number of zeros
+ * @param {String} str The string to convert to a fixed precision number
+ * @param {Number} precision The number of places after the decimal to truncate to
+ * @returns {String} A new string with the correct precision
+ */
+function toPrecision( str = '', precision = 0 ) {
+  const num = Number( str );
+
+  if ( !isNumber( num ) ) {
+    throw new Error( 'First argument must be a number.' );
+  }
+
+  return String( ( Math.round( ( num * 1000 ) / 10 ) / 100 ).toFixed( precision ) );
+}
+
 export {
   actionCreator,
   assign,
@@ -212,6 +228,7 @@ export {
   entries,
   isNumber,
   toArray,
+  toPrecision,
   toggleCFNotification,
   UNDEFINED
 };

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/average-cost.js
@@ -7,7 +7,7 @@ import {
   updateIsMonthlyCostAction
 } from '../reducers/route-option-reducer';
 import inputView from './input';
-import { toArray } from '../util';
+import { toArray, toPrecision } from '../util';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'm-yes-average-cost',
@@ -116,13 +116,19 @@ function averageCostView( element, { store, routeIndex, todoNotification } ) {
     }
   }
 
+  function _handleBlur( { event, value } ) {
+    event.target.value = toPrecision( value, 2 );
+    _handleAverageCostUpdate( { event, value: event.target.value } );
+  }
+
   /**
    * Initial the input elements this view manages.
    */
   function _initInputs() {
     inputView( _averageCostEl, {
       events: {
-        input: _handleAverageCostUpdate
+        input: _handleAverageCostUpdate,
+        blur: _handleBlur
       }
     } ).init();
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/input.js
@@ -1,5 +1,6 @@
 import { assign, entries } from '../util';
 import { setInitFlag } from '../../../../js/modules/util/atomic-helpers';
+import sanitizeMap from '../sanitizers';
 
 const defaultProps = {
   type: 'text'
@@ -64,15 +65,12 @@ function inputView( element, props = {} ) {
    * @returns {String} The sanitized input
    */
   function _sanitizeTextInput( target ) {
-    if ( _finalProps.type === 'text' ) {
-      if ( target.getAttribute( 'pattern' ) ) {
-        const pattern = new RegExp( target.getAttribute( 'pattern' ), 'g' );
-        const sanitized = target.value.replace( pattern, '' );
+    const sanitizeType = target.getAttribute( 'data-sanitize' );
+    const sanitizeMethod = sanitizeMap[sanitizeType];
 
-        target.value = sanitized;
-
-        return sanitized;
-      }
+    if ( sanitizeMethod ) {
+      const sanitized = sanitizeMethod( target.value );
+      target.value = sanitized;
     }
 
     return target.value;

--- a/test/unit_tests/apps/youth-employment-success/js/input-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/input-view-spec.js
@@ -72,9 +72,9 @@ describe( 'InputView', () => {
     } );
 
     describe( 'sanitizing data', () => {
-      it( 'removes data that does not match the pattern when pattern attribute is present', () => {
+      it( 'removes data that is not valid when `data-sanitize` attribute is present', () => {
         document.body.innerHTML = `
-          <input type="text" pattern="\\D+">
+          <input type="text" data-sanitize="money">
         `;
 
         const input = document.querySelector( 'input' );
@@ -82,7 +82,7 @@ describe( 'InputView', () => {
 
         input.value = '-122';
 
-        simulateEvent( 'blur', input );
+        simulateEvent( 'change', input );
 
         expect( input.value ).toBe( '122' );
         expect( mockHandler.mock.calls[0][0].value ).toBe( '122' );

--- a/test/unit_tests/apps/youth-employment-success/js/sanitizers/sanitizer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/sanitizers/sanitizer-spec.js
@@ -10,6 +10,11 @@ describe( 'exposed sanitize functions', () => {
       expect( moneySanitizer( badMoney ) ).toBe( '122.3' );
     } );
 
+    it('only allows for a single decimal place', () => {
+      const badMoney = '12.2.';
+      expect(moneySanitizer(badMoney)).toBe('12.2');
+    });
+
     it( 'removes all leading zeros from a number', () => {
       expect( moneySanitizer( '000000100.11' ) ).toBe( '100.11' );
     } );

--- a/test/unit_tests/apps/youth-employment-success/js/sanitizers/sanitizer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/sanitizers/sanitizer-spec.js
@@ -1,0 +1,33 @@
+import sanitizeMap from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/sanitizers';
+
+describe( 'exposed sanitize functions', () => {
+  describe( 'money', () => {
+    const moneySanitizer = sanitizeMap['money'];
+
+    it( 'strips all chars that are not numbers or a decimal', () => {
+      const badMoney = 'aasdas12$2.3#';
+
+      expect( moneySanitizer( badMoney ) ).toBe( '122.3' );
+    } );
+
+    it( 'removes all leading zeros from a number', () => {
+      expect( moneySanitizer( '000000100.11' ) ).toBe( '100.11' );
+    } );
+
+    it( 'truncates any numbers over a decimal precision of 2', () => {
+      expect( moneySanitizer( '100.111' ) ).toBe( '100.11' );
+    } );
+  } );
+
+  describe( 'any other number', () => {
+    const numberSanitizer = sanitizeMap['number'];
+
+    it( 'strips all leading zeros', () => {
+      expect( numberSanitizer( '000001' ) ).toBe( '1' );
+    } );
+
+    it( 'removes all characters that are not digits', () => {
+      expect( numberSanitizer( '@#Fd,,/:jfsjdhs2d' ) ).toBe( '2' );
+    } );
+  } );
+} );

--- a/test/unit_tests/apps/youth-employment-success/js/util-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/util-spec.js
@@ -5,6 +5,7 @@ import {
   combineReducers,
   entries,
   toArray,
+  toPrecision,
   toggleCFNotification
 } from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
 
@@ -205,6 +206,30 @@ describe( 'YES utility functions', () => {
       toggleCFNotification( el, false );
 
       expect( el.classList.contains( 'm-notification__visible' ) ).toBeFalsy();
+    } );
+  } );
+
+  describe( '.toPrecision', () => {
+    it( 'throws an error when a string that cannot be converted to a number is supplied', () => {
+      expect( () => toPrecision( 'string' )
+      ).toThrow();
+    } );
+
+    it( 'returns the original number when a precision is not specified', () => {
+      const num = '100';
+      expect( toPrecision( num ) ).toBe( num );
+    } );
+
+    it( 'returns a string of 0 when no arguments are supplied', () => {
+      expect( toPrecision() ).toBe( '0' );
+    } );
+
+    it( 'adds a number of zeros to the end of a string commesurate with the value supplied as the second argument', () => {
+      const string = '100.';
+
+      expect( toPrecision( string, 3 ) ).toBe( '100.000' );
+      expect( toPrecision( '100.1', 2 ) ).toBe( '100.10' );
+      expect( toPrecision( '100.00', 2 ) ).toBe( '100.00' );
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/average-cost-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/average-cost-spec.js
@@ -13,8 +13,10 @@ const HTML = `
   <div class="content-l content-l_col-2-3 block__sub-micro m-yes-average-cost">
       <div class="form-l_col form-l_col-1-4">
       <label class="a-label a-label__heading u-mb0" for="input_37b566d867b4ec_what's-the-average-cost">
-          What's the average cost?</label><p id="input_ht_37b566d867b67e_what's-the-average-cost"><small>If it's free, enter 0</small></p><input id="input_37b566d867b4ec_what's-the-average-cost" name="input_37b566d867b4ec_what's-the-average-cost" type="text" value="" data-js-name="averageCost" aria-describedby="&quot;input_ht_37b566d867b67e_what's-the-average-cost&quot;" class="">
-      
+        What's the average cost?
+      </label>
+      <p id="input_ht_37b566d867b67e_what's-the-average-cost"><small>If it's free, enter 0</small></p>
+      <input id="input_37b566d867b4ec_what's-the-average-cost" name="input_37b566d867b4ec_what's-the-average-cost" type="text" value="" data-js-name="averageCost" data-sanitize="money" class="">
     </div>
       <div class="m-form-field m-form-field__radio a-yes-average-cost">
         <input class="a-radio" type="radio" value="daily" id="input_37b566d867baf2_daily" name="average-cost">
@@ -77,6 +79,15 @@ describe( 'averageCostView', () => {
       } )
     );
   } );
+
+  it('sets the correct precision on blur', () => {
+    const costEl = document.querySelector( 'input[type="text"]' );
+    costEl.value = '12.03000';
+
+    simulateEvent('blur', costEl);
+
+    expect(costEl.value).toBe('12.03');
+  });
 
   it( 'dispatches the correct action when a radio button is selected', () => {
     const radioEls = document.querySelectorAll( `.${ CLASSES.RADIO }` );


### PR DESCRIPTION
To better improve user experience, the follow changes are being made to the input sanitization

## Changes

* Sanitizing is now a more robust chain of functions vs. a single pattern
* Strip leading zeros from all numbers
* Allow decimals back in
* Format all money numbers to a fixed decimal precision of 2

## Testing

1. Specs
2. Inputs should behave as outlined in specs when data is manually entered.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
