### PR TITLE
YES tool — Bug roundup

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
+++ b/cfgov/jinja2/v1/youth_employment_success/review/your-plan.html
@@ -18,7 +18,7 @@
     <div class="js-review-choice-heading">
       <p class="h3">Another possible option: <span class="js-transportation-option"></span></p>
       <p class="u-mb0">
-        <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
+        <p>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</p>
       </p>
     </div>
     <div class="block block__sub block__flush-bottom">

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -235,7 +235,7 @@ input:-moz-ui-invalid {
 }
 
 .highlight {
-  background-color: #f9f9f9;
+  background-color: #f7f8f9;
   padding: unit( 12px / @base-font-size-px, em );
 
   .respond-to-print({

--- a/cfgov/unprocessed/apps/youth-employment-success/js/sanitizers/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/sanitizers/index.js
@@ -120,4 +120,7 @@ const sanitizeMap = {
   number: sanitizeNumbers
 };
 
+export {
+  addCommas
+};
 export default sanitizeMap;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -1,3 +1,5 @@
+import { addCommas } from './sanitizers';
+
 let UNDEFINED;
 
 const REDUCER_RETURN_ERROR = 'Reducer must return a state object';
@@ -227,7 +229,7 @@ function toPrecision( value = '', precision = 0 ) {
     throw new Error( 'First argument must be a number.' );
   }
 
-  return String( ( Math.round( ( safeValue * 1000 ) / 10 ) / 100 ).toFixed( precision ) );
+  return addCommas( String( ( Math.round( ( safeValue * 1000 ) / 10 ) / 100 ).toFixed( precision ) ) );
 }
 
 function formatNegative( num ) {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/goals.js
@@ -43,7 +43,16 @@ function reviewGoalsView( element, { store } ) {
     const goals = state.goals;
     let shouldUpdate = false;
 
+    if (!Object.keys(prevGoals).length) {
+      return true;
+    }
+
     for ( const goal in prevGoals ) {
+      if (!prevGoals) {
+        shouldUpdate = true;
+        return shouldUpdate;
+      }
+
       if ( prevGoals.hasOwnProperty( goal ) ) {
         const prevGoalContent = prevGoals[goal];
         const goalContent = goals[goal];

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/goals.js
@@ -48,11 +48,6 @@ function reviewGoalsView( element, { store } ) {
     }
 
     for ( const goal in prevGoals ) {
-      if ( !prevGoals ) {
-        shouldUpdate = true;
-        return shouldUpdate;
-      }
-
       if ( prevGoals.hasOwnProperty( goal ) ) {
         const prevGoalContent = prevGoals[goal];
         const goalContent = goals[goal];

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/review/goals.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/review/goals.js
@@ -43,12 +43,12 @@ function reviewGoalsView( element, { store } ) {
     const goals = state.goals;
     let shouldUpdate = false;
 
-    if (!Object.keys(prevGoals).length) {
+    if ( !Object.keys( prevGoals ).length ) {
       return true;
     }
 
     for ( const goal in prevGoals ) {
-      if (!prevGoals) {
+      if ( !prevGoals ) {
         shouldUpdate = true;
         return shouldUpdate;
       }
@@ -80,7 +80,7 @@ function reviewGoalsView( element, { store } ) {
         if ( _goalsMap.hasOwnProperty( attr ) ) {
           const el = _goalsMap[attr];
 
-          el.innerHTML = goals[attr];
+          el.innerHTML = goals[attr] || '';
         }
       }
     }

--- a/cfgov/unprocessed/apps/youth-employment-success/webpack.config.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/webpack.config.js
@@ -73,7 +73,7 @@ const conf = {
   mode: 'production',
   output: {
     filename: '[name]',
-    jsonpFunction: 'oah'
+    jsonpFunction: 'yes'
   },
   resolveLoader: {
     alias: {

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/details-spec.js
@@ -23,7 +23,7 @@ const HTML = `
   <div class="block block__sub">
     <div class="${ CLASSES.CHOICE_HEADING }">
       <p class="h3">Another option you compared: <span class="js-transportation-option"></span></p>
-      <small>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</small>
+      <p>Depending on whether this fits in your budget and schedule, this could be a backup plan if you’re in a bind and your first choice doesn’t work out.</p>
     </div>
     <div class="yes-route-details">
       <div class="js-route-notification block block__sub-micro block__flush-top u-hidden"></div>

--- a/test/unit_tests/apps/youth-employment-success/js/views/review/goals-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/review/goals-spec.js
@@ -77,4 +77,29 @@ describe( 'reviewGoalsView', () => {
       expect( el.textContent ).toBe( expected );
     } );
   } );
+
+  it( 'updates when prevState has not been populated', () => {
+    const prevState = { goals: null };
+    const state = {
+      goals: {
+        longTermGoal: 'goal',
+        goalImportance: 'very',
+        goalSteps: 'several',
+        goalTimeline: '3 to 6 months'
+      }
+    };
+
+    let els = toArray( document.querySelectorAll( `.${ reviewGoalsView.CLASSES.GOAL }` ) );
+
+    els.forEach( el => expect( el.textContent ).toBe( '' ) );
+
+    store.subscriber()( prevState, state );
+
+    els = toArray( document.querySelectorAll( `.${ reviewGoalsView.CLASSES.GOAL }` ) );
+
+    els.forEach( el => {
+      const expected = state.goals[el.getAttribute( 'data-js-goal' )];
+      expect( el.textContent ).toBe( expected );
+    } );
+  } );
 } );


### PR DESCRIPTION
This PR fixes several bugs / design inconsistencies related to some of the new work

## Changes

- incorrect `small` tag changed to `p`
- background color for to-do list well now matches expandable background color
- `goals` in review section now updates properly on first render
- commas properly preserved when formatting money

## Testing

1. Specs
2. All money inputs should preserve commas when focus is lost
3. All money line item (totals) nodes should preserve commas
4. All money line item nodes should have two decimals places.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
