### PR TITLE
Fix button padding

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -1,8 +1,7 @@
 .o-carousel {
 
-  // Override default unordered list and button padding and button border.
-  & ul,
-  & button {
+  // Override default unordered list padding.
+  & ul {
     padding: 0;
   }
 
@@ -74,6 +73,8 @@
     // the border set on the parent.
     margin-left: -1px;
     margin-top: -1px;
+    // Remove default button padding.
+    padding: 0;
     border: 1px solid @gray;
     border-bottom: none;
     background: @white;


### PR DESCRIPTION
Fix issue introduced when merging https://github.com/cfpb/cfgov-refresh/pull/5377 and https://github.com/cfpb/cfgov-refresh/pull/5376 one after the other. One used the default button styles and the other set those styles to zero padding. The zero padding should only be applied to buttons in the thumbnails.

## Changes

- Move zero padding of buttons to thumbnails only.
