### PR TITLE
Add placeholder content for home page cards

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/card.html
+++ b/cfgov/jinja2/v1/_includes/molecules/card.html
@@ -18,7 +18,7 @@
    ========================================================================== #}
 
 {% macro render( value ) %}
-<div class="o-card-group">
+<div class="m-card">
     {{ svg_icon( value.icon ) }}
     <p>{{ value.text }}</p>
     <a href="{{ value.link_url }}">{{ value.link_text }}</a>

--- a/cfgov/jinja2/v1/_includes/molecules/card.html
+++ b/cfgov/jinja2/v1/_includes/molecules/card.html
@@ -1,17 +1,26 @@
 {# ==========================================================================
 
-   Card
+   card.render( value )
 
    ==========================================================================
 
    Description:
 
-   Creates a card with header and body text.
+   Creates markup for a Card molecule, which displays an icon, some text,
+   and a link.
+
+   value.text:                  Card body text.
+
+   value.link_text:             Card link text.
+
+   value.link_url:              Card link URL.
 
    ========================================================================== #}
 
-{# TODO: This is a prototype and needs to change the text via parameters. #}
-<div class="m-card">
-    <h3 class="h1 m-card_heading">Card Heading</h3>
-    <p class="m-card_body">Card text</p>
+{% macro render( value ) %}
+<div class="o-card-group">
+    {{ svg_icon( value.icon ) }}
+    <p>{{ value.text }}</p>
+    <a href="{{ value.link_url }}">{{ value.link_text }}</a>
 </div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/card-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/card-group.html
@@ -1,0 +1,33 @@
+{# ==========================================================================
+
+   card_group.render( heading, cards )
+
+   ==========================================================================
+
+   Description:
+
+   Creates markup for a Card Group organism, which displays a heading
+   and set of cards.
+
+   heading:                     Group heading.
+
+   card.icon:                   Card icon.
+
+   card.text:                   Card body text.
+
+   card.link_text:              Card link text.
+
+   card.link_url:               Card link URL.
+
+   ========================================================================== #}
+
+{% import "molecules/card.html" as card with context %}
+
+{% macro render( heading, cards ) %}
+<div class="o-card-group">
+    <h4>{{ heading }}</h4>
+    {% for _card in cards %}
+        {{ card.render( _card ) }}
+    {% endfor %}
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/home-page/index_new.html
+++ b/cfgov/jinja2/v1/home-page/index_new.html
@@ -1,5 +1,7 @@
 {% extends "layout-full.html" %}
 
+{% import "organisms/card-group.html" as card_group with context %}
+
 {% block title -%}
     {{ _('Consumer Financial Protection Bureau') }}
 {%- endblock %}
@@ -15,5 +17,9 @@
     {% with value = {'info_units': info_units, 'format': '33-33-33'} %}
     {% include 'organisms/info-unit-group-2.html' %}
     {% endwith %}
+</section>
+
+<section class="block">
+    {{ card_group.render( card_heading, cards ) }}   
 </section>
 {% endblock content_main %}

--- a/cfgov/jinja2/v1/home-page/index_new.html
+++ b/cfgov/jinja2/v1/home-page/index_new.html
@@ -20,6 +20,6 @@
 </section>
 
 <section class="block">
-    {{ card_group.render( card_heading, cards ) }}   
+    {{ card_group.render( card_heading, cards ) }}
 </section>
 {% endblock content_main %}

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -248,6 +248,40 @@ _info_units_by_language = {
 _info_units_by_language['es'] = _info_units_by_language['en']
 
 
+_cards_by_language = {
+    'en': [
+        {
+            'icon': 'warning',
+            'text': 'Have an issue with a financial product?',
+            'link_text': 'Submit a complaint',
+            'link_url': '/complaint/',
+        },
+        {
+            'icon': 'lightbulb',
+            'text': (
+                'Have a question on a financial topic? '
+                'Browse answers to hundreds of financial questions.'
+            ),
+            'link_text': 'Browse Ask CFPB',
+            'link_url': '/ask-cfpb/',
+        },
+        {
+            'icon': 'open-quote',
+            'text': (
+                'Tell us your experiences with money and financial services. '
+                'The CFPB is listening.'
+            ),
+            'link_text': 'Tell your story',
+            'link_url': '/your-story/',
+        },
+    ],
+}
+
+
+# TODO: Add real card content for Spanish.
+_cards_by_language['es'] = _cards_by_language['en']
+
+
 class HomePage(CFGOVPage):
     header = StreamField([
         ('info_unit', molecules.InfoUnit()),
@@ -295,6 +329,9 @@ class HomePage(CFGOVPage):
         context.update({
             'carousel_items': self.get_carousel_items(),
             'info_units': self.get_info_units(),
+            # TODO: Add Spanish version of this heading.
+            'card_heading': "We want to hear from you",
+            'cards': self.get_cards(),
             'latest_updates': self.get_latest_updates(request),
         })
         return context
@@ -307,6 +344,9 @@ class HomePage(CFGOVPage):
             molecules.InfoUnit().to_python(info_unit)
             for info_unit in _info_units_by_language[self.language]
         ]
+
+    def get_cards(self):
+        return _cards_by_language[self.language]
 
     def get_latest_updates(self, request):
         # TODO: There should be a way to express this as part of the query


### PR DESCRIPTION
This commit adds placeholder content for the cards in the new home page design, along with some stub frontend code for rendering them (desperately in need of styles).

@contolini 

## Testing

Run a local server and visit http://localhost:8000/?nhp=True.

## Screenshots

Currently renders like this:

![image](https://user-images.githubusercontent.com/654645/69677398-db4f2480-1070-11ea-95e2-8b61db2ff64f.png)

## Notes

I took a stab at creating an organism/molecule for these, but defer to FEWDs as to the right way to do this.

## Todos

- Needs automated tests.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: