### PR TITLE
Fix webpack mode warning

### DIFF
--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -9,7 +9,11 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 
 // Constants
 const COMMON_BUNDLE_NAME = 'common.js';
-const WEBPACK_MODE = 'production';
+
+/* This sets the default mode for webpack configurations to satisfy the need
+   of webpack to have a `mode` set.
+   This value gets overridden when NODE_ENV=development. */
+const WEBPACK_MODE_DEFAULT = 'production';
 
 /* Commmon webpack 'module' option used in each configuration.
    Runs code through Babel and uses global supported browser list. */
@@ -69,7 +73,7 @@ const STATS_CONFIG = {
 
 const commonConf = {
   cache: true,
-  mode: WEBPACK_MODE,
+  mode: WEBPACK_MODE_DEFAULT,
   module: COMMON_MODULE_CONFIG,
   output: {
     filename: '[name]'
@@ -87,7 +91,7 @@ const commonConf = {
 
 const externalConf = {
   cache: true,
-  mode: WEBPACK_MODE,
+  mode: WEBPACK_MODE_DEFAULT,
   module: COMMON_MODULE_CONFIG,
   output: {
     filename: 'external-site.js'
@@ -105,7 +109,7 @@ const externalConf = {
 
 const modernConf = {
   cache: true,
-  mode: WEBPACK_MODE,
+  mode: WEBPACK_MODE_DEFAULT,
   module: COMMON_MODULE_CONFIG,
   output: {
     filename: '[name]'
@@ -125,7 +129,7 @@ const modernConf = {
 };
 
 const onDemandHeaderRawConf = {
-  mode: WEBPACK_MODE,
+  mode: WEBPACK_MODE_DEFAULT,
   module: COMMON_MODULE_CONFIG,
   resolve: {
     symlinks: false
@@ -134,7 +138,7 @@ const onDemandHeaderRawConf = {
 
 const appsConf = {
   cache: true,
-  mode: WEBPACK_MODE,
+  mode: WEBPACK_MODE_DEFAULT,
   module: COMMON_MODULE_CONFIG,
   output: {
     filename: '[name]',
@@ -156,7 +160,7 @@ const appsConf = {
 
 const spanishConf = {
   cache: true,
-  mode: WEBPACK_MODE,
+  mode: WEBPACK_MODE_DEFAULT,
   module: COMMON_MODULE_CONFIG,
   output: {
     filename: 'spanish.js'

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -12,7 +12,8 @@ const COMMON_BUNDLE_NAME = 'common.js';
 
 /* This sets the default mode for webpack configurations to satisfy the need
    of webpack to have a `mode` set.
-   This value gets overridden when NODE_ENV=development. */
+   This value gets overridden when NODE_ENV=development.
+   See the `if ( envvars.NODE_ENV === 'development' )` block below. */
 const WEBPACK_MODE_DEFAULT = 'production';
 
 /* Commmon webpack 'module' option used in each configuration.

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -125,6 +125,7 @@ const modernConf = {
 };
 
 const onDemandHeaderRawConf = {
+  mode: 'production',
   module: COMMON_MODULE_CONFIG,
   resolve: {
     symlinks: false

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -10,7 +10,6 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 // Constants
 const COMMON_BUNDLE_NAME = 'common.js';
 const WEBPACK_MODE = 'production';
-const IS_MINIMIZED = true;
 
 /* Commmon webpack 'module' option used in each configuration.
    Runs code through Babel and uses global supported browser list. */
@@ -76,7 +75,6 @@ const commonConf = {
     filename: '[name]'
   },
   optimization: {
-    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -95,7 +93,6 @@ const externalConf = {
     filename: 'external-site.js'
   },
   optimization: {
-    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -117,7 +114,6 @@ const modernConf = {
     COMMON_CHUNK_CONFIG
   ],
   optimization: {
-    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -148,7 +144,6 @@ const appsConf = {
     COMMON_CHUNK_CONFIG
   ],
   optimization: {
-    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -167,7 +162,6 @@ const spanishConf = {
     filename: 'spanish.js'
   },
   optimization: {
-    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -9,6 +9,8 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 
 // Constants
 const COMMON_BUNDLE_NAME = 'common.js';
+const WEBPACK_MODE = 'production';
+const IS_MINIMIZED = true;
 
 /* Commmon webpack 'module' option used in each configuration.
    Runs code through Babel and uses global supported browser list. */
@@ -68,12 +70,13 @@ const STATS_CONFIG = {
 
 const commonConf = {
   cache: true,
+  mode: WEBPACK_MODE,
   module: COMMON_MODULE_CONFIG,
-  mode: 'production',
   output: {
     filename: '[name]'
   },
   optimization: {
+    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -86,13 +89,13 @@ const commonConf = {
 
 const externalConf = {
   cache: true,
+  mode: WEBPACK_MODE,
   module: COMMON_MODULE_CONFIG,
-  mode: 'production',
   output: {
     filename: 'external-site.js'
   },
   optimization: {
-    minimize: true,
+    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -105,7 +108,7 @@ const externalConf = {
 
 const modernConf = {
   cache: true,
-  mode: 'production',
+  mode: WEBPACK_MODE,
   module: COMMON_MODULE_CONFIG,
   output: {
     filename: '[name]'
@@ -114,6 +117,7 @@ const modernConf = {
     COMMON_CHUNK_CONFIG
   ],
   optimization: {
+    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -125,7 +129,7 @@ const modernConf = {
 };
 
 const onDemandHeaderRawConf = {
-  mode: 'production',
+  mode: WEBPACK_MODE,
   module: COMMON_MODULE_CONFIG,
   resolve: {
     symlinks: false
@@ -134,8 +138,8 @@ const onDemandHeaderRawConf = {
 
 const appsConf = {
   cache: true,
+  mode: WEBPACK_MODE,
   module: COMMON_MODULE_CONFIG,
-  mode: 'production',
   output: {
     filename: '[name]',
     jsonpFunction: 'apps'
@@ -144,6 +148,7 @@ const appsConf = {
     COMMON_CHUNK_CONFIG
   ],
   optimization: {
+    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]
@@ -156,12 +161,13 @@ const appsConf = {
 
 const spanishConf = {
   cache: true,
+  mode: WEBPACK_MODE,
   module: COMMON_MODULE_CONFIG,
-  mode: 'production',
   output: {
     filename: 'spanish.js'
   },
   optimization: {
+    minimize: IS_MINIMIZED,
     minimizer: [
       COMMON_MINIFICATION_CONFIG
     ]


### PR DESCRIPTION
## Changes

- Adds missing `mode` configuration to webpack config.
- Move webpack mode ~~and minimization~~ settings to constants.

## Testing

1. `gulp build` on `master` shows a warning for `mode`.
2. `gulp build` on this branch does not.
3. If you have `export NODE_ENV=development && gulp clean && gulp build` the code should be unminimized. If you `export NODE_ENV=production && gulp clean && gulp build` the code should be minimized.

## Screenshots

Fixes this warning
<img width="1029" alt="Screen Shot 2019-11-26 at 11 46 43 AM" src="https://user-images.githubusercontent.com/704760/69654968-a9739900-1043-11ea-9e7a-cb99afc423e3.png">
