### PR TITLE
YES Tool — Adds new default of '-' when line item totals cant be calculated

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/line-item.html
+++ b/cfgov/jinja2/v1/youth_employment_success/line-item.html
@@ -8,7 +8,7 @@
   </p>
   <div class="content-l_col content-l_col-1-3 u-align-right line-item line-item__content-r">
     <span>$</span>
-    <span class="{{ values.target }}">-</span>
+    <span class="{{ values.target }}">&mdash;</span>
   </div>
 </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/youth_employment_success/route/route-details.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route/route-details.html
@@ -2,7 +2,7 @@
 
 {% macro route_details() %}
 <div class="content-l u-mb0 yes-route-details">
-  <div class="content-l_col content-l_col-1 u-js-only block block__sub-micro block__flush-top js-route-notification u-hidden"></div>
+  <div class="content-l_col content-l_col-1 block block__sub-micro block__flush-top js-route-notification u-hidden u-js-only"></div>
   <div class="content-l_col content-l_col-1">
     <p class="h5 u-mt0 u-mb0">
       Summary for <span class="js-transportation-type"></span>
@@ -42,10 +42,10 @@
         <p class="content-l_col content-l_col-2-3 h4 m-hours_container">Total time to get to work</p>
         <div class="content-l_col content-l_col-1-3 u-align-right m-hours_container">
           <p class="content-l_col content-l_col-1-2 m-hours_data">
-            <span class="js-time-hours">-</span> hours
+            <span class="js-time-hours">&mdash;</span> hours
           </p>
           <p class="content-l_col content-l_col-1-2 m-minutes_data">
-            <span class="js-time-minutes">-</span> minutes
+            <span class="js-time-minutes">&mdash;</span> minutes
           </p>
         </div>
       </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route/route-details.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route/route-details.html
@@ -2,9 +2,7 @@
 
 {% macro route_details() %}
 <div class="content-l u-mb0 yes-route-details">
-  <div class="content-l_col content-l_col-1 u-js-only u-js-only block block__sub-micro block__flush-top">
-    <div class="js-route-notification block block__sub-micro block__flush-top u-hidden"></div>
-  </div>
+  <div class="content-l_col content-l_col-1 u-js-only block block__sub-micro block__flush-top js-route-notification u-hidden"></div>
   <div class="content-l_col content-l_col-1">
     <p class="h5 u-mt0 u-mb0">
       Summary for <span class="js-transportation-type"></span>

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -229,10 +229,6 @@ function toPrecision( value = '', precision = 0 ) {
     safeValue = Number( value );
   }
 
-  if ( !isNumber( safeValue ) ) {
-    throw new Error( 'First argument must be a number.' );
-  }
-
   return addCommas( String( ( Math.round( ( safeValue * 1000 ) / 10 ) / 100 ).toFixed( precision ) ) );
 }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -217,6 +217,10 @@ function toggleCFNotification( node, doShow ) {
  * @returns {String} A new string with the correct precision
  */
 function toPrecision( value = '', precision = 0 ) {
+  if ( !isNumber( value ) ) {
+    return value;
+  }
+
   let safeValue;
 
   if ( typeof value === 'string' ) {
@@ -240,7 +244,7 @@ function formatNegative( num ) {
   const [ significant, decimalZeros = '' ] = num.split( '.' );
   let decimals = '';
 
-  // Math.abs will preserve decimals, but not if they are zero
+  // Math.abs will preserve decimals, but not if they are a zero
   if ( ( /0+/ ).test( decimalZeros ) ) {
     decimals = decimalZeros;
   }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/validators/route-option.js
@@ -136,6 +136,7 @@ function isValidDriveData( { miles, daysPerWeek, actionPlanItems } ) {
  * @param {String} averageCost The cost of the trip
  * @param {Boolean} isMonthlyCost Whether or not the average cost is per day or per month
  * @param {Array} actionPlanItems The current to-do list of trip unknowns
+ * @returns {Boolean} Validity of the supplied data
  */
 function isValidAverageCost( { daysPerWeek, averageCost, isMonthlyCost, actionPlanItems } ) {
   if (
@@ -156,6 +157,24 @@ function isValidAverageCost( { daysPerWeek, averageCost, isMonthlyCost, actionPl
 }
 
 /**
+ * Helper function to determine what type of transportation data we should be
+ * validating (e.g. 'Drive' vs any other mode of transportation).
+ * @param {Object} data The route data to be validated
+ * @returns {Boolean} Validity of the supplied data
+ */
+function isValidTransportationData( data ) {
+  let valid = true;
+
+  if ( data.transportation === 'Drive' ) {
+    valid = isValidDriveData( data );
+  } else {
+    valid = isValidAverageCost( data );
+  }
+
+  return valid;
+}
+
+/**
  * Validate all data for a route
  * @param {object} data The transportation tool form data
  * @returns {Boolean} Data validity
@@ -169,11 +188,7 @@ function validate( data ) {
     return valid;
   }
 
-  if ( data.transportation === 'Drive' ) {
-    valid = isValidDriveData( data );
-  } else {
-    valid = isValidAverageCost( data );
-  }
+  valid = isValidTransportationData( data );
 
   return valid;
 }

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
@@ -6,12 +6,31 @@ import {
   updateDaysToActionPlan
 } from '../reducers/route-option-reducer';
 import inputView from './input';
+import { PLAN_TYPES } from '../data-types/todo-items';
 
 const CLASSES = Object.freeze( {
   CONTAINER: 'm-yes-days-per-week'
 } );
 
 const NOT_SURE_MESSAGE = 'Looking up how many days a week you\'ll make this trip was added to your to-do list.';
+
+/**
+ * Helper function to determine whether or not the state this view controls should
+ * be updated in the app's state store
+ * @param {String} daysPerWeek Value of daysPerWeek input node
+ * @param {Array} todoList Previous todo list items the user may have
+ * @returns {Boolean} Should the state be cleared
+ */
+function shouldClearDaysPerWeek(daysPerWeek, todoList) {
+  if (
+    daysPerWeek ||
+    todoList && todoList.indexOf(PLAN_TYPES.DAYS_PER_WEEK) !== -1
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 /**
  * DaysPerWeekView
@@ -71,6 +90,7 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
   function _onStateUpdate( prevState, state ) {
     const prevRouteState = routeSelector( prevState.routes, routeIndex );
     const routeState = routeSelector( state.routes, routeIndex );
+    const { daysPerWeek, actionPlanItems } = prevRouteState;
 
     if ( routeState.isMonthlyCost ) {
       _daysPerWeekEl.value = '';
@@ -79,7 +99,7 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
 
       todoNotification.remove();
 
-      if ( prevRouteState.daysPerWeek ) {
+      if ( shouldClearDaysPerWeek(daysPerWeek, actionPlanItems ) ) {
         store.dispatch( clearDaysPerWeekAction( { routeIndex } ) );
       }
     } else {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/days-per-week.js
@@ -21,10 +21,10 @@ const NOT_SURE_MESSAGE = 'Looking up how many days a week you\'ll make this trip
  * @param {Array} todoList Previous todo list items the user may have
  * @returns {Boolean} Should the state be cleared
  */
-function shouldClearDaysPerWeek(daysPerWeek, todoList) {
+function shouldClearDaysPerWeek( daysPerWeek, todoList ) {
   if (
     daysPerWeek ||
-    todoList && todoList.indexOf(PLAN_TYPES.DAYS_PER_WEEK) !== -1
+    todoList && todoList.indexOf( PLAN_TYPES.DAYS_PER_WEEK ) !== -1
   ) {
     return true;
   }
@@ -99,7 +99,7 @@ function daysPerWeekView( element, { store, routeIndex, todoNotification } ) {
 
       todoNotification.remove();
 
-      if ( shouldClearDaysPerWeek(daysPerWeek, actionPlanItems ) ) {
+      if ( shouldClearDaysPerWeek( daysPerWeek, actionPlanItems ) ) {
         store.dispatch( clearDaysPerWeekAction( { routeIndex } ) );
       }
     } else {

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -1,4 +1,4 @@
-import { assign, formatNegative, toArray, toPrecision } from '../util';
+import { assign, formatNegative, isNumber, toArray, toPrecision } from '../util';
 import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
 import { ALERT_TYPES } from '../data-types/notifications';
 import { getPlanItem } from '../data-types/todo-items';
@@ -52,7 +52,7 @@ function buildTodoListNodes( todosEl, todos = [], hasDefault ) {
   return fragment;
 }
 
-const DEFAULT_COST_ESTIMATE = '0';
+const DEFAULT_COST_ESTIMATE = '—';
 const WEEKLY_COST = 4.0;
 const AAA_ESTIMATED_COST_PER_MILE = 0.80;
 
@@ -84,12 +84,24 @@ function getCalculationFn( route ) {
   return calculatePerMonthCost( averageCost, daysPerWeek );
 }
 
+function useDefaultCostEstimate(value) {
+  if (!value || value === DEFAULT_COST_ESTIMATE ) {
+    return true
+  }
+
+  return false;
+}
+
 /**
  * Calculates the daily cost of driving
  * @param {string} numberOfMiles Number of miles user expects to drive each day
  * @returns {Number} The cost, in dollars, of driving each day
  */
 function calculateDrivingDailyCost( numberOfMiles = 0 ) {
+  if ( useDefaultCostEstimate(numberOfMiles) ) {
+    return DEFAULT_COST_ESTIMATE;
+  }
+
   return money.toDollars(
     parseFloat( numberOfMiles ) * AAA_ESTIMATED_COST_PER_MILE
   );
@@ -102,7 +114,7 @@ function calculateDrivingDailyCost( numberOfMiles = 0 ) {
  * @returns {String|Number} Retuns '-' if daysPerWeek is not supplied, otherwise returns the monthly cost
  */
 function calculatePerMonthCost( dailyCost, daysPerWeek ) {
-  if ( !daysPerWeek ) {
+  if ( useDefaultCostEstimate(daysPerWeek) || useDefaultCostEstimate(dailyCost)) {
     return DEFAULT_COST_ESTIMATE;
   }
 
@@ -122,6 +134,10 @@ function calculatePerMonthCost( dailyCost, daysPerWeek ) {
  * @returns {Number} The user's remaining monthly money.
  */
 function updateRemainingBudget( budget, transportationEstimate ) {
+  if ( useDefaultCostEstimate(budget) || useDefaultCostEstimate(transportationEstimate)) {
+    return DEFAULT_COST_ESTIMATE;
+  }
+
   return money.subtract(
     budget,
     transportationEstimate
@@ -250,17 +266,17 @@ function routeDetailsView( element, { alertTarget, hasDefaultTodo = false } ) {
       const costEstimate = getCalculationFn( route );
       const remainingBudget = money.subtract( budget.earned, budget.spent );
       const nextRemainingBudget = updateRemainingBudget(
-        remainingBudget,
+        String(remainingBudget),
         costEstimate
       );
-      const dataIsValid = validate( assign( {}, budget, route ) );
+      const isFormValid = validate( assign( {}, budget, route ) );
       const valuesForNotification = {
         [ALERT_TYPES.HAS_TODOS]: Boolean(
           route.transportation && route.actionPlanItems.length
         ),
-        [ALERT_TYPES.INVALID]: Boolean( route.transportation && !dataIsValid ),
-        [ALERT_TYPES.IN_BUDGET]: dataIsValid && nextRemainingBudget >= 0,
-        [ALERT_TYPES.OUT_OF_BUDGET]: dataIsValid && nextRemainingBudget < 0
+        [ALERT_TYPES.INVALID]: Boolean( route.transportation && !isFormValid ),
+        [ALERT_TYPES.IN_BUDGET]: isFormValid && nextRemainingBudget >= 0,
+        [ALERT_TYPES.OUT_OF_BUDGET]: isFormValid && nextRemainingBudget < 0
       };
       const todoListFragment = buildTodoListNodes(
         _todoItemsEl, route.actionPlanItems, hasDefaultTodo
@@ -274,18 +290,21 @@ function routeDetailsView( element, { alertTarget, hasDefaultTodo = false } ) {
         )
       );
       updateDom( _daysPerWeekEl, route.daysPerWeek );
+
       updateDom( _totalCostEl, toPrecision( costEstimate, 2 ) );
       updateDom( _budgetLeftEl,
         formatNegative(
           toPrecision( nextRemainingBudget, 2 )
         )
       );
-      updateDom( _timeHoursEl, route.transitTimeHours );
-      updateDom( _timeMinutesEl, route.transitTimeMinutes );
+
+      updateDom( _timeHoursEl, route.transitTimeHours || '-' );
+      updateDom( _timeMinutesEl, route.transitTimeMinutes || '-' );
       updateTodoList( todoListFragment );
 
       alertView.render( {
-        alertValues: valuesForNotification, alertTarget
+        alertValues: valuesForNotification,
+        alertTarget
       } );
     }
   };

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/route-details.js
@@ -81,12 +81,14 @@ function getCalculationFn( route ) {
     return averageCost;
   }
 
-  return calculatePerMonthCost( averageCost, daysPerWeek );
+  const validDaysPerWeek = isMonthlyCost === null ? null : daysPerWeek;
+
+  return calculatePerMonthCost( averageCost, validDaysPerWeek );
 }
 
-function useDefaultCostEstimate(value) {
-  if (!value || value === DEFAULT_COST_ESTIMATE ) {
-    return true
+function useDefaultCostEstimate( value ) {
+  if ( !value || value === DEFAULT_COST_ESTIMATE ) {
+    return true;
   }
 
   return false;
@@ -98,7 +100,7 @@ function useDefaultCostEstimate(value) {
  * @returns {Number} The cost, in dollars, of driving each day
  */
 function calculateDrivingDailyCost( numberOfMiles = 0 ) {
-  if ( useDefaultCostEstimate(numberOfMiles) ) {
+  if ( useDefaultCostEstimate( numberOfMiles ) ) {
     return DEFAULT_COST_ESTIMATE;
   }
 
@@ -114,7 +116,7 @@ function calculateDrivingDailyCost( numberOfMiles = 0 ) {
  * @returns {String|Number} Retuns '-' if daysPerWeek is not supplied, otherwise returns the monthly cost
  */
 function calculatePerMonthCost( dailyCost, daysPerWeek ) {
-  if ( useDefaultCostEstimate(daysPerWeek) || useDefaultCostEstimate(dailyCost)) {
+  if ( useDefaultCostEstimate( daysPerWeek ) || useDefaultCostEstimate( dailyCost ) ) {
     return DEFAULT_COST_ESTIMATE;
   }
 
@@ -134,7 +136,7 @@ function calculatePerMonthCost( dailyCost, daysPerWeek ) {
  * @returns {Number} The user's remaining monthly money.
  */
 function updateRemainingBudget( budget, transportationEstimate ) {
-  if ( useDefaultCostEstimate(budget) || useDefaultCostEstimate(transportationEstimate)) {
+  if ( useDefaultCostEstimate( budget ) || useDefaultCostEstimate( transportationEstimate ) ) {
     return DEFAULT_COST_ESTIMATE;
   }
 
@@ -266,7 +268,7 @@ function routeDetailsView( element, { alertTarget, hasDefaultTodo = false } ) {
       const costEstimate = getCalculationFn( route );
       const remainingBudget = money.subtract( budget.earned, budget.spent );
       const nextRemainingBudget = updateRemainingBudget(
-        String(remainingBudget),
+        String( remainingBudget ),
         costEstimate
       );
       const isFormValid = validate( assign( {}, budget, route ) );

--- a/cfgov/unprocessed/js/routes/on-demand/youth-employment-programs/buying-a-car/index.js
+++ b/cfgov/unprocessed/js/routes/on-demand/youth-employment-programs/buying-a-car/index.js
@@ -36,7 +36,7 @@ const expandableData = expandableEls.reduce( ( memo, expandable ) => {
   return memo;
 }, {} );
 
-document.querySelector(`.${TEMPLATE_SELECTOR}`).parentNode.classList.add('cbg-print-block');
+document.querySelector( `.${ TEMPLATE_SELECTOR }` ).parentNode.classList.add( 'cbg-print-block' );
 
 const items = selectedItems( { maxElements: 5 } );
 const checklistLookup = checklistMap( expandableData );

--- a/test/unit_tests/apps/youth-employment-success/js/util-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/util-spec.js
@@ -211,9 +211,8 @@ describe( 'YES utility functions', () => {
   } );
 
   describe( '.toPrecision', () => {
-    it( 'throws an error when a string that cannot be converted to a number is supplied', () => {
-      expect( () => toPrecision( 'string' )
-      ).toThrow();
+    it( 'returns the value if it cant be coerced into a number', () => {
+      expect(toPrecision( 'string' )).toBe('string');
     } );
 
     it( 'returns the original number when a precision is not specified', () => {

--- a/test/unit_tests/apps/youth-employment-success/js/util-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/util-spec.js
@@ -212,7 +212,7 @@ describe( 'YES utility functions', () => {
 
   describe( '.toPrecision', () => {
     it( 'returns the value if it cant be coerced into a number', () => {
-      expect(toPrecision( 'string' )).toBe('string');
+      expect( toPrecision( 'string' ) ).toBe( 'string' );
     } );
 
     it( 'returns the original number when a precision is not specified', () => {

--- a/test/unit_tests/apps/youth-employment-success/js/validators/route-option-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/validators/route-option-spec.js
@@ -16,12 +16,12 @@ describe( '.validate', () => {
     expect( validate( data ) ).toBeTruthy();
   } );
 
-  it('validates undefined data', () => {
-    expect(validate({
+  it( 'validates undefined data', () => {
+    expect( validate( {
       ...data,
       earned: undefined
-    })).toBeFalsy();
-  });
+    } ) ).toBeFalsy();
+  } );
 
   it( 'validates data to false if not all required fields are present', () => {
     expect( validate( {} ) ).toBeFalsy();

--- a/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/days-per-week-spec.js
@@ -120,7 +120,8 @@ describe( 'DaysPerWeekView', () => {
       const state = {
         routes: {
           routes: [ {
-            transportation: 'Drive'
+            transportation: 'Drive',
+            actionPlanItems: []
           } ]
         }
       };
@@ -130,13 +131,14 @@ describe( 'DaysPerWeekView', () => {
       expect( dom.classList.contains( 'u-hidden' ) ).toBeFalsy();
     } );
 
-    describe( 'when average cost is defined as a montly cost', () => {
+    describe( 'when average cost is defined as a monthly cost', () => {
       const days = '2';
       const checked = 'checked';
       const prevState = {
         routes: {
           routes: [ {
-            daysPerWeek: days
+            daysPerWeek: days,
+            actionPlanItems: []
           } ]
         }
       };
@@ -144,7 +146,8 @@ describe( 'DaysPerWeekView', () => {
         routes: {
           routes: [ {
             transportation: 'Walk',
-            isMonthlyCost: true
+            isMonthlyCost: true,
+            actionPlanItems: []
           } ]
         }
       };

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -150,86 +150,142 @@ describe( 'routeDetailsView', () => {
     } );
 
     describe( 'total costs', () => {
-      it( 'correctly calculates driving cost', () => {
-        view.render( nextState );
+      let totalCostEl;
 
-        const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
+      beforeEach(() => {
+        totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
+      });
 
-        expect( totalCostEl.textContent ).toBe( '192.00' );
+      describe('when driving', () => {
+        it( 'correctly calculates driving cost', () => {
+          view.render( nextState );
+  
+          expect( totalCostEl.textContent ).toBe( '192.00' );
+        } );
+  
+        it('does not update calculations if `miles` is not supplied', () => {
+          view.render({
+            ...nextState,
+            route: {
+              ...nextState.route,
+              miles: ''
+            }
+          });
+  
+          expect( totalCostEl.textContent ).toBe( '—' );
+        });
+  
+        it('does not update calculations if daysPerWeek is not supplied', () => {
+          view.render({
+            ...nextState,
+            route: {
+              ...nextState.route,
+              daysPerWeek: ''
+            }
+          });
+  
+          expect( totalCostEl.textContent ).toBe( '—' );
+        });
+      });
+
+      describe('when using another mode of transportation', () => {
+        it( 'correctly calculates monthly cost', () => {
+          const state = {
+            budget: { ...nextState.budget },
+            route: {
+              ...nextState.route,
+              transportation: 'Walk',
+              isMonthlyCost: true,
+              averageCost: '100'
+            }
+          };
+  
+          view.render( state );
+  
+          expect( totalCostEl.textContent ).toBe( '100.00' );
+        } );
+  
+        it( 'correctly calculates monthly cost based on daily cost', () => {
+          const state = {
+            budget: { ...nextState.budget },
+            route: {
+              ...nextState.route,
+              transportation: 'Walk',
+              isMonthlyCost: false
+            }
+          };
+  
+          view.render( state );
+  
+          expect( totalCostEl.textContent ).toBe( '120.00' );
+        } );
+
+        it ('does not update the total cost if per day or per month is not supplied', () => {
+          const state = {
+            budget: { ...nextState.budget },
+            route: {
+              ...nextState.route,
+              transportation: 'Walk',
+              isMonthlyCost: null
+            }
+          };
+  
+          view.render( state );
+  
+          expect( totalCostEl.textContent ).toBe( '-' );
+        });
+  
+        it('does not update the total cost if averageCost is not supplied', () => {
+          const state = {
+            budget: { ...nextState.budget },
+            route: {
+              ...nextState.route,
+              transportation: 'Walk',
+              isMonthlyCost: false,
+              averageCost: '',
+              daysPerWeek: 1
+            }
+          };
+  
+          view.render( state );
+  
+          expect( totalCostEl.textContent ).toBe( '—' );
+        });
+  
+        it( 'does not update the total cost if daysPerWeek is not supplied', () => {
+          const state = {
+            budget: { ...nextState.budget },
+            route: {
+              ...nextState.route,
+              transportation: 'Walk',
+              isMonthlyCost: false,
+              daysPerWeek: 0
+            }
+          };
+  
+          view.render( state );
+  
+          expect( totalCostEl.textContent ).toBe( '—' );
+        } );
+  
+        it( 'updates total cost properly when daysPerWeek is supplied', () => {
+          const state = {
+            budget: { ...nextState.budget },
+            route: {
+              ...nextState.route,
+              transportation: 'Walk',
+              isMonthlyCost: false,
+              daysPerWeek: 2,
+              averageCost: '100'
+            }
+          };
+  
+          view.render( state );
+  
+          expect( totalCostEl.textContent ).toBe( '800.00' );
+        } );
       } );
-
-      it( 'correctly calculates monthly cost', () => {
-        const state = {
-          budget: { ...nextState.budget },
-          route: {
-            ...nextState.route,
-            transportation: 'Walk',
-            isMonthlyCost: true,
-            averageCost: '100'
-          }
-        };
-
-        view.render( state );
-
-        const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
-
-        expect( totalCostEl.textContent ).toBe( '100.00' );
-      } );
-
-      it( 'correctly calculates monthly cost based on daily cost', () => {
-        const state = {
-          budget: { ...nextState.budget },
-          route: {
-            ...nextState.route,
-            transportation: 'Walk',
-            isMonthlyCost: false
-          }
-        };
-
-        view.render( state );
-
-        const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
-
-        expect( totalCostEl.textContent ).toBe( '120.00' );
-      } );
-
-      it( 'does not update the total cost if daysPerWeek is not supplied', () => {
-        const state = {
-          budget: { ...nextState.budget },
-          route: {
-            ...nextState.route,
-            transportation: 'Walk',
-            isMonthlyCost: false,
-            daysPerWeek: 0
-          }
-        };
-
-        view.render( state );
-
-        const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
-
-        expect( totalCostEl.textContent ).toBe( '0.00' );
-      } );
-
-      it( 'updates total cost properly when daysPerWeek is supplied', () => {
-        const state = {
-          budget: { ...nextState.budget },
-          route: {
-            ...nextState.route,
-            transportation: 'Walk',
-            isMonthlyCost: false,
-            daysPerWeek: 2,
-            averageCost: '100'
-          }
-        };
-
-        view.render( state );
-
-        const totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
-
-        expect( totalCostEl.textContent ).toBe( '800.00' );
-      } );
-    } );
+    });
 
     it( 'updates its budget remaining', () => {
       view.render( nextState );

--- a/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/route-details-spec.js
@@ -152,43 +152,43 @@ describe( 'routeDetailsView', () => {
     describe( 'total costs', () => {
       let totalCostEl;
 
-      beforeEach(() => {
+      beforeEach( () => {
         totalCostEl = document.querySelector( `.${ CLASSES.TOTAL_COST }` );
-      });
+      } );
 
-      describe('when driving', () => {
+      describe( 'when driving', () => {
         it( 'correctly calculates driving cost', () => {
           view.render( nextState );
-  
+
           expect( totalCostEl.textContent ).toBe( '192.00' );
         } );
-  
-        it('does not update calculations if `miles` is not supplied', () => {
-          view.render({
+
+        it( 'does not update calculations if `miles` is not supplied', () => {
+          view.render( {
             ...nextState,
             route: {
               ...nextState.route,
               miles: ''
             }
-          });
-  
+          } );
+
           expect( totalCostEl.textContent ).toBe( '—' );
-        });
-  
-        it('does not update calculations if daysPerWeek is not supplied', () => {
-          view.render({
+        } );
+
+        it( 'does not update calculations if daysPerWeek is not supplied', () => {
+          view.render( {
             ...nextState,
             route: {
               ...nextState.route,
               daysPerWeek: ''
             }
-          });
-  
-          expect( totalCostEl.textContent ).toBe( '—' );
-        });
-      });
+          } );
 
-      describe('when using another mode of transportation', () => {
+          expect( totalCostEl.textContent ).toBe( '—' );
+        } );
+      } );
+
+      describe( 'when using another mode of transportation', () => {
         it( 'correctly calculates monthly cost', () => {
           const state = {
             budget: { ...nextState.budget },
@@ -199,12 +199,12 @@ describe( 'routeDetailsView', () => {
               averageCost: '100'
             }
           };
-  
+
           view.render( state );
-  
+
           expect( totalCostEl.textContent ).toBe( '100.00' );
         } );
-  
+
         it( 'correctly calculates monthly cost based on daily cost', () => {
           const state = {
             budget: { ...nextState.budget },
@@ -214,13 +214,13 @@ describe( 'routeDetailsView', () => {
               isMonthlyCost: false
             }
           };
-  
+
           view.render( state );
-  
+
           expect( totalCostEl.textContent ).toBe( '120.00' );
         } );
 
-        it ('does not update the total cost if per day or per month is not supplied', () => {
+        it( 'does not update the total cost if per day or per month is not supplied', () => {
           const state = {
             budget: { ...nextState.budget },
             route: {
@@ -229,13 +229,13 @@ describe( 'routeDetailsView', () => {
               isMonthlyCost: null
             }
           };
-  
+
           view.render( state );
-  
-          expect( totalCostEl.textContent ).toBe( '-' );
-        });
-  
-        it('does not update the total cost if averageCost is not supplied', () => {
+
+          expect( totalCostEl.textContent ).toBe( '—' );
+        } );
+
+        it( 'does not update the total cost if averageCost is not supplied', () => {
           const state = {
             budget: { ...nextState.budget },
             route: {
@@ -246,12 +246,12 @@ describe( 'routeDetailsView', () => {
               daysPerWeek: 1
             }
           };
-  
+
           view.render( state );
-  
+
           expect( totalCostEl.textContent ).toBe( '—' );
-        });
-  
+        } );
+
         it( 'does not update the total cost if daysPerWeek is not supplied', () => {
           const state = {
             budget: { ...nextState.budget },
@@ -262,12 +262,12 @@ describe( 'routeDetailsView', () => {
               daysPerWeek: 0
             }
           };
-  
+
           view.render( state );
-  
+
           expect( totalCostEl.textContent ).toBe( '—' );
         } );
-  
+
         it( 'updates total cost properly when daysPerWeek is supplied', () => {
           const state = {
             budget: { ...nextState.budget },
@@ -279,13 +279,13 @@ describe( 'routeDetailsView', () => {
               averageCost: '100'
             }
           };
-  
+
           view.render( state );
-  
+
           expect( totalCostEl.textContent ).toBe( '800.00' );
         } );
       } );
-    });
+    } );
 
     it( 'updates its budget remaining', () => {
       view.render( nextState );


### PR DESCRIPTION
To avoid confusing the user with calculations made from incomplete data, always display a `-` in the line item break totals of `Average monthly cost of x` and `Total left in your budget after x`.

## Changes

- Always show a `-` in the aforementioned totals unless all fields necessary for calculation are present. Previously, the field defaulted to  `$0.00` once the user started entering values.

## Testing

1. Specs

2. With `Drive` selected and the budget fields filled in:
* Enter `numberOfMiles`, totals should be `-`
* Enter `daysPerWeek` totals should calculate
* Delete `numberOfMiles`, totals should be `-`

3. Now, select a new mode of transportation:
* Totals should be `-`
* Fill in `averageCost`, totals should be `-`
* Select `per month`, totals should calculate
* Select `per day`, remove `daysPerWeek`, totals should be `-`

## Todos

- Updating specs
