### PR TITLE
New homepage image updates

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -32,9 +32,9 @@
     </div>
     <div class="o-carousel_item-visual">
         {% set image_atom = make_image_atom( item.image ) %}
-        {% set original_image = image( image_atom.upload, 'original' ) %}
+        {% set image_original = image( image_atom.upload, 'original' ) %}
         <img class="o-carousel_item-img"
-             src="{{ original_image.url }}"
+             src="{{ image_original.url }}"
              alt="{{ image_atom.alt }}"
         >
     </div>
@@ -46,9 +46,9 @@
     <li class="o-carousel_thumbnail-layout">
         <div class="o-carousel_thumbnail-visual">
             {% set image_atom = make_image_atom( item.image ) %}
-            {% set thumbnail_image = image( image_atom.upload, 'fill-50x50' ) %}
+            {% set image_thumbnail = image( image_atom.upload, 'fill-50x50' ) %}
             <img class="o-carousel_thumbnail-img"
-                src="{{ thumbnail_image.url }}"
+                src="{{ image_thumbnail.url }}"
                 alt="{{ image_atom.alt }}">
         </div>
         <p class="o-carousel_thumbnail-text">
@@ -68,9 +68,9 @@
         <div class="o-carousel_thumbnail-visual">
             <a href="{{ item.link.url }}">
                 {% set image_atom = make_image_atom( item.image ) %}
-                {% set thumbnail_image = image( image_atom.upload, 'fill-50x50' ) %}
+                {% set image_thumbnail = image( image_atom.upload, 'fill-50x50' ) %}
                 <img class="o-carousel_thumbnail-img"
-                    src="{{ thumbnail_image.url }}"
+                    src="{{ image_thumbnail.url }}"
                     alt="{{ image_atom.alt }}">
             </a>
         </div>

--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -19,11 +19,7 @@
 
    item.link.url:               Panel link URL.
 
-   item.image.url:              URL to panel image.
-
-   item.image.alt_text:         Alt text for panel image.
-
-   item.image.thumbnail_url:    URL to panel thumbnail image.
+   item.image:                  Panel Wagtail image.
 
    ========================================================================== #}
 
@@ -35,9 +31,11 @@
         <p><a href="{{ item.link.url }}">{{ item.link.text }}</a></p>
     </div>
     <div class="o-carousel_item-visual">
+        {% set image_atom = make_image_atom( item.image ) %}
+        {% set original_image = image( image_atom.upload, 'original' ) %}
         <img class="o-carousel_item-img"
-             src="{{ item.image.url }}"
-             alt="{{ item.image.alt_text }}"
+             src="{{ original_image.url }}"
+             alt="{{ image_atom.alt }}"
         >
     </div>
 </section>
@@ -47,9 +45,11 @@
 <button class="o-carousel_thumbnail{% if is_selected %} o-carousel_thumbnail-selected{%endif%}">
     <li class="o-carousel_thumbnail-layout">
         <div class="o-carousel_thumbnail-visual">
+            {% set image_atom = make_image_atom( item.image ) %}
+            {% set thumbnail_image = image( image_atom.upload, 'fill-50x50' ) %}
             <img class="o-carousel_thumbnail-img"
-                src="{{ item.image.thumbnail_url }}"
-                alt="{{ item.image.alt_text }}">
+                src="{{ thumbnail_image.url }}"
+                alt="{{ image_atom.alt }}">
         </div>
         <p class="o-carousel_thumbnail-text">
             {{ item.title }}

--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -67,9 +67,11 @@
     <li class="o-carousel_thumbnail-layout">
         <div class="o-carousel_thumbnail-visual">
             <a href="{{ item.link.url }}">
+                {% set image_atom = make_image_atom( item.image ) %}
+                {% set thumbnail_image = image( image_atom.upload, 'fill-50x50' ) %}
                 <img class="o-carousel_thumbnail-img"
-                    src="{{ item.image.thumbnail_url }}"
-                    alt="{{ item.image.alt_text }}">
+                    src="{{ thumbnail_image.url }}"
+                    alt="{{ image_atom.alt }}">
             </a>
         </div>
         <p class="o-carousel_thumbnail-text">

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -100,7 +100,7 @@ _info_units_by_language = {
         {
             'image': {
                 'alt': 'Alt text goes here',
-                'upload': 2485,
+                'upload': 2503,
             },
             'heading': {
                 'text': 'Empowering Consumers',
@@ -121,7 +121,7 @@ _info_units_by_language = {
         {
             'image': {
                 'alt': 'Alt text goes here',
-                'upload': 2485,
+                'upload': 2507,
             },
             'heading': {
                 'text': 'Rules of the Road',
@@ -145,7 +145,7 @@ _info_units_by_language = {
         {
             'image': {
                 'alt': 'Alt text goes here',
-                'upload': 2485,
+                'upload': 2504,
             },
             'heading': {
                 'text': 'Enforcing the Law',
@@ -169,7 +169,7 @@ _info_units_by_language = {
         {
             'image': {
                 'alt': 'Alt text goes here',
-                'upload': 2485,
+                'upload': 2506,
             },
             'heading': {
                 'text': 'Learning through data and research',
@@ -193,7 +193,7 @@ _info_units_by_language = {
         {
             'image': {
                 'alt': 'Alt text goes here',
-                'upload': 2485,
+                'upload': 2508,
             },
             'heading': {
                 'text': 'Supervision',
@@ -219,7 +219,7 @@ _info_units_by_language = {
         {
             'image': {
                 'alt': 'Alt text goes here',
-                'upload': 2485,
+                'upload': 2505,
             },
             'heading': {
                 'text': 'Events',

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -13,22 +13,15 @@ from wagtail.wagtailsearch import index
 from flags.state import flag_enabled
 from modelcluster.fields import ParentalKey
 
-from v1.atomic_elements import molecules
+from v1.atomic_elements import atoms, molecules
 from v1.models.base import CFGOVPage
 from v1.util import ref
 
 
 """Placeholder until these are exposed in the Wagtail admin."""
-_placeholder_carousel_image_url = (
-    'https://files.consumerfinance.gov/f/original_images/'
-    'cfpb_mayg_bookshelf_puppy-in-the-window.jpg'
-)
-
-
 _placeholder_carousel_image = {
-    'url': _placeholder_carousel_image_url,
-    'alt_text': 'Alt text goes here',
-    'thumbnail_url': _placeholder_carousel_image_url,
+    'alt': 'Alt text goes here',
+    'upload': 2509,
 }
 
 
@@ -328,6 +321,7 @@ class HomePage(CFGOVPage):
         context = super(HomePage, self).get_context(request)
         context.update({
             'carousel_items': self.get_carousel_items(),
+            'make_image_atom': self.make_image_atom,
             'info_units': self.get_info_units(),
             # TODO: Add Spanish version of this heading.
             'card_heading': "We want to hear from you",
@@ -338,6 +332,10 @@ class HomePage(CFGOVPage):
 
     def get_carousel_items(self):
         return _carousel_items_by_language[self.language]
+
+    def make_image_atom(self, value):
+        # TODO: Not needed once the entire carousel is in Wagtail.
+        return atoms.ImageBasic().to_python(value)
 
     def get_info_units(self):
         return [

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -19,12 +19,6 @@ from v1.util import ref
 
 
 """Placeholder until these are exposed in the Wagtail admin."""
-_placeholder_carousel_image = {
-    'alt': 'Alt text goes here',
-    'upload': 2509,
-}
-
-
 _carousel_items_by_language = {
     'en': [
         {
@@ -38,46 +32,60 @@ _carousel_items_by_language = {
                 'text': 'Learn how to get started',
                 'url': '/start-small-save-up/',
             },
-            'image': _placeholder_carousel_image,
-        },
-        {
-            'title': 'Tax time',
-            'body': (
-                'Take advantage of the time when you are filing your tax '
-                'return to set aside a portion of your refund towards savings.'
-            ),
-            'link': {
-                'text': 'Learn more about tax time savings',
-                'url': '/about-us/blog/tax-time-saving-tips/',
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2516,
             },
-            'image': _placeholder_carousel_image,
         },
         {
-            'title': 'Building a Bridge to Credit Visibility Symposium',
+            'title': 'CFPB Research Conference',
             'body': (
-                'Mark your Calendar to join the Bureau for a day-long '
-                'symposium on September 17, 2018, from 8:00am to 4:45pm'
+                'CFPB hosting research conference featuring research from a '
+                'range of disciplines and approaches that can inform the '
+                'topic of consumer finance.'
             ),
             'link': {
-                'text': 'Learn more about this event',
+                'text': 'Learn about the conference',
+                'url': '/data-research/cfpb-research-conference/',
+            },
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2515,
+            },
+        },
+        {
+            'title': 'Protect yourself from debt collection scams',
+            'body': (
+                'Watch our new video to learn how to tell the difference '
+                'between legitimate debt collector and scammers'
+            ),
+            'link': {
+                'text': 'Learn how to protect yourself',
                 'url': (
-                    '/about-us/events/archive-past-events'
-                    '/building-bridge-credit-visibility/'
+                    '/about-us/blog/how-tell-difference-between-legitimate-'
+                    'debt-collector-and-scammers/'
                 ),
             },
-            'image': _placeholder_carousel_image,
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2514,
+            },
         },
         {
-            'title': 'Equifax data breach updates',
+            'title': 'TODO',
             'body': (
-                'Today the CFPB, FTC and States Announced Settlement with '
-                'Equifax Over 2017 Data Breach.'
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In '
+                'pellentesque odio et nulla ornare porta. Nulla lobortis '
+                'tincidunt congue nullam.'
             ),
             'link': {
-                'text': 'Find out more details',
-                'url': '/equifax-settlement/',
+                'text': 'TODO',
+                'url': '/',
             },
-            'image': _placeholder_carousel_image,
+            'image': {
+                'alt': 'Alt text goes here',
+                'upload': 2516,
+            },
         },
     ],
 }


### PR DESCRIPTION
This PR updates the (harcoded) images on the new homepage design.

First, the info units are all updated to be more appropriate. These are now hardcoded to Wagtail image IDs that exist in our production database. For these to work locally, you'll need all of the relevant image and rendition files locally. These can be grabbed as part of the full dump using the process described [here](http://cfpb.github.io/cfgov-refresh/installation/#sync-local-image-storage).

Second, the carousel image logic has been changed incrementally to also rely on a Wagtail image instead of a hardcoded URL, as a step towards the larger change being worked on in #5383. This makes use of [Wagtail image template tags](https://docs.wagtail.io/en/v2.7/topics/images.html) with a `fill-50x50` filter to generate the square thumbnail image. Again, to test locally you'll need both a recent dump along with a synced local image set.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/69991647-12f91900-1516-11ea-85bd-440c9e57cfa2.png)

![image](https://user-images.githubusercontent.com/654645/69991670-20160800-1516-11ea-9cb7-053e16824dad.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: