### PR TITLE
Homepage: Add analytics code to carousel

### DIFF
--- a/cfgov/unprocessed/js/organisms/Carousel.js
+++ b/cfgov/unprocessed/js/organisms/Carousel.js
@@ -26,7 +26,7 @@ function Carousel( element ) { // eslint-disable-line max-lines-per-function
 
   // Track how many unique slides the user has seen in the carousel.
   let _slideVisitCount = 1;
-  const ALL_SLIDES_VISITED = 15;
+  const ALL_SLIDES_VISITED = Math.pow( 2, _items.length ) - 1;
   let _allSlidesVisited = false;
 
   /**
@@ -117,11 +117,11 @@ function Carousel( element ) { // eslint-disable-line max-lines-per-function
      * 0010 = item two (2 decimal).
      * 0100 = item three (4 decimal).
      * 1000 = item four (8 decimal).
-     * 1111 = all visited (15 decimal).
+     * 1111 = all visited (if there are four items) (15 decimal).
      *
-     * We need to map 0, 1, 2, 3 item indices to bitwise digits to 1, 2, 4, 8.
+     * We need to map 0, 1, 2, … item indices to bitwise digits to 1, 2, 4, ….
      */
-    _slideVisitCount |= [ 1, 2, 4, 8 ][newCurrItemIndex];
+    _slideVisitCount |= Math.pow( 2, newCurrItemIndex );
     if ( _slideVisitCount === ALL_SLIDES_VISITED &&
          _allSlidesVisited !== true ) {
       Analytics.sendEvent( {

--- a/cfgov/unprocessed/js/organisms/Carousel.js
+++ b/cfgov/unprocessed/js/organisms/Carousel.js
@@ -1,4 +1,5 @@
 // Required modules.
+import Analytics from '../modules/Analytics';
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 
 const BASE_CLASS = 'o-carousel';
@@ -22,6 +23,10 @@ function Carousel( element ) {
   const _thumbnails = _dom.querySelectorAll( `.${ BASE_CLASS }_thumbnail` );
   const _items = _dom.querySelectorAll( `.${ BASE_CLASS }_item` );
   let _currItemIndex = 0;
+
+  // Track how many unique slides the user has seen in the carousel.
+  let _slideVisitCount = 1;
+  const ALL_SLIDES_VISITED = 15;
 
   /**
    * @returns {Carousel} An instance.
@@ -57,14 +62,14 @@ function Carousel( element ) {
    * Handle clicks of the previous button.
    */
   function _btnPrevClicked() {
-    _updateDisplay( _currItemIndex, _currItemIndex - 1 );
+    _updateDisplay( _currItemIndex, _currItemIndex - 1, 'Previous Arrow' );
   }
 
   /**
    * Handle clicks of the next button.
    */
   function _btnNextClicked() {
-    _updateDisplay( _currItemIndex, _currItemIndex + 1 );
+    _updateDisplay( _currItemIndex, _currItemIndex + 1, 'Next Arrow' );
   }
 
   /**
@@ -80,17 +85,22 @@ function Carousel( element ) {
         ++i;
       }
     }
-    if ( _currItemIndex !== i ) {
-      _updateDisplay( _currItemIndex, i );
-    }
+
+    _updateDisplay( _currItemIndex, i, 'Tab' );
   }
 
   /**
    * Update which carousel item is being displayed.
    * @param {number} oldCurrItemIndex - The previous index value of the selected item.
    * @param {number} newCurrItemIndex - The new index value of the selected item.
+   * @param {string} interactionLabel - A label for what called this method.
+   * @returns {boolean} True if the display was updated, false otherwise.
    */
-  function _updateDisplay( oldCurrItemIndex, newCurrItemIndex ) {
+  function _updateDisplay( oldCurrItemIndex, newCurrItemIndex, interactionLabel ) {
+    if ( oldCurrItemIndex === newCurrItemIndex ) {
+      return false;
+    }
+
     const lastItem = _items[oldCurrItemIndex];
     const lastThumbnail = _thumbnails[oldCurrItemIndex];
 
@@ -100,11 +110,42 @@ function Carousel( element ) {
     } else if ( _currItemIndex > _items.length - 1 ) {
       _currItemIndex = 0;
     }
+
+    // Update visible slides.
     _items[_currItemIndex].classList.remove( 'u-alpha-0' );
     lastItem.classList.add( 'u-alpha-0' );
 
     _thumbnails[_currItemIndex].classList.add( `${ BASE_CLASS }_thumbnail-selected` );
     lastThumbnail.classList.remove( `${ BASE_CLASS }_thumbnail-selected` );
+
+
+    /*
+     Send off analytics.
+
+     We use a bitmask to see if all slides have been visited:
+     0001 = item one (1 decimal).
+     0010 = item two (2 decimal).
+     0100 = item three (4 decimal).
+     1000 = item four (8 decimal).
+     1111 = all visited (15 decimal).
+     We need to map 0, 1, 2, 3 item indices to bitwise digits to 1, 2, 4, 8.
+     */
+    _slideVisitCount |= [ 1, 2, 4, 8 ][newCurrItemIndex];
+    if ( _slideVisitCount === ALL_SLIDES_VISITED ) {
+      Analytics.sendEvent( {
+        event: 'Page Interaction',
+        action: 'Carousel',
+        label: 'All Items Seen'
+      } );
+    }
+
+    Analytics.sendEvent( {
+      event: 'Page Interaction',
+      action: 'Carousel',
+      label: `${ interactionLabel } Clicked: Page ${ _currItemIndex + 1 }`
+    } );
+
+    return true;
   }
 
   this.init = init;

--- a/cfgov/unprocessed/js/organisms/Carousel.js
+++ b/cfgov/unprocessed/js/organisms/Carousel.js
@@ -1,6 +1,6 @@
 // Required modules.
-import Analytics from '../modules/Analytics';
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import Analytics from '../modules/Analytics';
 
 const BASE_CLASS = 'o-carousel';
 
@@ -15,7 +15,7 @@ const BASE_CLASS = 'o-carousel';
  *   The DOM element within which to search for the organism.
  * @returns {Carousel} An instance.
  */
-function Carousel( element ) {
+function Carousel( element ) { // eslint-disable-line max-lines-per-function
   const _dom = checkDom( element, BASE_CLASS );
   const _btnPrev = _dom.querySelector( `.${ BASE_CLASS }_btn-prev` );
   const _btnNext = _dom.querySelector( `.${ BASE_CLASS }_btn-next` );
@@ -27,6 +27,7 @@ function Carousel( element ) {
   // Track how many unique slides the user has seen in the carousel.
   let _slideVisitCount = 1;
   const ALL_SLIDES_VISITED = 15;
+  let _allSlidesVisited = false;
 
   /**
    * @returns {Carousel} An instance.
@@ -62,18 +63,21 @@ function Carousel( element ) {
    * Handle clicks of the previous button.
    */
   function _btnPrevClicked() {
-    _updateDisplay( _currItemIndex, _currItemIndex - 1, 'Previous Arrow' );
+    if ( _updateDisplay( _currItemIndex, _currItemIndex - 1 ) ) {
+      _sendAnalytics( _currItemIndex, 'Previous Arrow' );
+    }
   }
 
   /**
    * Handle clicks of the next button.
    */
   function _btnNextClicked() {
-    _updateDisplay( _currItemIndex, _currItemIndex + 1, 'Next Arrow' );
+    if ( _updateDisplay( _currItemIndex, _currItemIndex + 1 ) ) {
+      _sendAnalytics( _currItemIndex, 'Next Arrow' );
+    }
   }
 
   /**
-   *
    * @param {MouseEvent} event - The event object corresponding to the mouse click of a thumbnail.
    */
   function _thumbnailClicked( event ) {
@@ -86,17 +90,56 @@ function Carousel( element ) {
       }
     }
 
-    _updateDisplay( _currItemIndex, i, 'Tab' );
+    if ( _updateDisplay( _currItemIndex, i ) ) {
+      _sendAnalytics( i, 'Tab' );
+    }
+  }
+
+  /**
+   * Sends events to our analytics provider.
+   *
+   * @param {number} newCurrItemIndex - The new index value of the selected item.
+   * @param {string} interactionLabel - A label for what called this method.
+   */
+  function _sendAnalytics( newCurrItemIndex, interactionLabel ) {
+    // Send individual event
+    Analytics.sendEvent( {
+      event: 'Page Interaction',
+      action: 'Carousel',
+      label: `${ interactionLabel } Clicked: Page ${ _currItemIndex + 1 }`
+    } );
+
+    /**
+     * Send All Items Seen event if all slides have been visited.
+     *
+     * We use a bitmask to see if all slides have been visited:
+     * 0001 = item one (1 decimal).
+     * 0010 = item two (2 decimal).
+     * 0100 = item three (4 decimal).
+     * 1000 = item four (8 decimal).
+     * 1111 = all visited (15 decimal).
+     *
+     * We need to map 0, 1, 2, 3 item indices to bitwise digits to 1, 2, 4, 8.
+     */
+    _slideVisitCount |= [ 1, 2, 4, 8 ][newCurrItemIndex];
+    if ( _slideVisitCount === ALL_SLIDES_VISITED &&
+         _allSlidesVisited !== true ) {
+      Analytics.sendEvent( {
+        event: 'Page Interaction',
+        action: 'Carousel',
+        label: 'All Items Seen'
+      } );
+      _allSlidesVisited = true;
+    }
   }
 
   /**
    * Update which carousel item is being displayed.
    * @param {number} oldCurrItemIndex - The previous index value of the selected item.
    * @param {number} newCurrItemIndex - The new index value of the selected item.
-   * @param {string} interactionLabel - A label for what called this method.
    * @returns {boolean} True if the display was updated, false otherwise.
    */
-  function _updateDisplay( oldCurrItemIndex, newCurrItemIndex, interactionLabel ) {
+  function _updateDisplay( oldCurrItemIndex, newCurrItemIndex ) {
     if ( oldCurrItemIndex === newCurrItemIndex ) {
       return false;
     }
@@ -117,33 +160,6 @@ function Carousel( element ) {
 
     _thumbnails[_currItemIndex].classList.add( `${ BASE_CLASS }_thumbnail-selected` );
     lastThumbnail.classList.remove( `${ BASE_CLASS }_thumbnail-selected` );
-
-
-    /*
-     Send off analytics.
-
-     We use a bitmask to see if all slides have been visited:
-     0001 = item one (1 decimal).
-     0010 = item two (2 decimal).
-     0100 = item three (4 decimal).
-     1000 = item four (8 decimal).
-     1111 = all visited (15 decimal).
-     We need to map 0, 1, 2, 3 item indices to bitwise digits to 1, 2, 4, 8.
-     */
-    _slideVisitCount |= [ 1, 2, 4, 8 ][newCurrItemIndex];
-    if ( _slideVisitCount === ALL_SLIDES_VISITED ) {
-      Analytics.sendEvent( {
-        event: 'Page Interaction',
-        action: 'Carousel',
-        label: 'All Items Seen'
-      } );
-    }
-
-    Analytics.sendEvent( {
-      event: 'Page Interaction',
-      action: 'Carousel',
-      label: `${ interactionLabel } Clicked: Page ${ _currItemIndex + 1 }`
-    } );
 
     return true;
   }


### PR DESCRIPTION
## Changes

- Adds analytics code to carousel interactions.

## Testing

1. Pull branch
2. Add console.log statements above the `Analytics.sendEvent` entries in this PR with the value of the `label`.
3. `gulp clean && gulp build`
4. Visit http://localhost:8000/?nhp=True and click the next/previous buttons and/or the thumbnails in the carousel. You should see outputs like:

<img width="301" alt="Screen Shot 2019-12-02 at 6 45 46 PM" src="https://user-images.githubusercontent.com/704760/70004811-a2fa8b00-1535-11ea-905b-85991a6ebdeb.png">

Once all slides are seen you will see "All Items Seen"


## Notes

- Once all slides are seen the "All Items Seen" event will fire each time the slide is changed since there's no logic to reset the count. I'm not sure if this is the desired behavior or not.
