### PR TITLE
Homepage: mobile carousel items

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -32,11 +32,7 @@
     <div class="o-carousel_item-text">
         <h2>{{ item.title }}</h2>
         <p>{{ item.body }}</p>
-        <p>
-            <a href="{{ item.link.url }}">
-                {{ item.link.text }}
-            </a>
-        </p>
+        <p><a href="{{ item.link.url }}">{{ item.link.text }}</a></p>
     </div>
     <div class="o-carousel_item-visual">
         <img class="o-carousel_item-img"
@@ -48,23 +44,36 @@
 {% endmacro %}
 
 {% macro render_carousel_thumbnail( item, is_selected=false ) %}
-{#
-    Since desktop uses a button and mobile uses links,
-    we simulate a button here at desktop sizes, so we need to set the tab index.
-#}
-<div class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}"
-     role="button"
-     tabindex="0">
+<button class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
     <li class="o-carousel_thumbnail-layout">
         <div class="o-carousel_thumbnail-visual">
-            <a href="{{ item.link.url }}" tabindex="-1">
+            <img class="o-carousel_thumbnail-img"
+                src="{{ item.image.thumbnail_url }}"
+                alt="{{ item.image.alt_text }}">
+        </div>
+        <p class="o-carousel_thumbnail-text">
+            {{ item.title }}
+        <p>
+    </li>
+</button>
+{% endmacro %}
+
+{#
+    Since desktop uses a button and mobile uses links,
+    we duplicate the markup here but use a div instead of a button.
+#}
+{% macro render_carousel_thumbnail_mobile( item, is_selected=false ) %}
+<div class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
+    <li class="o-carousel_thumbnail-layout">
+        <div class="o-carousel_thumbnail-visual">
+            <a href="{{ item.link.url }}">
                 <img class="o-carousel_thumbnail-img"
                     src="{{ item.image.thumbnail_url }}"
                     alt="{{ item.image.alt_text }}">
             </a>
         </div>
         <p class="o-carousel_thumbnail-text">
-            <a href="{{ item.link.url }}" tabindex="-1">
+            <a href="{{ item.link.url }}">
                 {{ item.title }}
             </a>
         <p>
@@ -97,6 +106,12 @@
     <ul class="o-carousel_thumbnails">
         {% for item in value._items %}
             {{ render_carousel_thumbnail( item, loop.first ) }}
+        {% endfor %}
+    </ul>
+
+    <ul class="o-carousel_thumbnails o-carousel_thumbnails__mobile">
+        {% for item in value._items %}
+            {{ render_carousel_thumbnail_mobile( item, loop.first ) }}
         {% endfor %}
     </ul>
 </div>

--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -32,7 +32,11 @@
     <div class="o-carousel_item-text">
         <h2>{{ item.title }}</h2>
         <p>{{ item.body }}</p>
-        <p><a href="{{ item.link.url }}">{{ item.link.text }}</a></p>
+        <p>
+            <a href="{{ item.link.url }}">
+                {{ item.link.text }}
+            </a>
+        </p>
     </div>
     <div class="o-carousel_item-visual">
         <img class="o-carousel_item-img"
@@ -44,22 +48,33 @@
 {% endmacro %}
 
 {% macro render_carousel_thumbnail( item, is_selected=false ) %}
-<button class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
+{#
+    Since desktop uses a button and mobile uses links,
+    we simulate a button here at desktop sizes, so we need to set the tab index.
+#}
+<div class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}"
+     role="button"
+     tabindex="0">
     <li class="o-carousel_thumbnail-layout">
         <div class="o-carousel_thumbnail-visual">
-            <img class="o-carousel_thumbnail-img"
-                src="{{ item.image.thumbnail_url }}"
-                alt="{{ item.image.alt_text }}">
+            <a href="{{ item.link.url }}" tabindex="-1">
+                <img class="o-carousel_thumbnail-img"
+                    src="{{ item.image.thumbnail_url }}"
+                    alt="{{ item.image.alt_text }}">
+            </a>
         </div>
         <p class="o-carousel_thumbnail-text">
-            {{ item.title }}
+            <a href="{{ item.link.url }}" tabindex="-1">
+                {{ item.title }}
+            </a>
         <p>
     </li>
-</button>
+</div>
 {% endmacro %}
 
 {% macro render(value) %}
 <div class="o-carousel u-hidden">
+    <h5>Featured</h5>
     <div class="o-carousel_navigator">
 
         <button class="o-carousel_btn o-carousel_btn-prev a-btn" aria-label="Previous showcase item">

--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -63,7 +63,7 @@
     we duplicate the markup here but use a div instead of a button.
 #}
 {% macro render_carousel_thumbnail_mobile( item, is_selected=false ) %}
-<div class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
+<div class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{% endif %}">
     <li class="o-carousel_thumbnail-layout">
         <div class="o-carousel_thumbnail-visual">
             <a href="{{ item.link.url }}">

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -140,8 +140,28 @@
     display: table;
   }
 
-  // Only show hover and top border at desktop sizes.
-  .respond-to-min( @bp-xs-max, {
+  // Mobile view.
+  .respond-to-max( @bp-xs-max, {
+    &_thumbnails {
+      display: none;
+    }
+
+    &_thumbnails__mobile {
+      display: block !important;
+    }
+
+    // Allow focus state on image inside link.
+    &_thumbnail-visual a {
+      display: block;
+      border-bottom-width: 0;
+    }
+  } );
+
+  // Desktop view.
+  .respond-to-min( @bp-sm-min, {
+    &_thumbnails__mobile {
+      display: none;
+    }
 
     // Hide "featured" heading at desktop size.
     & h5 {
@@ -171,7 +191,6 @@
         display: block;
       }
     }
-
   } );
 
   &_thumbnail:focus {
@@ -201,18 +220,6 @@
     text-align: left;
     vertical-align: top;
   }
-
-  // Disable thumbnail links on anything but mobile size.
-  .respond-to-min( @bp-xs-max, {
-    &_thumbnail-text a,
-    &_thumbnail-visual a {
-      pointer-events: none;
-      text-decoration: none;
-      border: none;
-      color: @black;
-    }
-
-  } );
 }
 
 // Show no-js state of carousel where all items show and buttons are hidden.

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -91,6 +91,7 @@
   &_thumbnail {
     flex-grow: 1;
     flex-direction: column;
+    box-sizing: border-box;
     min-width: 200px;
     width: 25%;
 
@@ -112,21 +113,6 @@
     display: flex;
     align-items: stretch;
     position: relative;
-
-    // We can't do a straight top border because it gets included in the
-    // box model and pushes the content down. This floats a border above the
-    // content.
-    &:before {
-      content: '';
-      position: absolute;
-      height: 5px;
-      width: 100%;
-    }
-
-    &:hover:before {
-      border-top: 5px solid @gray-40;
-      display: block;
-    }
 
     &:focus {
       outline: 1px dotted @pacific;
@@ -154,14 +140,39 @@
     display: table;
   }
 
-  &_thumbnail-selected {
-    background: @white;
+  // Only show hover and top border at desktop sizes.
+  .respond-to-min( @bp-xs-max, {
 
-    &:before {
-      border-top: 5px solid @green;
+    // Hide "featured" heading at desktop size.
+    & h5 {
+      display: none;
+    }
+
+    // We can't do a straight top border because it gets included in the
+    // box model and pushes the content down. This floats a border above the
+    // content.
+    &_thumbnail:before {
+      content: '';
+      position: absolute;
+      height: 5px;
+      width: 100%;
+    }
+
+    &_thumbnail:hover:before {
+      border-top: 5px solid @gray-40;
       display: block;
     }
-  }
+
+    &_thumbnail-selected {
+      background: @white;
+
+      &:before {
+        border-top: 5px solid @green;
+        display: block;
+      }
+    }
+
+  } );
 
   &_thumbnail:focus {
     z-index: 1;
@@ -190,6 +201,18 @@
     text-align: left;
     vertical-align: top;
   }
+
+  // Disable thumbnail links on anything but mobile size.
+  .respond-to-min( @bp-xs-max, {
+    &_thumbnail-text a,
+    &_thumbnail-visual a {
+      pointer-events: none;
+      text-decoration: none;
+      border: none;
+      color: @black;
+    }
+
+  } );
 }
 
 // Show no-js state of carousel where all items show and buttons are hidden.


### PR DESCRIPTION
## Changes

- Add mobile carousel appearance.

## Testing

1. Pull branch and build.
2. Visit http://localhost:8000/?nhp=True and resize the page and see that the thumbnails lose their selected state and show links.
3. Focus state should be the whole button at desktop when tabbing. It should be the image and links at mobile size.

## Screenshots

<img width="457" alt="Screen Shot 2019-12-02 at 11 27 21 AM" src="https://user-images.githubusercontent.com/704760/69977331-9e63b180-14f8-11ea-9468-7da5282d3928.png">
<img width="1071" alt="Screen Shot 2019-12-02 at 11 38 07 AM" src="https://user-images.githubusercontent.com/704760/69977332-9e63b180-14f8-11ea-8788-ae90c4ac2a2f.png">

## Notes

- I originally used the same markup for both mobile and desktop, however, to get the focus behavior to work correctly when tabbing through the content we'd need to set the tabindex to ignore the thumbnail text and image links at desktop sizes, these would then need to be removed via JavaScript from the mobile size. I opted instead to duplicate the markup, which is unfortunate, but I think it is more maintainable. The original commit can be viewed at https://github.com/cfpb/cfgov-refresh/commit/5d9c3c87c7f18571d051f94c9d426ed871ef57cf
