### PR TITLE
YES tool — Fixes bug where to-do list was cleared on single item removal

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/data/todo-items.js
@@ -6,10 +6,10 @@ const PLAN_TYPES = Object.freeze( {
 } );
 
 const ACTION_PLAN = Object.freeze( {
-  AVERAGE_COST: 'average cost',
-  DAYS_PER_WEEK: 'days per week',
-  MILES: 'miles',
-  TIME: 'Look up how to estimate transit time.'
+  AVERAGE_COST: 'Look up average daily cost.',
+  DAYS_PER_WEEK: 'Find out how many days per week you\'ll make this trip.',
+  MILES: ' Look up how many miles you drive each day.',
+  TIME: ' Look up how long this trip takes.'
 } );
 
 /**

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -126,7 +126,7 @@ function updateActionPlan( state, routeIndex, itemType, doUpdate ) {
   const actionPlan = todoListSelector( state, routeIndex );
 
   if ( !doUpdate ) {
-    actionPlan.splice( actionPlan.indexOf( itemType ) );
+    actionPlan.splice( actionPlan.indexOf( itemType ), 1 );
 
     return actionPlan.slice();
   }

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -194,6 +194,26 @@ describe( 'routeOptionReducer', () => {
       expect( nextState.routes[0].transitTimeHours ).toBe( '1' );
     } );
 
+    it( 'properly reduces the state of the actionPlanItems list', () => {
+      const state = routeOptionReducer(
+        {
+          routes: [
+            createRoute( {
+              actionPlanItems: [ PLAN_TYPES.TIME, PLAN_TYPES.MILES ]
+            } )
+          ]
+        },
+        updateTimeToActionPlan( {
+          routeIndex: 0,
+          value: false } )
+      );
+
+      const todos = routeSelector( state, 0 ).actionPlanItems;
+
+      expect( todos.length ).toBe( 1 );
+      expect( todos[0] ).toBe( PLAN_TYPES.MILES );
+    } );
+
     it( 'reduces the .updateTimeToActionPlan action', () => {
       const state = routeOptionReducer(
         initial,

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -246,6 +246,33 @@ describe( 'routeDetailsView', () => {
       expect( todoItemsEl.querySelectorAll( 'li' ).length ).toBe( 0 );
     } );
 
+    it.only( 'does not hide the to-do list when an item is removed and there are remaining items', () => {
+      const state = {
+        budget: { ...nextState.budget },
+        route: {
+          ...nextState.route,
+          actionPlanItems: nextState.route.actionPlanItems.concat( [ PLAN_TYPES.MILES ] )
+        }
+      };
+
+      view.render( state );
+
+      const todosEl = document.querySelector( `.${ CLASSES.TODO_LIST }` );
+      const todoItemsEl = document.querySelector( `.${ CLASSES.TODO_ITEMS }` );
+
+      expect( todoItemsEl.querySelectorAll( 'li' ).length ).toBe( 2 );
+
+      view.render( {
+        budget: { ...state.budget },
+        route: {
+          ...state.route,
+          actionPlanItems: [ PLAN_TYPES.MILES ]
+        }
+      } );
+
+      expect( todosEl.classList.contains( 'u-hidden' ) ).toBeFalsy();
+    } );
+
     it( 'shows the out of budget alert when the route is out of budget', () => {
       const state = {
         budget: { earned: '1', spent: '100' },


### PR DESCRIPTION
Previously, with multiple items in the to-do list, clearing one item would clear out the entire list. Now users can toggle list items and be confident that only the toggled item is getting removed.

## Changes

- Added the second argument to `splice` in the `updateActionPlan` method of the `route-option-reducer`, the reducer will now correctly remove a single item.


## Testing

1. Specs
2. In the transportation tool, select 2 or more `not sure` checkboxes. Then, deselect one. The to-do list section should remain visible, and correctly reflect the number of checked items.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
