### PR TITLE
Added iterlists import from django.utils.six to fix 500 error in Python 3

### DIFF
--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -5,6 +5,7 @@ from django.core.paginator import InvalidPage, Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.six import iterlists
 
 from prepaid_agreements.models import PrepaidProduct
 from v1.models.snippets import ReusableText
@@ -95,7 +96,8 @@ def get_support_text():
 
 
 def index(request):
-    params = dict(request.GET.iterlists())
+    query = request.GET.copy()
+    params = dict(iterlists(query))
     available_filters = {}
     search_term = None
     search_field = None


### PR DESCRIPTION
Prepaid agreement search throws a 500 error in Python 3

## Additions

- Added iterlists import from django.utils.six in views.py

## Python 2 and Python 3 Testing

1. http://localhost:8000/data-research/prepaid-accounts/search-agreements/
2. http://localhost:8333/data-research/prepaid-accounts/search-agreements/

## Checklist

- [x] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [X] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android
