### PR TITLE
Carousel: Eliminate extra vertical space (the red bar) below large images

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -83,7 +83,11 @@
     height: 300px;
 
     // This is a temporary value.
-    background: red;
+    // background: red;
+  }
+
+  &_item-img {
+      display: block;
   }
 
   &_thumbnails {


### PR DESCRIPTION
Sets the large images to `display: block` to eliminate the inherent vertical line height of inline images. Also comments out the red background color which still appears at anything less than max page width.

## Testing

1. Pull branch
1. `yarn run gulp styles`
1. Load up the homepage and see no more red bar

## Screenshots

### Before

![Carousel screenshot with red bar below main image](https://user-images.githubusercontent.com/1044670/70088801-f841a580-15e4-11ea-8102-0c37a7af252c.png)

### After

![Carousel screenshot with no red bar below main image](https://user-images.githubusercontent.com/1044670/70088853-13141a00-15e5-11ea-939a-151d4a4fde82.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [x] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android
