### PR TITLE
Homepage: Set focus styles on carousel thumbnails

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -32,10 +32,6 @@
 
   &_item {
     box-sizing: border-box;
-
-    &:not( .u-hidden ) {
-      display: table-row;
-    }
   }
 
   &_item-text {
@@ -43,6 +39,7 @@
     width: 66%;
     padding: unit( @grid_gutter-width / @base-font-size-px, em );
     padding-left: unit( ( @grid_gutter-width * 3 ) / @base-font-size-px, em );
+    vertical-align: top;
   }
 
   &_item-visual {
@@ -68,16 +65,16 @@
     flex-direction: column;
     min-width: 200px;
     width: 25%;
-
-    // To avoid a double border, we offset the position by a pixel to overlap
-    // the border set on the parent.
-    margin-left: -1px;
-    margin-top: -1px;
-    // Remove default button padding.
+    // Remove default button padding and border.
     padding: 0;
-    border: 1px solid @gray;
-    border-bottom: none;
+    border: none;
+    border-right: 1px solid @gray;
     background: @white;
+
+    &:focus {
+      outline: 1px dotted @pacific;
+      outline-offset: 2px;
+    }
   }
 
   &_thumbnail-layout {
@@ -87,6 +84,10 @@
 
   &_thumbnail-selected {
     background: @gray-10;
+  }
+
+  &_thumbnail:focus {
+    z-index: 1;
   }
 
   &_thumbnail-visual,


### PR DESCRIPTION
## Changes

- Set focus state on carousel thumbnails.
- Vertical-align the slide text content to the top.
- Remove unneeded `display: table-row` rule.

## Testing

1. Pull branch, `gulp clean && gulp build`
2. Visit http://localhost:8000/?nhp=True
3. Click into the carousel and then use the tab key to navigate to the thumbnails. Note that they get a focus border around them. Use the spacebar to "click" them. Use shift+tab key to go in the reverse order.

## Screenshots

<img width="1155" alt="Screen Shot 2019-11-26 at 5 04 45 PM" src="https://user-images.githubusercontent.com/704760/69676518-ea34d780-106e-11ea-9abd-7a1a698d66b8.png">
