### PR TITLE
Homepage: Convert to standard button for carousel slideshow

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -58,11 +58,11 @@
 <div class="o-carousel u-hidden">
     <div class="o-carousel_navigator">
 
-        <button class="o-carousel_btn o-carousel_btn-prev" aria-label="Previous showcase item">
-            {{ svg_icon( 'left-round' ) }}
+        <button class="o-carousel_btn o-carousel_btn-prev a-btn" aria-label="Previous showcase item">
+            {{ svg_icon( 'left' ) }}
         </button>
-        <button class="o-carousel_btn o-carousel_btn-next" aria-label="Next showcase item">
-            {{ svg_icon( 'right-round' ) }}
+        <button class="o-carousel_btn o-carousel_btn-next a-btn" aria-label="Next showcase item">
+            {{ svg_icon( 'right' ) }}
         </button>
 
         <ul class="o-carousel_items">

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -10,11 +10,8 @@
   }
 
   &_btn {
-    background: @white;
-    border: none;
-    border-radius: 1000px;
-    width: 32px;
-    height: 32px;
+    padding-left: unit( 10px / @btn-font-size, em );
+    padding-right: unit( 10px / @btn-font-size, em );
     margin-top: -16px;
     position: absolute;
     top: 50%;
@@ -25,17 +22,6 @@
 
     &-next {
       right: 20px;
-    }
-
-    & svg {
-      position: absolute;
-
-      // These are essentially magic numbers to position the SVG in the middle of a solid circle.
-      left: 2px;
-      top: -2px;
-      width: 28px;
-      height: 36px;
-      font-size: 40px;
     }
   }
 


### PR DESCRIPTION
## Changes

- Changes next/previous buttons in the carousel slideshow to use standard `a-btn` CF classes.

## Testing

1. Pull branch, run `gulp clean && gulp build`
2. Visit http://localhost:8000/?nhp=True and see that buttons are standard blue buttons.

## Screenshots

<img width="376" alt="Screen Shot 2019-11-26 at 11 41 55 AM" src="https://user-images.githubusercontent.com/704760/69653843-cc04b280-1041-11ea-8004-226905c22f2a.png">