### PR TITLE
Add hardcoded InfoUnits to new homepage design

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/info-unit-group-2.html
+++ b/cfgov/jinja2/v1/_includes/organisms/info-unit-group-2.html
@@ -47,7 +47,7 @@
 {%- from 'molecules/info-unit-2.html' import info_unit with context %}
 
 <div class="o-info-unit-group"
-     {{- ' id="' ~ value.heading.text|slugify ~ '" ' if value.heading.text else ' ' -}}>
+     {{- ' id="' ~ value.heading.text|slugify ~ '" ' if value.heading and value.heading.text else ' ' -}}>
 
 {% if value.heading and value.heading.text %}
     <{{ value.heading.level }}>

--- a/cfgov/jinja2/v1/home-page/index_new.html
+++ b/cfgov/jinja2/v1/home-page/index_new.html
@@ -1,14 +1,17 @@
 {% extends "layout-full.html" %}
 
-{% block content_main %}
-
-<h1>
+{% block title -%}
     {{ _('Consumer Financial Protection Bureau') }}
-</h1>
+{%- endblock %}
 
+{% block content_main %}
 {% block carousel %}
     {% import 'organisms/carousel.html' as o_carousel with context %}
     {{ o_carousel.render() }}
 {% endblock carousel %}
+
+{% with value = {'info_units': info_units, 'format': '33-33-33'} %}
+{% include 'organisms/info-unit-group-2.html' %}
+{% endwith %}
 
 {% endblock content_main %}

--- a/cfgov/jinja2/v1/home-page/index_new.html
+++ b/cfgov/jinja2/v1/home-page/index_new.html
@@ -10,8 +10,9 @@
     {{ o_carousel.render() }}
 {% endblock carousel %}
 
-{% with value = {'info_units': info_units, 'format': '33-33-33'} %}
-{% include 'organisms/info-unit-group-2.html' %}
-{% endwith %}
-
+<section class="block">
+    {% with value = {'info_units': info_units, 'format': '33-33-33'} %}
+    {% include 'organisms/info-unit-group-2.html' %}
+    {% endwith %}
+</section>
 {% endblock content_main %}

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 from django.db import models
 from django.db.models import Q
 
@@ -15,6 +16,142 @@ from modelcluster.fields import ParentalKey
 from v1.atomic_elements import molecules
 from v1.models.base import CFGOVPage
 from v1.util import ref
+
+
+"""Placeholder until these are exposed in the Wagtail admin."""
+_info_units_by_language = {
+    'en': [
+        {
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2485,
+            },
+            'heading': {
+                'text': 'Empowering Consumers',
+                'level': 'h3',
+            },
+            'body': (
+                'We produce innovation products to help consumers make '
+                'informed financial decisions and choose products and '
+                'services that fit their needs.'
+            ),
+            'links': [
+                {
+                    'text': 'Consumer tools',
+                    'url': '/consumer-tools/',
+                },
+                {
+                    'text': 'Resources for practitioners',
+                    'url': '/practitioner-resources/',
+                },
+            ],
+        },
+        {
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2485,
+            },
+            'heading': {
+                'text': 'Rules of the Road',
+                'level': 'h3',
+            },
+            'body': (
+                'We create clear rules to implement the law and preserve '
+                'choices for consumers.'
+            ),
+            'links': [
+                {
+                    'text': 'Rulemaking',
+                    'url': '/policy-compliance/rulemaking/',
+                },
+            ],
+        },
+        {
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2485,
+            },
+            'heading': {
+                'text': 'Enforcing the Law',
+                'level': 'h3',
+            },
+            'body': (
+                'We enforce federal consumer financial laws by investigating '
+                'cases of potential wrongdoing and taking action.'
+            ),
+            'links': [
+                {
+                    'text': 'Enforcement',
+                    'url': '/policy-compliance/enforcement/'
+                },
+            ],
+        },
+        {
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2485,
+            },
+            'heading': {
+                'text': 'Learning through data and research',
+                'level': 'h3',
+            },
+            'body': (
+                u'We publish research and information we’ve collected above '
+                u'the consumer financial marketplace.'
+            ),
+            'links': [
+                {
+                    'text': 'Data & Research',
+                    'url': '/data-research/',
+                },
+            ],
+        },
+        {
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2485,
+            },
+            'heading': {
+                'text': 'Supervision',
+                'level': 'h3',
+            },
+            'body': (
+                'We supervise financial companies to ensure compliance with '
+                'federal consumer laws.'
+            ),
+            'links': [
+                {
+                    'text': 'Policy & Compliance',
+                    'url': '/policy-compliance/',
+                },
+            ],
+        },
+        {
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2485,
+            },
+            'heading': {
+                'text': 'Events',
+                'level': 'h3',
+            },
+            'body': (
+                'We host conferences, workshops, townhalls, symposiums, and '
+                'Advisory Committee meetings.'
+            ),
+            'links': [
+                {
+                    'text': 'Events',
+                    'url': '/about-us/events/',
+                },
+            ],
+        },
+    ],
+}
+
+
+# TODO: Add real info unit content for Spanish.
+_info_units_by_language['es'] = _info_units_by_language['en']
 
 
 class HomePage(CFGOVPage):
@@ -61,8 +198,17 @@ class HomePage(CFGOVPage):
 
     def get_context(self, request):
         context = super(HomePage, self).get_context(request)
-        context['latest_updates'] = self.get_latest_updates(request)
+        context.update({
+            'info_units': self.get_info_units(),
+            'latest_updates': self.get_latest_updates(request),
+        })
         return context
+
+    def get_info_units(self):
+        return [
+            molecules.InfoUnit().to_python(info_unit)
+            for info_unit in _info_units_by_language[self.language]
+        ]
 
     def get_latest_updates(self, request):
         # TODO: There should be a way to express this as part of the query

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -40,10 +40,6 @@ _info_units_by_language = {
                     'text': 'Consumer tools',
                     'url': '/consumer-tools/',
                 },
-                {
-                    'text': 'Resources for practitioners',
-                    'url': '/practitioner-resources/',
-                },
             ],
         },
         {
@@ -64,6 +60,10 @@ _info_units_by_language = {
                     'text': 'Rulemaking',
                     'url': '/policy-compliance/rulemaking/',
                 },
+                {
+                    'text': 'Notice and Opportunities to Comment',
+                    'url': '/policy-compliance/notice-opportunities-comment/'
+                },
             ],
         },
         {
@@ -82,8 +82,12 @@ _info_units_by_language = {
             'links': [
                 {
                     'text': 'Enforcement',
-                    'url': '/policy-compliance/enforcement/'
+                    'url': '/policy-compliance/enforcement/',
                 },
+                {
+                    'text': 'Payments to harmed consumers',
+                    'url': '/about-us/payments-harmed-consumers/',
+                }
             ],
         },
         {
@@ -101,8 +105,12 @@ _info_units_by_language = {
             ),
             'links': [
                 {
-                    'text': 'Data & Research',
+                    'text': 'Data and Research',
                     'url': '/data-research/',
+                },
+                {
+                    'text': 'Financial Well-being survey',
+                    'url': '/data-research/financial-well-being-survey-data/',
                 },
             ],
         },
@@ -121,8 +129,14 @@ _info_units_by_language = {
             ),
             'links': [
                 {
-                    'text': 'Policy & Compliance',
-                    'url': '/policy-compliance/',
+                    'text': 'Compliance and Guidance',
+                    'url': '/policy-compliance/guidance/',
+                },
+                {
+                    'text': 'Supervisory Highlights',
+                    'url': (
+                        '/policy-compliance/guidance/supervisory-highlights/'
+                    ),
                 },
             ],
         },
@@ -141,8 +155,12 @@ _info_units_by_language = {
             ),
             'links': [
                 {
-                    'text': 'Events',
-                    'url': '/about-us/events/',
+                    'text': 'Archive of Events',
+                    'url': '/about-us/events/archive-past-events/',
+                },
+                {
+                    'text': 'Request a Speaker',
+                    'url': '/about-us/events/request-speaker/',
                 },
             ],
         },


### PR DESCRIPTION
This commit adds some hardcoded InfoUnits to the new homepage design, using the 33/33/33 InfoUnitGroup template. This content is hardcoded pending implementation as editable Wagtail blocks. Content is placeholder and is the same in both English and Spanish right now.

@contolini 

## Testing

To test, visit the English and Spanish versions of the new homepage:

- http://localhost:8000/?nhp=True
- http://localhost:8000/es/?nhp=True

## Screenshots

For this to work correctly you need to have the referenced image locally; see #5365 for one way to pull down production images to your local storage.

![image](https://user-images.githubusercontent.com/654645/69378851-3c47b880-0c7d-11ea-8e51-21be6f555daa.png)

The colored box above is the in-progress carousel; @anselmbradford do you have any suggestions for the right way to add some margin between it and this new content?

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: