### PR TITLE
Handle missing carousel organism on home page

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/home-page.js
+++ b/cfgov/unprocessed/js/routes/on-demand/home-page.js
@@ -5,5 +5,8 @@
 import Carousel from '../../organisms/Carousel.js';
 
 const carouselDom = document.querySelector( `.${ Carousel.BASE_CLASS }` );
-const carousel = new Carousel( carouselDom );
-carousel.init();
+
+if ( carouselDom ) {
+    const carousel = new Carousel( carouselDom );
+    carousel.init();
+}


### PR DESCRIPTION
This commit fixes a bug with the prototype carousel created for a new home page design. When running the current production home page, there's no carousel element, so this causes a JS console error.

This change handles the case where there is no carousel organism, while still properly handling the case when there is one.

@contolini

## Testing

To test: `gulp clean && gulp build`, visit http://localhost:8000.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: