### PR TITLE
YES tool — Updates validation, fixes reducer splice logic

### DIFF
--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -126,7 +126,11 @@ function updateActionPlan( state, routeIndex, itemType, doUpdate ) {
   const actionPlan = todoListSelector( state, routeIndex );
 
   if ( !doUpdate ) {
-    actionPlan.splice( actionPlan.indexOf( itemType ), 1 );
+    const toRemove = actionPlan.indexOf( itemType );
+
+    if ( toRemove !== -1 ) {
+      actionPlan.splice( toRemove, 1 );
+    }
 
     return actionPlan.slice();
   }
@@ -230,7 +234,7 @@ function routeOptionReducer( state = initialState, action ) {
           actionPlanItems: updateActionPlan(
             state,
             action.data.routeIndex,
-            PLAN_TYPES.DAYS,
+            PLAN_TYPES.DAYS_PER_WEEK,
             false
           )
         }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
@@ -36,6 +36,34 @@ function isFieldInActionPlan( fieldName, routeTodoList ) {
 }
 
 /**
+ * Determine is a value can be considered empty. It is empty if the value is:
+ *
+ * null
+ * undefined
+ * an empty string
+ * an empty array
+ * an empty object
+ *
+ * @param {*} value The value to be checked
+ * @returns {Boolean} If this value is empty or not
+ */
+function isEmpty( value ) {
+  if ( typeof value === 'undefined' ) {
+    return true;
+  }
+
+  if ( value === '' ) {
+    return true;
+  }
+
+  if ( value === null ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Determine if a field has a value OR is in the user's todo list of actions.
  * Fields in the to-do list do not require values.
  *
@@ -45,7 +73,10 @@ function isFieldInActionPlan( fieldName, routeTodoList ) {
  * @returns {Boolean} Whether or not the field is valid
  */
 function valueOrActionPlan( fieldName, value, actionItems ) {
-  if ( !isFieldInActionPlan( fieldName, actionItems ) && !value ) {
+  if (
+    !isFieldInActionPlan( fieldName, actionItems ) &&
+    isEmpty( value )
+  ) {
     return false;
   }
 
@@ -98,6 +129,33 @@ function isValidDriveData( { miles, daysPerWeek, actionPlanItems } ) {
 }
 
 /**
+ * Determine if a transportation mode that requires entering the averageCost
+ * and its associated fields (all modes except 'Drive') is valid
+ * @param {Object} data The data to validate
+ * @param {String} daysPerWeek The number of days the user will make the trip
+ * @param {String} averageCost The cost of the trip
+ * @param {Boolean} isMonthlyCost Whether or not the average cost is per day or per month
+ * @param {Array} actionPlanItems The current to-do list of trip unknowns
+ */
+function isValidAverageCost( { daysPerWeek, averageCost, isMonthlyCost, actionPlanItems } ) {
+  if (
+    isEmpty( averageCost ) ||
+    isEmpty( isMonthlyCost )
+  ) {
+    return false;
+  }
+
+  if (
+    !isMonthlyCost &&
+    !valueOrActionPlan( 'daysPerWeek', daysPerWeek, actionPlanItems )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Validate all data for a route
  * @param {object} data The transportation tool form data
  * @returns {Boolean} Data validity
@@ -113,6 +171,8 @@ function validate( data ) {
 
   if ( data.transportation === 'Drive' ) {
     valid = isValidDriveData( data );
+  } else {
+    valid = isValidAverageCost( data );
   }
 
   return valid;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -177,6 +177,11 @@ function updateDomNode( node, nextValue ) {
   }
 }
 
+/**
+ * Toggle the visibility of a node
+ * @param {HTMLElement} node The element to show or hide
+ * @param {Boolean} visibility Whether to show or hide the element
+ */
 function updateNodeVisibility( node, visibility ) {
   const predicate = typeof visibility === 'function' ?
     visibility : () => visibility;

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -214,6 +214,26 @@ describe( 'routeOptionReducer', () => {
       expect( todos[0] ).toBe( PLAN_TYPES.MILES );
     } );
 
+    it( 'reduces the state of actionPlanItems when a mismatching type is supplied', () => {
+      const state = routeOptionReducer(
+        {
+          routes: [
+            createRoute( {
+              actionPlanItems: [ PLAN_TYPES.TIME ]
+            } )
+          ]
+        },
+        updateMilesToActionPlan( {
+          routeIndex: 0,
+          value: false } )
+      );
+
+      const todos = routeSelector( state, 0 ).actionPlanItems;
+
+      expect( todos.length ).toBe( 1 );
+      expect( todos[0] ).toBe( PLAN_TYPES.TIME );
+    } );
+
     it( 'reduces the .updateTimeToActionPlan action', () => {
       const state = routeOptionReducer(
         initial,
@@ -358,7 +378,7 @@ describe( 'routeOptionReducer', () => {
 
       state = routeOptionReducer(
         state,
-        clearDaysPerWeekAction( { routeIndex } )
+        clearDaysPerWeekAction( { routeIndex, value: false } )
       );
 
       currRoute = routeSelector( state, routeIndex );

--- a/test/unit_tests/apps/youth-employment-success/js/validators/route-option-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/validators/route-option-spec.js
@@ -2,10 +2,12 @@ import validate from '../../../../../../cfgov/unprocessed/apps/youth-employment-
 
 describe( '.validate', () => {
   const data = {
-    earned: 1,
-    spent: 1,
-    transitTimeMinutes: 1,
-    transitTimeHours: 1,
+    earned: '1',
+    spent: '1',
+    averageCost: '1',
+    isMonthlyCost: true,
+    transitTimeMinutes: '1',
+    transitTimeHours: '1',
     transportation: 'Walk',
     actionPlanItems: []
   };
@@ -13,6 +15,13 @@ describe( '.validate', () => {
   it( 'validates data to true if all required fields are present', () => {
     expect( validate( data ) ).toBeTruthy();
   } );
+
+  it('validates undefined data', () => {
+    expect(validate({
+      ...data,
+      earned: undefined
+    })).toBeFalsy();
+  });
 
   it( 'validates data to false if not all required fields are present', () => {
     expect( validate( {} ) ).toBeFalsy();
@@ -50,6 +59,34 @@ describe( '.validate', () => {
     expect( validate( {
       ...driveData,
       miles: ''
+    } ) ).toBeFalsy();
+    expect( validate( {
+      ...driveData,
+      daysPerWeek: ''
+    } ) ).toBeFalsy();
+  } );
+
+  it( 'validates non-driving data correctly', () => {
+    expect( validate( {
+      ...data,
+      averageCost: ''
+    } ) ).toBeFalsy();
+
+    expect( validate( {
+      ...data,
+      averageCost: '',
+      isMonthlyCost: null
+    } ) ).toBeFalsy();
+
+    expect( validate( {
+      ...data,
+      isMonthlyCost: null
+    } ) ).toBeFalsy();
+
+    expect( validate( {
+      ...data,
+      isMonthlyCost: false,
+      daysPerWeek: ''
     } ) ).toBeFalsy();
   } );
 } );


### PR DESCRIPTION
This PR fixes the following issues around which alert notifications should be displayed:

* When `averageCost` is entered but `per month` or `per day` is not, the yellow incomplete alert
should be displayed.

* When `averageCost` is entered and `per day` is selected, but `daysPerWeek` is empty, the yellow incomplete alert should be displayed.

* When a to-do list item is selected, and all other data is filled in, and the user moves to a different transportation type, the green success alert `looks good, but with todos` should show.

## Additions

- Adds validations for all transportation types other than `drive`, to capture the behavior of the `averageCost` and associated fields

- Adds `isEmpty` method to determine if a value is empty, rather than relying on a straight boolean check (`!value`)

## Changes

* Updates `updateActionPlanItems`. Performing a `splice` of a non-existent index is the same as -1,1, meaning the first element of an array will always be removed. Now we check that the item to be removed from the `actionPlanItems` array is present.


## Testing

1. Specs, and the notes above.
