### PR TITLE
Carousel: Keep bar on active item green on hover

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -188,7 +188,7 @@
     }
 
     &_thumbnail:hover:before {
-      border-top: 5px solid @gray-40;
+      background: @gray-40;
       display: block;
     }
 
@@ -196,8 +196,12 @@
       background: @white;
 
       &:before {
-        border-top: 5px solid @green;
+        background: @green;
         display: block;
+      }
+
+      &:hover:before {
+        background: @green;
       }
     }
   } );


### PR DESCRIPTION
We want the top bar on the active item's thumbnail to stay green, even when it's being hovered.

## Testing

1. Pull branch
1. `yarn run gulp styles`
1. Reload homepage and try hovering over the active item

## Notes

- Another thing to consider would be removing the hand cursor on that item.

/cc @huetingj

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [x] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android
