### PR TITLE
Bump wagtail-inventory version from 0.7 to 0.8

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -40,7 +40,7 @@ unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1
 wagtail-flags==4.1.0b2
-wagtail-inventory==0.7
+wagtail-inventory==0.8
 wagtail-sharing==0.8
 wagtail-treemodeladmin==1.0.4
 


### PR DESCRIPTION
This upgrade doesn't affect functionality, but does keep us up to date.

[The 0.8 release](https://pypi.org/project/wagtail-inventory/) adds support for Wagtail 2.6.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: