### PR TITLE
Paying for college: Fix the https URL of S3 resources

### DIFF
--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -217,7 +217,7 @@ def load(source, s3=False):
     updated_programs = 0
     FAILED = []  # failed messages
     if s3:
-        s3_url = ('https://s3.amazonaws.com/files.consumerfinance.gov'
+        s3_url = ('https://files.consumerfinance.gov'
                   '/pb/paying_for_college/csv/validated_program_data/{}')
         raw_data = read_in_s3(s3_url.format(source))
     else:

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -217,7 +217,7 @@ def load(source, s3=False):
     updated_programs = 0
     FAILED = []  # failed messages
     if s3:
-        s3_url = ('https://files.consumerfinance.gov.s3.amazonaws.com'
+        s3_url = ('https://s3.amazonaws.com/files.consumerfinance.gov'
                   '/pb/paying_for_college/csv/validated_program_data/{}')
         raw_data = read_in_s3(s3_url.format(source))
     else:


### PR DESCRIPTION
In September we changed some http URLs used in code to https.
Most of the changes were good as-is, but one related to an S3 resource made
a Jenkins job fail, because the S3 URL was not designed to be used with https.

In this case, the old URL was:
`http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/validated_program_data/[SLUG]`

Using that URL with https raises a certificate error when a Jenkins job requests it.

The https form that we can use (as pointed out by @rosskarchner) is:
`https://s3.amazonaws.com/files.consumerfinance.gov/pb/paying_for_college/csv/validated_program_data/[SLUG]`

## Testing
To load an S3 resource locally and confirm that the S3 file is fetched using https without error, run
```bash
./cfgov/manage.py load_programs --s3 true CFPB_EDMC_20191017.csv
```

You should get an echo saying:
```bash
0 programs created. 2 programs updated.
```
