### PR TITLE
YES Tool — Use actual daysPerWeek value input by user

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -45,15 +45,10 @@ function updateTodoList( todos = [] ) {
   return fragment;
 }
 
-/* Assuming days per week for a transportation option to be 5 days per week.
-   This could easily not be accurate as people frequently have weekend jobs,
-   multiple shifts etc, but should work for now. */
-const FULL_TIME_DAYS = 5;
-
 const DEFAULT_COST_ESTIMATE = '0';
 
 // Rough estimate to account for weeks that have more or less days
-const WEEKLY_COST_MODIFIER = 4.2;
+const WEEKLY_COST = 4.0;
 
 // This number will be pulled from a data set, for now, its magic
 const ESTIMATED_COST_PER_MILE = 1.8;
@@ -83,7 +78,7 @@ function getCalculationFn( route ) {
     return averageCost;
   }
 
-  return calculatePerMonthCost( averageCost, FULL_TIME_DAYS );
+  return calculatePerMonthCost( averageCost, daysPerWeek );
 }
 
 /**
@@ -91,7 +86,7 @@ function getCalculationFn( route ) {
  * @param {string} numberOfMiles Number of miles user expects to drive each day
  * @returns {Number} The cost, in dollars, of driving each day
  */
-function calculateDrivingDailyCost( numberOfMiles = '0' ) {
+function calculateDrivingDailyCost( numberOfMiles = 0 ) {
   return money.toDollars(
     parseFloat( numberOfMiles ) * ESTIMATED_COST_PER_MILE
   );
@@ -113,7 +108,7 @@ function calculatePerMonthCost( dailyCost, daysPerWeek ) {
   return money.toDollars(
     money.toDollars( dailyCost ) *
     normalizedDays *
-    WEEKLY_COST_MODIFIER
+    WEEKLY_COST
   );
 }
 

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -116,7 +116,7 @@ describe( 'routeDetailsView', () => {
 
         const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
 
-        expect( totalCostEl.textContent ).toBe( '454' );
+        expect( totalCostEl.textContent ).toBe( '432' );
       } );
 
       it( 'correctly calculates monthly cost', () => {
@@ -151,10 +151,10 @@ describe( 'routeDetailsView', () => {
 
         const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
 
-        expect( totalCostEl.textContent ).toBe( '210' );
+        expect( totalCostEl.textContent ).toBe( '120' );
       } );
 
-      it( 'updates its total cost value using a presumed 5 days per week if daysPerWeek are not supplied', () => {
+      it( 'does not update the total cost if daysPerWeek is not supplied', () => {
         const state = {
           budget: { ...nextState.budget },
           route: {
@@ -169,7 +169,26 @@ describe( 'routeDetailsView', () => {
 
         const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
 
-        expect( totalCostEl.textContent ).toBe( '210' );
+        expect( totalCostEl.textContent ).toBe( '0' );
+      } );
+
+      it( 'updates total cost properly when daysPerWeek is supplied', () => {
+        const state = {
+          budget: { ...nextState.budget },
+          route: {
+            ...nextState.route,
+            transportation: 'Walk',
+            isMonthlyCost: false,
+            daysPerWeek: 2,
+            averageCost: '100'
+          }
+        };
+
+        view.render( state );
+
+        const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
+
+        expect( totalCostEl.textContent ).toBe( '800' );
       } );
     } );
 
@@ -178,7 +197,7 @@ describe( 'routeDetailsView', () => {
 
       const budgetLeftEl = document.querySelector( `.${ CLASSES.BUDGET_REMAINING }` );
 
-      expect( budgetLeftEl.textContent ).toBe( '-379' );
+      expect( budgetLeftEl.textContent ).toBe( '-357' );
     } );
 
     it( 'updates the time in hours', () => {


### PR DESCRIPTION
Due to a code oversight, the current uses a default of 5 days per week to calculate the total monthly cost of the user's selected transportation option. This PR removes the default and fills in a `0` unless the user specifically indicates the number of days per week they expect to make their commute.

## Removals

- Removes default days per week value

## Changes

- Calculations for a full month are now multiplied by a straight `4`, instead of a slightly higher value to accommodate months that may have 5 weeks.

## Testing

1. Specs pass
2. In the tool, the estimated cost line item should be 0 unless the days per week field is filled in, or the average cost is a monthly cost.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
