### PR TITLE
Prepare placeholder carousel data for Wagtail

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -9,36 +9,52 @@
    Creates markup for a Carousel organism, which displays a set of
    blocks of content that can be navigated through sequentially.
 
+   value._items:                Carousel content panels.
+
+   item.title:                  Panel title.
+
+   item.body:                   Panel body text.
+
+   item.link.text:              Panel link text.
+
+   item.link.url:               Panel link URL.
+
+   item.image.url:              URL to panel image.
+
+   item.image.alt_text:         Alt text for panel image.
+
+   item.image.thumbnail_url:    URL to panel thumbnail image.
+
    ========================================================================== #}
 
-{% macro render_carousel_item( title ) %}
+{% macro render_carousel_item( item ) %}
 <section class="o-carousel_item">
     <div class="o-carousel_item-text">
-        <h2>{{ title }}</h2>
-        <p>
-            {{ caller() }}
-        </p>
+        <h2>{{ item.title }}</h2>
+        <p>{{ item.body }}</p>
+        <p><a href="{{ item.link.url }}">{{ item.link.text }}</a></p>
     </div>
     <div class="o-carousel_item-visual">
         <img class="o-carousel_item-img"
-            src="https://dummyimage.com/1076x606/addc91/101820"
-            alt="">
+             src="{{ item.image.url }}"
+             alt="{{ item.image.alt_text }}"
+        >
     </div>
 </section>
 {% endmacro %}
 
-{% macro render_carousel_thumbnail( title, is_selected=false ) %}
+{% macro render_carousel_thumbnail( item, is_selected=false ) %}
 <button class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
     <div class="o-carousel_thumbnail-visual">
         <img class="o-carousel_thumbnail-img"
-            src="https://dummyimage.com/48x48/addc91/101820"
-            alt="">
+             src="{{ item.image.thumbnail_url }}"
+             alt="{{ item.image.alt_text }}">
     </div>
-    <h6 class="o-carousel_thumbnail-text">{{ title }}</h6>
+    <h6 class="o-carousel_thumbnail-text">{{ item.title }}</h6>
 </button>
 {% endmacro %}
 
-{% macro render() %}
+{% macro render(value) %}
 <div class="o-carousel u-hidden">
     <div class="o-carousel_navigator">
 
@@ -50,33 +66,19 @@
         </button>
 
         <ul class="o-carousel_items">
-
-            {% call render_carousel_item( 'Start small, Save Up campaign' ) %}
-                Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.
-            {% endcall %}
-
-            {% call render_carousel_item( 'Financial Literacy Month' ) %}
-                Show belly cat milk copy park pee walk owner escape bored tired cage droppings sick vet vomit favor packaging over toy cats making all the muffins get scared by doggo also cucumerro . Sit in window and stare oooh, a bird, yum meow meow.
-            {% endcall %}
-
-            {% call render_carousel_item( 'This is a key initiative' ) %}
-                Doggo ipsum dat tungg tho wrinkler heck borking doggo aqua doggo, pats heckin borkdrive. Heckin angery woofer fluffer thicc blep, big ol pupper length boy shooberino super chub, heckin shibe. Smol borking doggo with a long snoot for pats boofers borkdrive such treat fat boi, puggorino borkf long woofer.
-            {% endcall %}
-
-            {% call render_carousel_item( 'This is title fourth item' ) %}
-                Robot ipsum Zygolike perfluoroeae benzocy equiphage telluriose quinhood exbiile hysterophyceae tetride. Italocarp nonalyte silicoistically isoaria Panule genitoatory gamolog herpetoonymy. Thanatostat Sinophorous poikiloite toxoid dermatocarpous osmioopsy xennamancy. Omphaloate nanoonymy ekageny euphane forthphyll deuterolepry auxostomy. Choleid symule vicelike italoderm cacory bradynasty speleoite enneanomics. Papaphilous petaworthy eurie contrataxy poikilooideae contraal limnont quinathon umbeont. Dextomy raceade.
-            {% endcall %}
-
+            {% for item in value._items %}
+                {{ render_carousel_item( item ) }}
+            {% endfor %}
         </ul>
 
     </div>
 
     <ul class="o-carousel_thumbnails">
-        {{ render_carousel_thumbnail( 'Start small, Save Up campaign', true ) }}
-        {{ render_carousel_thumbnail( 'Financial Literacy Month' ) }}
-        {{ render_carousel_thumbnail( 'This is a key initiative' ) }}
-        {{ render_carousel_thumbnail( 'This is title fourth item' ) }}
+        {% for item in value._items %}
+            {{ render_carousel_thumbnail( item, loop.first ) }}
+        {% endfor %}
     </ul>
 </div>
-
 {% endmacro %}
+
+{% if value %}{{ render(value) }}{% endif %}

--- a/cfgov/jinja2/v1/home-page/index_new.html
+++ b/cfgov/jinja2/v1/home-page/index_new.html
@@ -6,8 +6,9 @@
 
 {% block content_main %}
 {% block carousel %}
-    {% import 'organisms/carousel.html' as o_carousel with context %}
-    {{ o_carousel.render() }}
+    {% with value = {'_items': carousel_items} %}
+    {% include 'organisms/carousel.html' %}
+    {% endwith %}
 {% endblock carousel %}
 
 <section class="block">

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -19,6 +19,82 @@ from v1.util import ref
 
 
 """Placeholder until these are exposed in the Wagtail admin."""
+_placeholder_carousel_image_url = (
+    'https://files.consumerfinance.gov/f/original_images/'
+    'cfpb_mayg_bookshelf_puppy-in-the-window.jpg'
+)
+
+
+_placeholder_carousel_image = {
+    'url': _placeholder_carousel_image_url,
+    'alt_text': 'Alt text goes here',
+    'thumbnail_url': _placeholder_carousel_image_url,
+}
+
+
+_carousel_items_by_language = {
+    'en': [
+        {
+            'title': 'Start Small, Save Up',
+            'body': (
+                'Whether you want to put money aside for unexpected expenses '
+                'or make a plan to save for your future goals, we have '
+                'resources that can help.'
+            ),
+            'link': {
+                'text': 'Learn how to get started',
+                'url': '/start-small-save-up/',
+            },
+            'image': _placeholder_carousel_image,
+        },
+        {
+            'title': 'Tax time',
+            'body': (
+                'Take advantage of the time when you are filing your tax '
+                'return to set aside a portion of your refund towards savings.'
+            ),
+            'link': {
+                'text': 'Learn more about tax time savings',
+                'url': '/about-us/blog/tax-time-saving-tips/',
+            },
+            'image': _placeholder_carousel_image,
+        },
+        {
+            'title': 'Building a Bridge to Credit Visibility Symposium',
+            'body': (
+                'Mark your Calendar to join the Bureau for a day-long '
+                'symposium on September 17, 2018, from 8:00am to 4:45pm'
+            ),
+            'link': {
+                'text': 'Learn more about this event',
+                'url': (
+                    '/about-us/events/archive-past-events'
+                    '/building-bridge-credit-visibility/'
+                ),
+            },
+            'image': _placeholder_carousel_image,
+        },
+        {
+            'title': 'Equifax data breach updates',
+            'body': (
+                'Today the CFPB, FTC and States Announced Settlement with '
+                'Equifax Over 2017 Data Breach.'
+            ),
+            'link': {
+                'text': 'Find out more details',
+                'url': '/equifax-settlement/',
+            },
+            'image': _placeholder_carousel_image,
+        },
+    ],
+}
+
+
+# TODO: Add real carousel content for Spanish.
+_carousel_items_by_language['es'] = _carousel_items_by_language['en']
+
+
+"""Placeholder until these are exposed in the Wagtail admin."""
 _info_units_by_language = {
     'en': [
         {
@@ -217,10 +293,14 @@ class HomePage(CFGOVPage):
     def get_context(self, request):
         context = super(HomePage, self).get_context(request)
         context.update({
+            'carousel_items': self.get_carousel_items(),
             'info_units': self.get_info_units(),
             'latest_updates': self.get_latest_updates(request),
         })
         return context
+
+    def get_carousel_items(self):
+        return _carousel_items_by_language[self.language]
 
     def get_info_units(self):
         return [


### PR DESCRIPTION
This change adds some placeholder content for the carousel in the new home page design.

@contolini 

## Testing

Run a local server and visit http://localhost:8000/?nhp=True.

## Screenshots

The design still needs some work to properly handle image sizing, I think?

![image](https://user-images.githubusercontent.com/654645/69549704-c9358f00-0f67-11ea-9142-891185a0502b.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: