### PR TITLE
Fix the ability to run tox tests in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,6 @@ RUN yum -y install \
     source /etc/profile && \
     pip install --no-cache-dir --upgrade pip setuptools
 
-# Disables pip cache. Reduces build time, and suppresses warnings when run as non-root.
-# NOTE: MUST be after pip upgrade. Build fails otherwise due to bug in old pip.
-ENV PIP_NO_CACHE_DIR true
-
 # Install python requirements
 COPY requirements requirements
 


### PR DESCRIPTION
Setting `PIP_NO_CACHE_DIR` to `true` breaks our use of venv-update in tox. This means it's not possible to successfully run the Python unit tests in the Docker container.

Since our primary use of Docker at the moment is for local development, so it seems prudent to preserve the ability to do all aspects of development, including run the test. The cost of longer build time and some warnings seems worth that to me.

We should revisit this when/if we deploy Docker containers for deployment.

## Testing

1. `docker-compose build python2 python3`
2. `docker-compose up`

Then, in another terminal:

3. `docker-compose exec python3 bash`
4. `tox`

Prior to this change you would see the following error when tox tries to create the virtual envs:

```
Traceback (most recent call last):
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/virtualenv_support/pip-9.0.1-py2.py3-none-any.whl/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/virtualenv_support/pip-9.0.1-py2.py3-none-any.whl/pip/commands/install.py", line 272, in run
    with self._build_session(options) as session:
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/virtualenv_support/pip-9.0.1-py2.py3-none-any.whl/pip/basecommand.py", line 69, in _build_session
    if options.cache_dir else None
  File "/src/cfgov-refresh/.tox/lint-py36/lib64/python3.6/posixpath.py", line 78, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not int
```

After this change, `tox` should run successfully.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
