### PR TITLE
Homepage: Add initial carousel organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -1,0 +1,28 @@
+{# ==========================================================================
+
+   carousel.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates markup for a Carousel organism, which displays a set of 
+   blocks of content that can be navigated through sequentially.
+
+   ========================================================================== #}
+
+{% macro render() %}
+
+<div class="o-carousel">
+    <ul class="o-carousel_items">
+        <div class="o-carousel_item">Item 1</div>
+        <div class="o-carousel_item">Item 2</div>
+        <div class="o-carousel_item">Item 3</div>
+        <div class="o-carousel_item">Item 4</div>
+    </ul>
+    
+    <button class="o-carousel_btn-prev">Prev</button>
+    <button class="o-carousel_btn-next">Next</button>
+</div>
+
+{% endmacro %}

--- a/cfgov/jinja2/v1/home-page/index_new.html
+++ b/cfgov/jinja2/v1/home-page/index_new.html
@@ -1,5 +1,14 @@
 {% extends "layout-full.html" %}
 
 {% block content_main %}
-{{ _('Consumer Financial Protection Bureau') }}
+
+<h1>
+    {{ _('Consumer Financial Protection Bureau') }}
+</h1>
+
+{% block carousel %}
+    {% import 'organisms/carousel.html' as o_carousel with context %}
+    {{ o_carousel.render() }}
+{% endblock carousel %}
+
 {% endblock content_main %}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -128,6 +128,7 @@
 @import (less) "organisms/sidebar-contact-info.less";
 @import (less) "organisms/sidebar-content.less";
 @import (less) "organisms/video-player.less";
+@import (less) "organisms/carousel.less";
 
 
 /* Template pieces

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -1,0 +1,31 @@
+.o-carousel {
+  width: 100%;
+
+  // Override default unordered list padding.
+  & ul {
+    padding: 0;
+  }
+
+  &_item {
+    border: 1px solid red;
+    height: 100px;
+    width: 100%;
+    padding: 30px;
+  }
+
+  &_item:nth-child(1) {
+    background: orange;
+  }
+
+  &_item:nth-child(2) {
+    background: greenyellow;
+  }
+
+  &_item:nth-child(3) {
+    background: cyan;
+  }
+
+  &_item:nth-child(4) {
+    background: forestgreen;
+  }
+}

--- a/cfgov/unprocessed/js/organisms/Carousel.js
+++ b/cfgov/unprocessed/js/organisms/Carousel.js
@@ -1,0 +1,116 @@
+// Required modules.
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+
+const BASE_CLASS = 'o-carousel';
+
+/**
+ * Carousel
+ * @class
+ *
+ * @classdesc Initializes a new Carousel organism.
+ * A Carousel contains a list of CarouselItems for showing/hiding them sequentially.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the organism.
+ * @returns {Carousel} An instance.
+ */
+function Carousel( element ) {
+  const _dom = checkDom( element, BASE_CLASS );
+  const _btnPrev = _dom.querySelector( `.${ BASE_CLASS }_btn-prev` );
+  const _btnNext = _dom.querySelector( `.${ BASE_CLASS }_btn-next` );
+
+  const _items = [];
+  let _currItemIndex = 0;
+  
+  /**
+   * @returns {Carousel} An instance.
+   */
+  function init() {
+    if ( !setInitFlag( _dom ) ) {
+      return this;
+    }
+
+    // Grab all carousel item DOM references. 
+    let itemDoms = element.querySelectorAll( `.${ BASE_CLASS }_item` );
+
+    // Create carousel item instances.
+    let itemDom;
+    for ( let i = 0, len = itemDoms.length; i < len; i++ ) {
+      itemDom = itemDoms[i];
+      _items.push( new CarouselItem( itemDom ) );
+      if ( i > 0 ){
+        itemDom.classList.add( 'u-hidden' );
+      }
+    }
+
+    _btnPrev.addEventListener( 'click', _btnPrevClicked );
+    _btnNext.addEventListener( 'click', _btnNextClicked );
+
+    return this;
+  }
+
+  /**
+   * Handle clicks of the previous button.
+   */
+  function _btnPrevClicked() {
+    _updateDisplay( _currItemIndex, _currItemIndex - 1 );
+  }
+
+  /**
+   * Handle clicks of the next button.
+   */
+  function _btnNextClicked() {
+    _updateDisplay( _currItemIndex, _currItemIndex + 1 );
+  }
+
+  /**
+   * Update which carousel item is being displayed.
+   * @param {number} oldCurrItemIndex - The previous index value of the selected item.
+   * @param {number} newCurrItemIndex - The new index value of the selected item.
+   */
+  function _updateDisplay( oldCurrItemIndex, newCurrItemIndex ) {
+    const lastItem = _items[oldCurrItemIndex];
+    _currItemIndex = newCurrItemIndex;
+    if ( _currItemIndex < 0 ) {
+      _currItemIndex = _items.length -1;
+    } else if ( _currItemIndex > _items.length - 1 ) {
+      _currItemIndex = 0;
+    }
+    _items[_currItemIndex].show();
+    lastItem.hide();
+  }
+
+  this.init = init;
+
+  return this;
+}
+
+/**
+ * Private class for handling carousel item API.
+ * @param {HTMLElement} element - Carousel item's DOM element.
+ */
+function CarouselItem( element ) {
+  
+  /**
+   * Display this carousel item.
+   */
+  function show() {
+    element.classList.remove( 'u-hidden' );
+  }
+
+  /**
+   * Hide this carousel item.
+   */
+  function hide() {
+    element.classList.add( 'u-hidden' );
+  }
+
+  this.show = show;
+  this.hide = hide;
+
+  return this;
+}
+
+Carousel.BASE_CLASS = BASE_CLASS;
+
+export default Carousel;

--- a/cfgov/unprocessed/js/routes/on-demand/home-page.js
+++ b/cfgov/unprocessed/js/routes/on-demand/home-page.js
@@ -1,8 +1,8 @@
 /* ==========================================================================
-   Scripts for the hompage only.
+   Scripts for the homepage only.
    ========================================================================== */
 
-import Carousel from '../organisms/Carousel.js';
+import Carousel from '../../organisms/Carousel.js';
 
 const carouselDom = document.querySelector( `.${ Carousel.BASE_CLASS }` );
 const carousel = new Carousel( carouselDom );

--- a/cfgov/unprocessed/js/routes/single.js
+++ b/cfgov/unprocessed/js/routes/single.js
@@ -1,0 +1,9 @@
+/* ==========================================================================
+   Scripts for the hompage only.
+   ========================================================================== */
+
+import Carousel from '../organisms/Carousel.js';
+
+const carouselDom = document.querySelector( `.${ Carousel.BASE_CLASS }` );
+const carousel = new Carousel( carouselDom );
+carousel.init();

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -51,6 +51,10 @@ class HomePage(CFGOVPage):
 
     search_fields = CFGOVPage.search_fields + [index.SearchField('header')]
 
+    @property
+    def page_js(self):
+        return super(HomePage, self).page_js + ['home-page.js']
+
     def get_category_name(self, category_icon_name):
         cats = dict(ref.limited_categories)
         return cats[str(category_icon_name)]


### PR DESCRIPTION
Adds an initial front-end architecture for a carousel organism, for cycling through a sequence of blocks of content.

## Additions

- Adds Carousel organism JavaScript, CSS, and jinja template.
- Adds `single.js` script for scripts only on the homepage route.

## Testing

1. Pull branch, run `gulp clean && gulp build`
2. Enable alternate homepage design (via instructions in https://github.com/cfpb/cfgov-refresh/pull/5335)
3. Visit http://localhost:8000/?nhp=True and see there's a barebones carousel that you can click forward and backward through.

## Screenshots

![carousel](https://user-images.githubusercontent.com/704760/69164949-d281b000-0abe-11ea-8994-e41ed8b0a7fb.gif)
