### PR TITLE
Ask CFPB - Remove "Next Steps" content well

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -72,17 +72,6 @@
                     </span>
                 </button>
             </div>
-        {% if page.related_resource and page.related_resource.trans_text(page.language) | striptags %}
-            <div class="block next-steps">
-                <div class="o-well">
-                <h2 class="u-mb15">
-                    {{ _('Take the next step') }}
-                </h2>
-                <h3 class="u-mt15">{{ page.related_resource.trans_title(page.language) | safe }}</h3>
-                {{ page.related_resource.trans_text(page.language) | safe }}
-                </div>
-            </div>
-        {% endif %}
 
         <div class="block related-questions">
             <h2>{{ _('Don\'t see what you\'re looking for?') }}</h2>


### PR DESCRIPTION
Per stakeholder request (GHE issue link available upon request), we are temporarily removing the "Next steps module" from Ask CFPB answer pages. The simplest solution seemed to be removing the block altogether, although I am open to other solutions.

## Additions
- Remove code which creates "Next steps" content well

## Testing
1. Run this branch and check to see if the Next Steps content is still there. It shouldn't be!

## Notes
- Since the stakeholder indicates this is intended as "temporary," maybe we could just make it evaluate to `false` or something, but I tend to err towards removal because, hey, the git history is always there!

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
