### PR TITLE
Restore content on print

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
@@ -52,7 +52,7 @@
     }
 
     thead {
-        display: table-header-group; /* h5bp.com/t */
+        display: none;
     }
 
     img {

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -148,7 +148,7 @@
 @import (less) "pages/error.less";
 @import (less) "pages/home.less";
 @import (less) "pages/press-resources.less";
-@import (less) "pages/car-buying-guide.less";
+// @import (less) "pages/car-buying-guide.less";
 
 
 /* Print styles


### PR DESCRIPTION
The stylesheet for the forthcoming YES car buying guide was a little too aggressive in hiding things on print, and it was being applied globally. Since that page hasn't launched, I have commented it out of the global `main.less` file to fix the immediate problem. Further consideration will need to be given to how to scope the styles that the car buying guide will need to only that page.

## Testing

1. Visit http://localhost:8000/find-a-housing-counselor/?zipcode=12306
2. Print preview (the easiest way to do this in Chrome is to use the Print command and look at the preview); see that the list of counselors is missing
3. Pull this branch
4. `yarn run gulp styles`
5. Hard refresh the page
6. Print preview again and see that the content appears

## Todos

- Figure out a better solution for scoping CSS to a particular page (in a future PR)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [x] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android