### PR TITLE
YES tool — Adds missing rideshare transportation option

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/route-option-form.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-option-form.html
@@ -1,6 +1,6 @@
 {% from 'atoms/radio-button.html' import render with context %}
 {% import 'alert.html' as alert with context %}
-{% set labels = ['Walk', 'Drive', 'Bike', 'Public transit', 'Get dropped off'] %}
+{% set labels = ['Walk', 'Drive', 'Bike', 'Public transit', 'Rideshare or cab', 'Get dropped off'] %}
 
 <form class="o-yes-route-option" autocomplete="new-password">
   <span class="a-label__heading u-mb0">

--- a/cfgov/unprocessed/apps/youth-employment-success/js/data/transportation-map.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/data/transportation-map.js
@@ -1,18 +1,20 @@
-const transportation = Object.freeze( {
+const TRANSPORTATION = Object.freeze( {
   WALK: 'Walk',
   DRIVE: 'Drive',
   BIKE: 'Bike',
   PUBLIC_TRANSIT: 'Public transportation',
-  DROPPED_OFF: 'Get dropped off'
+  DROPPED_OFF: 'Get dropped off',
+  RIDESHARE: 'Rideshare or cab'
 } );
 
 const transportationMap = Object.freeze( {
-  'Walk': 'walking',
-  'Drive': 'driving',
-  'Bike': 'biking',
-  'Public transit': 'public transit',
-  'Get dropped off': 'getting dropped off'
+  [TRANSPORTATION.WALK]: 'walking',
+  [TRANSPORTATION.DRIVE]: 'driving',
+  [TRANSPORTATION.BIKE]: 'biking',
+  [TRANSPORTATION.PUBLIC_TRANSIT]: 'public transit',
+  [TRANSPORTATION.DROPPED_OFF]: 'getting dropped off',
+  [TRANSPORTATION.RIDESHARE]: 'rideshare or cab'
 } );
 
-export { transportation };
+export { TRANSPORTATION };
 export default transportationMap;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -6,7 +6,7 @@ import {
 import TodoNotification from './todo-notification';
 import inputView from './views/input';
 import { toArray } from './util';
-import { transportation } from './data/transportation-map';
+import { TRANSPORTATION } from './data/transportation-map';
 
 const CLASSES = Object.freeze( {
   FORM: 'o-yes-route-option',
@@ -59,7 +59,7 @@ function RouteOptionFormView( element, {
   function _updateToolTip( transportationOption ) {
     const tooltip = _dom.querySelector( `.${ CLASSES.DISCOUNT }` );
 
-    if ( transportationOption === transportation.WALK ) {
+    if ( transportationOption === TRANSPORTATION.WALK ) {
       tooltip.classList.add( 'u-hidden' );
     } else {
       tooltip.classList.remove( 'u-hidden' );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/driving-cost-estimate.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/driving-cost-estimate.js
@@ -1,5 +1,5 @@
 import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
-import { transportation } from '../data/transportation-map';
+import { TRANSPORTATION } from '../data/transportation-map';
 
 const CLASSES = {
   CONTAINER: 'js-driving-estimate',
@@ -26,7 +26,7 @@ function drivingCostEstimate( element ) {
       }
     },
     render( route ) {
-      if ( route.transportation === transportation.DRIVE ) {
+      if ( route.transportation === TRANSPORTATION.DRIVE ) {
         _dom.classList.remove( 'u-hidden' );
         // Magic number for now, until we get an actual average cost
         _costPerMileEl.textContent = '$1.80';

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/details.js
@@ -57,11 +57,11 @@ function reviewDetailsView( element, { store, routeDetailsView } ) {
    */
   function _handleStateUpdate( _, state ) {
     const otherRoutes = state.routes.routes.slice();
-    const preferredRoute = otherRoutes.splice( state.routeChoice );
-    const routes = preferredRoute.concat( otherRoutes );
+    const preferredRoute = otherRoutes.splice( state.routeChoice, 1 );
+    const finalRoutes = preferredRoute.concat( otherRoutes );
 
     _detailsViews.forEach( ( view, index ) => {
-      const route = routes[index] || {};
+      const route = finalRoutes[index] || {};
 
       if ( Object.keys( route ).length ) {
         const transporationDesc = transportationMap[route.transportation];


### PR DESCRIPTION
Adds option for `rideshare` in transportation options 

## Additions

- Adds ridesahre option
 
## Testing

1. Specs
2. `Rideshare or cab` should be a selectable mode of transportation; it behaves the same as the non `Drive` options


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
