### PR TITLE
Homepage: Flexible thumbnail layout in carousel

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -45,12 +45,14 @@
 
 {% macro render_carousel_thumbnail( item, is_selected=false ) %}
 <button class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
-    <div class="o-carousel_thumbnail-visual">
-        <img class="o-carousel_thumbnail-img"
-             src="{{ item.image.thumbnail_url }}"
-             alt="{{ item.image.alt_text }}">
-    </div>
-    <h6 class="o-carousel_thumbnail-text">{{ item.title }}</h6>
+    <li class="o-carousel_thumbnail-layout">
+        <div class="o-carousel_thumbnail-visual">
+            <img class="o-carousel_thumbnail-img"
+                src="{{ item.image.thumbnail_url }}"
+                alt="{{ item.image.alt_text }}">
+        </div>
+        <h6 class="o-carousel_thumbnail-text">{{ item.title }}</h6>
+    </li>
 </button>
 {% endmacro %}
 

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -1,7 +1,8 @@
 .o-carousel {
 
-  // Override default unordered list padding.
-  & ul {
+  // Override default unordered list and button padding and button border.
+  & ul,
+  & button {
     padding: 0;
   }
 
@@ -71,26 +72,27 @@
   }
 
   &_thumbnails {
-    // Remove gap between child inline elements. See https://stackoverflow.com/questions/26950005/strange-gap-between-two-buttons
-    font-size: 0;
+    display: flex;
+    flex-wrap: wrap;
+    border: 1px solid @gray;
+    border-right: none;
   }
 
   &_thumbnail {
+    flex-grow: 1;
+    flex-direction: column;
+    min-width: 200px;
     width: 25%;
-    display: table-row;
-
-    // This should be set to the height of the thumbnail image we want to include.
-    height: 100px;
-
-    // Set font-size to override parent font-size:0, which removes the gap between the thumbnails.
-    font-size: unit( 16px / @base-font-size-px, rem );
-    background: @white;
+    margin-left: -1px;
+    margin-top: -1px;
     border: 1px solid @gray;
-    border-right: none;
+    border-bottom: none;
+    background: @white;
+  }
 
-    &:nth-child(4) {
-      border-right: 1px solid @gray;
-    }
+  &_thumbnail-layout {
+    width: 100%;
+    display: table;
   }
 
   &_thumbnail-selected {
@@ -100,10 +102,12 @@
   &_thumbnail-visual,
   &_thumbnail-text {
     display: table-cell;
+    padding: 10px;
+  }
 
-    padding: 5px;
-    text-align: left;
-    vertical-align: top;
+  // Set to same size as child image.
+  &_thumbnail-visual {
+    width: 48px;
   }
 
   // These are temporary styles.
@@ -112,6 +116,11 @@
     width: 48px;
     display: block;
     border: 1px solid gray;
+  }
+
+  &_thumbnail-text {
+    text-align: left;
+    vertical-align: top;
   }
 }
 

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -83,6 +83,9 @@
     flex-direction: column;
     min-width: 200px;
     width: 25%;
+
+    // To avoid a double border, we offset the position by a pixel to overlap
+    // the border set on the parent.
     margin-left: -1px;
     margin-top: -1px;
     border: 1px solid @gray;


### PR DESCRIPTION
## Changes

- Incorporates flexbox into thumbnail layout for a flexible responsive layout for the thumbnails.

## Testing

1. Pull branch, `gulp clean && gulp build`
2. Visit http://localhost:8000/?nhp=True and edit content to add longer text and see that all thumbnails have single pixel borders and are top aligned at all screen sizes.

## Screenshots

With taller content:
<img width="1056" alt="Screen Shot 2019-11-26 at 11 00 38 AM" src="https://user-images.githubusercontent.com/704760/69650288-62ce7080-103c-11ea-9df2-b61e911e3c60.png">

Responsive:
![carousel](https://user-images.githubusercontent.com/704760/69650327-6feb5f80-103c-11ea-990a-6bdadf9a85c8.gif)


## Notes

- Focus states are not ready.
- We'll likely want to add flexbox to modernizr and hide it when flexbox is not supported (legacy IE)