### PR TITLE
Skip some unit tests when using an SQLite db

### DIFF
--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -5,10 +5,12 @@ import datetime
 import json
 import os
 import six
+import unittest
 from decimal import Decimal
 
 import django
 from django.conf import settings
+from django.db import connection
 from django.utils import timezone
 
 import requests
@@ -165,6 +167,8 @@ class TestScripts(django.test.TestCase):
             None
         )
 
+    @unittest.skipUnless(
+        connection.vendor == 'postgresql', 'PostgreSQL-dependent')
     def test_run_cohorts(self):
         school = School.objects.get(pk=100654)
         self.assertIs(
@@ -183,6 +187,8 @@ class TestScripts(django.test.TestCase):
             100
         )
 
+    @unittest.skipUnless(
+        connection.vendor == 'postgresql', 'PostgreSQL-dependent')
     def test_run_cohorts_singleton(self):
         school = School.objects.get(pk=100654)
         self.assertIs(
@@ -231,6 +237,8 @@ class TestScripts(django.test.TestCase):
         self.assertEqual(school.grad_rate_lt4, Decimal('0.54'))
         self.assertEqual(school.grad_rate_4yr, None)
 
+    @unittest.skipUnless(
+        connection.vendor == 'postgresql', 'PostgreSQL-dependent')
     @patch(
         'paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_api_school_query(self, mock_requests):
@@ -242,6 +250,8 @@ class TestScripts(django.test.TestCase):
         self.assertEqual(mock_requests.call_count, 1)
         self.assertTrue(mock_requests.called_with((123456, 'school.name')))
 
+    @unittest.skipUnless(
+        connection.vendor == 'postgresql', 'PostgreSQL-dependent')
     @patch('paying_for_college.disclosures.scripts.update_colleges.get_scorecard_data')  # noqa
     def test_single_school_request(self, mock_get_data):
         mock_get_data.return_value = self.mock_results.get('results')[0]


### PR DESCRIPTION
Tests that involve Postgres-only features, such as the JSONField column setting,
need to be skipped if we're running unit tests that create a database other than Postgres, 
such as SQLite, which is the Django default test db.

This change allows users to run tests without setting a TEST_DATABASE_URL env var.

## Testing

Try running PFC tests without a specified test database:

```bash
unset TEST_DATABASE_URL
tox -e fast paying_for_college
```
Four tests should be skipped, and coverage will go down a bit.

To see the full PFC test suite run against a Postgres database, restore the var:

```bash
export TEST_DATABASE_URL=postgres://cfpb@localhost/test_cfgov
tox -e fast paying_for_college
```

All tests should run.

### Note
This change won't affect our Travis CI tests, which use Postgres by default.
