### PR TITLE
Homepage: Fix issue with layering in carousel items

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -18,7 +18,7 @@
   &_btn {
     position: absolute;
     top: 50%;
-    z-index: 2;
+    z-index: 3;
     padding-left: unit( 10px / @btn-font-size, em );
     padding-right: unit( 10px / @btn-font-size, em );
     margin-top: -16px;
@@ -56,6 +56,11 @@
       left: -25% * ( @value - 1 );
     }
   } );
+
+  // Bring the currently visible slide forward so it's above the invisible ones.
+  &_item:not( .u-alpha-0 ) {
+    z-index: 2;
+  }
 
   &_item-text {
     display: table-cell;


### PR DESCRIPTION
## Changes

- Makes currently visible carousel item layered above other hidden slides.

## Testing

1. Pull branch and build
2. Visit http://localhost:8000/?nhp=True and text in the slide should be selectable and right-clickable.
