### PR TITLE
Add helper script to sync local image storage

### DIFF
--- a/cfgov/v1/management/commands/sync_image_storage.py
+++ b/cfgov/v1/management/commands/sync_image_storage.py
@@ -1,0 +1,63 @@
+import os
+
+from django.core.management.base import BaseCommand
+
+from wagtail.wagtailimages import get_image_model
+
+import requests
+import requests.exceptions
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('base_url',
+                            help='ex: https://files.consumerfinance.gov/f/')
+        parser.add_argument('dest_dir', help='ex: ./cfgov/f/')
+
+    def handle(self, *args, **options):
+        base_url = options['base_url']
+        dest_dir = options['dest_dir']
+
+        for subdir in ('images', 'original_images'):
+            directory = os.path.join(dest_dir, subdir)
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+
+        images = get_image_model().objects.all()
+        image_count = images.count()
+
+        for i, image in enumerate(images):
+            self.stdout.write('%d/%d ' % (i + 1, image_count), ending='')
+            self.save(base_url, dest_dir, image.file.name)
+
+            renditions = image.renditions.all()
+            rendition_count = renditions.count()
+
+            for j, rendition in enumerate(renditions):
+                self.stdout.write(
+                    '%d/%d %d/%d ' % (
+                        i + 1,
+                        image_count,
+                        j + 1,
+                        rendition_count
+                    ),
+                    ending=''
+                )
+                self.save(base_url, dest_dir, rendition.file.name)
+
+    def save(self, base_url, dest_dir, path):
+        url = base_url + path
+        filename = dest_dir + path
+
+        self.stdout.write('Saving %s to %s\n' % (url, filename))
+
+        response = requests.get(url, stream=True)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            self.stderr.write(str(e))
+        else:
+            with open(filename, 'wb') as f:
+                for block in response.iter_content(1024):
+                    f.write(block)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -340,6 +340,27 @@ To apply any unapplied migrations to a database created from a dump, run:
 python cfgov/manage.py migrate
 ```
 
+### Sync local image storage
+
+If using a database dump, pages will contain links to images that exist in
+the database but don't exist on your local disk. This will cause broken or
+missing images when browsing the site locally.
+
+For example, in production images are stored on S3, but when running locally
+they are stored on disk.
+
+This project includes a Django management command that can be used to download
+any remote images referenced in the database so that they can be served when
+running locally.
+
+```bash
+cfgov/manage.py sync_image_storage https://files.consumerfinance.gov/f/ ./cfgov/f/
+```
+
+This downloads all remote images (and image renditions) referenced in the
+database, retrieving them from the specified URL and storing them in the
+specified local directory.
+
 ### Set variables for working with the GovDelivery API
 
 Uncomment and set the GovDelivery environment variables in your `.env` file.


### PR DESCRIPTION
When developing locally using a production database dump, it can be distracting and difficult to work with Wagtail images. Images (and their renditions) are stored in the database, but in production the image files themselves are stored in S3. When developing locally with a dump, you have the references to those files, but not the files themselves. This means missing images when browsing pages, which can break layout and make it hard to debug and develop visual styles.

This commit adds a new Django management command, `sync_image_storage`, that can be used to download in bulk all images and renditions referenced in the database.

## Testing

```sh
cfgov/manage.py sync_image_storage https://files.consumerfinance.gov/f/ ./cfgov/f/
```

## Screenshots

![image](https://user-images.githubusercontent.com/654645/69372591-fc2e0900-0c6f-11ea-9d58-a102645413da.png)

## Notes

Note that this can take a little while as it downloads quite a few files (currently 4000+ files, ~400MB).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: