### PR TITLE
Prepaid: fix blank search 500s

### DIFF
--- a/cfgov/prepaid_agreements/tests/test_views.py
+++ b/cfgov/prepaid_agreements/tests/test_views.py
@@ -15,6 +15,13 @@ from prepaid_agreements.views import (
 class TestViews(TestCase):
 
     def test_get_available_filters(self):
+        products = PrepaidProduct.objects
+
+        self.assertEqual(
+            get_available_filters(products),
+            {'prepaid_type': [], 'status': [], 'issuer_name': []}
+        )
+
         product1 = PrepaidProduct(
             issuer_name='Bank of CFPB',
             prepaid_type='Tax'
@@ -22,7 +29,6 @@ class TestViews(TestCase):
         product1.save()
         product2 = PrepaidProduct(prepaid_type='Travel')
         product2.save()
-        products = PrepaidProduct.objects.all()
         self.assertEqual(
             get_available_filters(products),
             {

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -32,7 +32,7 @@ def validate_page_number(request, paginator):
 
 def get_available_filters(products):
     available_filters = {'prepaid_type': [], 'status': [], 'issuer_name': []}
-    for product in products:
+    for product in products.all():
         prepaid_type = product.prepaid_type
         if prepaid_type and prepaid_type != '':
             if prepaid_type not in available_filters['prepaid_type']:


### PR DESCRIPTION
A blank search of prepaid agreements (/data-research/prepaid-accounts/search-agreements/) currently results in a 500 error. This PR fixes that.

This is because the `get_available_filters` is being passed `products` as a `Manager` object that's empty. Attempting to iterate it will raise a `TypeError`. This means blank searches will 500. This fix uses `products.all()` when iterating over the manager passed to `get_available_filters` that results from searching products.

It also fixes the test to catch this issue. This function gets the queryset in code but was getting `objects.all()` in the test.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
