### PR TITLE
Homepage: Carousel no-js state

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -13,7 +13,7 @@
 
 {% macro render() %}
 
-<div class="o-carousel">
+<div class="o-carousel u-hidden">
     <ul class="o-carousel_items">
         <div class="o-carousel_item">Item 1</div>
         <div class="o-carousel_item">Item 2</div>
@@ -21,8 +21,8 @@
         <div class="o-carousel_item">Item 4</div>
     </ul>
     
-    <button class="o-carousel_btn-prev">Prev</button>
-    <button class="o-carousel_btn-next">Next</button>
+    <button class="o-carousel_btn o-carousel_btn-prev">Prev</button>
+    <button class="o-carousel_btn o-carousel_btn-next">Next</button>
 </div>
 
 {% endmacro %}

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -29,3 +29,13 @@
     background: forestgreen;
   }
 }
+
+// Show no-js state of carousel where all items show and buttons are hidden.
+.no-js .o-carousel {
+  // Override u-hidden when 
+  display: block !important;
+
+  &_btn {
+    display: hidden !important;
+  }
+}

--- a/cfgov/unprocessed/js/organisms/Carousel.js
+++ b/cfgov/unprocessed/js/organisms/Carousel.js
@@ -46,6 +46,9 @@ function Carousel( element ) {
     _btnPrev.addEventListener( 'click', _btnPrevClicked );
     _btnNext.addEventListener( 'click', _btnNextClicked );
 
+    // Carousel ready, show it!
+    element.classList.remove( 'u-hidden' );
+  
     return this;
   }
 


### PR DESCRIPTION
Hides carousel by default on page load and then shows it when the JS has initialized. Shows the carousel stacked in the no-js state.

## Changes

- Hides carousel by default till JS is initialized.
- Stacks carousel in no-js state.

## Testing

1. Pull branch, run `gulp clean && gulp build`
2. Load http://localhost:8000/?nhp=True and see that Carousel is hidden till JS is initialized.
3. Inspect the page and change the `js` class on the `html` element to `no-js` and see that the carousel items stack on top of each other and the buttons disappear.
