### PR TITLE
Fix iRegs wayfinder JS errors on odd paragraphs

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -122,13 +122,16 @@ const getCommentMarker = label => {
   let commentParagraphID = '';
 
   const splitCurrentParagraph = label.split( 'Interp' );
+  /* A guard clause just in case any comment paragraphs have an invalid ID that
+     doesn't have 'Interp' in it */
+  if ( splitCurrentParagraph.length < 2 ) {
+    return '';
+  }
   if ( splitCurrentParagraph !== null ) {
     commentedParagraphID = splitCurrentParagraph[0]
       .split( '-' );
-    if ( splitCurrentParagraph[1] ) {
-      commentParagraphID = splitCurrentParagraph[1]
-        .split( '-' );
-    }
+    commentParagraphID = splitCurrentParagraph[1]
+      .split( '-' );
   }
   if ( commentedParagraphID !== null ) {
     commentedSection = commentedParagraphID[0];
@@ -141,13 +144,11 @@ const getCommentMarker = label => {
         .join( ')(' );
       commentedParagraph = '(' + commentedParagraph + ')';
     }
-    if ( commentParagraphID !== '' ) {
-      commentParagraph = commentParagraphID
-        .slice( 1 )
-        .join( '.' );
-      if ( commentParagraph !== '' ) {
-        commentParagraph = '-' + commentParagraph;
-      }
+    commentParagraph = commentParagraphID
+      .slice( 1 )
+      .join( '.' );
+    if ( commentParagraph !== '' ) {
+      commentParagraph = '-' + commentParagraph;
     }
   }
 

--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -125,8 +125,10 @@ const getCommentMarker = label => {
   if ( splitCurrentParagraph !== null ) {
     commentedParagraphID = splitCurrentParagraph[0]
       .split( '-' );
-    commentParagraphID = splitCurrentParagraph[1]
-      .split( '-' );
+    if ( splitCurrentParagraph[1] ) {
+      commentParagraphID = splitCurrentParagraph[1]
+        .split( '-' );
+    }
   }
   if ( commentedParagraphID !== null ) {
     commentedSection = commentedParagraphID[0];
@@ -139,11 +141,13 @@ const getCommentMarker = label => {
         .join( ')(' );
       commentedParagraph = '(' + commentedParagraph + ')';
     }
-    commentParagraph = commentParagraphID
-      .slice( 1 )
-      .join( '.' );
-    if ( commentParagraph !== '' ) {
-      commentParagraph = '-' + commentParagraph;
+    if ( commentParagraphID !== '' ) {
+      commentParagraph = commentParagraphID
+        .slice( 1 )
+        .join( '.' );
+      if ( commentParagraph !== '' ) {
+        commentParagraph = '-' + commentParagraph;
+      }
     }
   }
 

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -203,6 +203,7 @@ describe( 'The Regs3K permalinks utils', () => {
       expect( utils.getCommentMarker( '17-a-1-Interp-1' ) ).toEqual( '17(a)(1)-1' );
       expect( utils.getCommentMarker( '3-d-Interp-1' ) ).toEqual( '3(d)-1' );
       expect( utils.getCommentMarker( '3-c-2-Interp-1' ) ).toEqual( '3(c)(2)-1' );
+      expect( utils.getCommentMarker( '1' ) ).toEqual('');
     } );
 
   } );


### PR DESCRIPTION
Certain paragraphs in iRegs have odd `data-label` values, e.g., the first five paragraphs on 
https://www.consumerfinance.gov/policy-compliance/rulemaking/regulations/1002/Interp-9/. This commit puts certain statements containing methods that were assuming other formats for that attribute inside conditionals to prevent those methods from erroring on the unexpected input.

/cc @contolini, @cfarm 

## Testing

1. Visit https://www.consumerfinance.gov/policy-compliance/rulemaking/regulations/1002/Interp-9/
1. Open the dev tools console and start scrolling down
1. Observe errors popping in, e.g., `Uncaught TypeError: Cannot read property 'split' of undefined`
1. Pull this branch
1. `yarn run gulp scripts:apps`
1. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1002/Interp-9/
1. Open the dev tools console and start scrolling down
1. Observe no errors!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android
