### PR TITLE
Better logging for sync_image_storage script

### DIFF
--- a/cfgov/v1/management/commands/sync_image_storage.py
+++ b/cfgov/v1/management/commands/sync_image_storage.py
@@ -27,22 +27,20 @@ class Command(BaseCommand):
         image_count = images.count()
 
         for i, image in enumerate(images):
-            self.stdout.write('%d/%d ' % (i + 1, image_count), ending='')
+            image_prefix = '%d/%d (%d) ' % (i + 1, image_count, image.pk)
+            self.stdout.write(image_prefix, ending='')
             self.save(base_url, dest_dir, image.file.name)
 
             renditions = image.renditions.all()
             rendition_count = renditions.count()
 
             for j, rendition in enumerate(renditions):
-                self.stdout.write(
-                    '%d/%d %d/%d ' % (
-                        i + 1,
-                        image_count,
-                        j + 1,
-                        rendition_count
-                    ),
-                    ending=''
+                rendition_prefix = '%d/%d (%d) ' % (
+                    j + 1,
+                    rendition_count,
+                    rendition.pk
                 )
+                self.stdout.write(image_prefix + rendition_prefix, ending='')
                 self.save(base_url, dest_dir, rendition.file.name)
 
     def save(self, base_url, dest_dir, path):


### PR DESCRIPTION
The sync_image_storage management command introduced in #5365 logs the images and renditions that it tries to download. This change modifies the log output so that the primary key is also logged, making it easier to debug any failures.

New log output looks like:

```
1/100 (123) Saving https://files.consumerfinance.gov/f/original_images/foo.png to ./cfgov/f/original_images/foo.png
1/100 (123) 1/3 (456) Saving https://files.consumerfinance.gov/f/images/foo.max-800x600.png to ./cfgov/f/images/foo.max-800x600.png
...
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: