### PR TITLE
Job posting expandable fix

### DIFF
--- a/cfgov/jinja2/v1/job-description-page/index.html
+++ b/cfgov/jinja2/v1/job-description-page/index.html
@@ -79,7 +79,7 @@
         <div data-qa-hook="expandable"
              data-read-more="true"
              class="o-expandable
-                    o-expandable__read-more">
+                    o-expandable__read-more-mobile">
             <div class="o-expandable_content" id="job-description-expandable">
                 <h4>Summary</h4>
                 {{ page.description | safe }}


### PR DESCRIPTION
Limit read more functionality to mobile screens.


## Changes

- Update read-more class

## Testing

1. Check out branch
2. Navigate to a job posting page locally
3. Verify that that job description is not displayed in an expandable at desktop screen size
4. Verify that job description is truncated and expandable at mobile screen sizes


## Screenshots

### Before, desktop
<img width="818" alt="Screen Shot 2019-11-18 at 11 59 22 AM" src="https://user-images.githubusercontent.com/778171/69086713-4d819280-09fb-11ea-8b35-2a2d45851407.png">


### After, desktop
<img width="810" alt="Screen Shot 2019-11-18 at 12 03 04 PM" src="https://user-images.githubusercontent.com/778171/69086939-65591680-09fb-11ea-8a71-9e4f88ed83e1.png">

### After, mobile
<img width="479" alt="Screen Shot 2019-11-18 at 12 03 51 PM" src="https://user-images.githubusercontent.com/778171/69087396-8d487a00-09fb-11ea-99d1-3e6199afcf0b.png">



