### PR TITLE
Update owning-a-home-api to 0.12.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -45,7 +45,7 @@ wagtail-sharing==0.8
 wagtail-treemodeladmin==1.0.4
 
 # These packages are installed from GitHub.
-https://github.com/cfpb/owning-a-home-api/releases/download/0.12.2/owning_a_home_api-0.12.2-py2.py3-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.12.3/owning_a_home_api-0.12.3-py2.py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.10.3/retirement-0.10.3-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.12/ccdb5_api-1.1.12-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.3.4/ccdb5_ui-1.3.4-py2.py3-none-any.whl


### PR DESCRIPTION
Remove manual SQL action from migration

## Removals

The manual SQL action didn't work as intended anywhere except production for reasons that are not entirely obvious. We think it's safest just to remove it, and we'll manually work on any databases we might need to.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
