### PR TITLE
Update govdelivery package to v1.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -19,7 +19,7 @@ django-treebeard==3.0
 django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
-govdelivery==1.2
+govdelivery==1.3
 Jinja2==2.10.1
 jsonfield==2.0.2
 lxml==4.2.5


### PR DESCRIPTION
The final piece of the get-govdelivery-up-to-snuff work!

## Testing

1. Pull branch
1. `docker-compose build python2 python3`
1. See that it installs govdelivery 1.3
1. `docker-compose up`
1. Visit http://localhost:8000/about-us/blog/ and test the email signup form (ask me if you need staging environment credentials)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
