### PR TITLE
Homepage: Fix carousel no-js state

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -224,11 +224,23 @@
 
 // Show no-js state of carousel where all items show and buttons are hidden.
 .no-js .o-carousel {
-  // Override u-hidden when
+  // Override u-hidden when JS is turned off.
   display: block !important;
 
+  // Revert item layout.
+  &_items {
+    width: auto;
+    display: block;
+  }
+
+  &_item {
+    position: static;
+    display: block;
+    border-bottom: 1px solid @gray-40;
+  }
+
   &_btn,
-  &_thumbnails {
+  &_thumbnails:not( .o-carousel_thumbnails__mobile ) {
     display: none !important;
   }
 }


### PR DESCRIPTION
Carousel was busted in the no-js state, this fixes it.

## Changes

- Fix layout when in the no-js state so mobile thumbnails show up and carousel items are stacked at desktop.

## Testing

1. Pull branch and build
2. http://localhost:8000/?nhp=True and turn JS off. Carousel items should stack at desktop and be thumbnail links at mobile.

## Screenshots

<img width="839" alt="Screen Shot 2019-12-02 at 7 38 11 PM" src="https://user-images.githubusercontent.com/704760/70006544-9c6f1200-153b-11ea-8902-900fb6799052.png">
