### PR TITLE
Bypass CloudFront when accessing HUD search results in S3

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -330,7 +330,7 @@ STATIC_VERSION = ''
 
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN')
 HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
-    'https://files.consumerfinance.gov'
+    'https://s3.amazonaws.com/files.consumerfinance.gov'
     '/a/assets/hud/{file_format}s/{zipcode}.{file_format}'
 )
 

--- a/cfgov/housing_counselor/tests/test_views.py
+++ b/cfgov/housing_counselor/tests/test_views.py
@@ -12,13 +12,13 @@ class HousingCounselorS3URLMixinTestCase(TestCase):
     def test_s3_json_url(self):
         self.assertEqual(
             HousingCounselorS3URLMixin.s3_json_url(20001),
-            'https://files.consumerfinance.gov/a/assets/hud/jsons/20001.json'
+            'https://s3.amazonaws.com/files.consumerfinance.gov/a/assets/hud/jsons/20001.json'  # noqa: E501
         )
 
     def test_s3_pdf_url(self):
         self.assertEqual(
             HousingCounselorS3URLMixin.s3_pdf_url(20009),
-            'https://files.consumerfinance.gov/a/assets/hud/pdfs/20009.pdf'
+            'https://s3.amazonaws.com/files.consumerfinance.gov/a/assets/hud/pdfs/20009.pdf'  # noqa: E501
         )
 
 


### PR DESCRIPTION
Previously, when there was an error fetching a file from the bucket (a 500 error in S3), CloudFront would cache the error for five minutes, meaning that even if the underlying error was resolved, end users would still receive an error when trying to visit that page in the FAHC tool.

We have code to retry a request to S3 if it receives a 5XX error, which was not useful when CloudFront was caching responses. By bypassing CF, requests that 500 will be retried immediately, which may reduce the number of user-facing 500 errors.

## Changes

- From the Housing Counselor tool, use `https://s3.amazonaws.com/files.consumerfinance.gov` to directly access the files.consumerfinance.gov S3 bucket, instead of accessing it via CloudFront.

## Testing

1. Run this branch
2. Visit http://localhost:8000/find-a-housing-counselor/
3. Search for a ZIP, see that the result location pins show in the map view
4. Click "save list as PDF", see that the resulting PDF gets fetched from S3

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: