### PR TITLE
Add Spanish translation for "Featured" on homepage

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -87,7 +87,7 @@
 
 {% macro render(value) %}
 <div class="o-carousel u-hidden">
-    <h5>Featured</h5>
+    <h5>{{ _( 'Featured' ) }}</h5>
     <div class="o-carousel_navigator">
 
         <button class="o-carousel_btn o-carousel_btn-prev a-btn" aria-label="Previous showcase item">


### PR DESCRIPTION
The new homepage design includes the word "Featured" above the carousel when viewed at narrow screen widths (mobile). We want this word to translate properly for Spanish versions of the page.

To test, run a local server and visit http://localhost:8000/es/?nhp=True at a mobile width. You should see the translation "Destacado". This comes from [the existing translations for this project](https://github.com/cfpb/cfgov-refresh/blob/aaf5405c55aef08f424f86d4a63b9736f26ccaf7/cfgov/locale/es/LC_MESSAGES/django.po#L78).

Ping @sonnakim.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/70183587-15917500-16b4-11ea-96e8-3d77dbbecd4a.png)

![image](https://user-images.githubusercontent.com/654645/70183565-07435900-16b4-11ea-82ba-135b597beefb.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: