### PR TITLE
YES Tool — Conditionally hide the days per week copy

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/line-item.html
+++ b/cfgov/jinja2/v1/youth_employment_success/line-item.html
@@ -2,7 +2,9 @@
 <div class="content-l m-yes-line-item u-clearfix">
   <p class="content-l_col content-l_col-2-3 line-item line-item__content-l h4">
     {{ values.label | safe }}
-    {{ values.helperText | safe if values.helperText else '' }}
+    <span class="line-item__content-l">
+      {{ values.helperText | safe if values.helperText else '' }}
+    </span>
   </p>
   <div class="content-l_col content-l_col-1-3 u-align-right line-item line-item__content-r">
     <span>$</span>

--- a/cfgov/jinja2/v1/youth_employment_success/route/route-details.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route/route-details.html
@@ -20,7 +20,7 @@
       }}
       {{
         line_item.render({
-          'helperText': '<br/><small class="a-label a-label_helper">Based on <span class="js-days-per-week"></span> days a week you will make this trip</small>',
+          'helperText': '<span class="js-average-cost-helper"><br/><small class="a-label a-label_helper">Based on <span class="js-days-per-week"></span> days a week you will make this trip</small></span>',
           'label': 'Average monthly cost of <span class="js-transportation-type"></span>',
           'target': 'js-total-cost'
         })

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -8,6 +8,7 @@ import transportationMap from '../data-types/transportation-map';
 import validate from '../validators/route-option';
 
 const CLASSES = Object.freeze( {
+  AVERAGE_COST_HELPER: 'js-average-cost-helper',
   CONTAINER: 'yes-route-details',
   TRANSPORTATION_TYPE: 'js-transportation-type',
   BUDGET: 'js-budget',
@@ -180,6 +181,17 @@ function updateDomNode( node, nextValue ) {
   }
 }
 
+function updateNodeVisibility( node, visibility ) {
+  const predicate = typeof visibility === 'function' ?
+    visibility : () => visibility;
+
+  if ( predicate() ) {
+    node.classList.add( 'u-hidden' );
+  } else {
+    node.classList.remove( 'u-hidden' );
+  }
+}
+
 /**
  * RouteDetailsView
  * @class
@@ -195,6 +207,7 @@ function routeDetailsView( element, { alertTarget, hasDefaultTodo = false } ) {
   const _transportationEl = toArray(
     _dom.querySelectorAll( `.${ CLASSES.TRANSPORTATION_TYPE }` )
   );
+  const _averageCostHelperEl = _dom.querySelector( `.${ CLASSES.AVERAGE_COST_HELPER }` );
   const _budgetEl = _dom.querySelector( `.${ CLASSES.BUDGET }` );
   const _daysPerWeekEl = _dom.querySelector( `.${ CLASSES.DAYS_PER_WEEK }` );
   const _totalCostEl = _dom.querySelector( `.${ CLASSES.TOTAL_COST }` );
@@ -252,6 +265,7 @@ function routeDetailsView( element, { alertTarget, hasDefaultTodo = false } ) {
         _todoItemsEl, route.actionPlanItems, hasDefaultTodo
       );
 
+      updateNodeVisibility( _averageCostHelperEl, route.isMonthlyCost );
       updateDom( _transportationEl, transportationMap[route.transportation] );
       updateDom( _budgetEl,
         formatNegative(

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -36,7 +36,7 @@ const HTML = `
       </p>
       <div>
         Average monthly cost of <span class="js-transportation-type"></span>
-        <span>
+        <span class="js-average-cost-helper">
           Based on <span class="js-days-per-week"></span> days a week you will make this trip
         </span>
       </div>
@@ -131,6 +131,23 @@ describe( 'routeDetailsView', () => {
 
       expect( daysPerWeekEl.textContent ).toBe( nextState.route.daysPerWeek );
     } );
+
+    it('hides the average cost helper text when isMonthlyCost is true', () => {
+      const state = {
+        budget: { ...nextState.budget },
+        route: {
+          ...nextState.route,
+          transportation: 'Walk',
+          isMonthlyCost: true,
+          averageCost: '100'
+        }
+      };
+
+      view.render( state );
+
+      const averageCostHelperEl = document.querySelector(`.${CLASSES.AVERAGE_COST_HELPER}`);
+      expect(averageCostHelperEl.classList.contains('u-hidden')).toBeTruthy();
+    });
 
     describe( 'total costs', () => {
       it( 'correctly calculates driving cost', () => {


### PR DESCRIPTION
So the user doesn't get confused by situational text, remove the `Based on the {n} days a week you will make this trip` text when the user indicates that their average cost of getting to work is calculated on a monthly basis.

## Changes

- Hide this text when the user indicates their average cost to get to work is
a monthly cost


## Testing

1. Specs should pass
2. In a route option form, select the `monthly` radio button choice in the `average cost` fieldset
