### PR TITLE
[TDP] Bump teachers_digital_platform to version 1.1.9

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -50,4 +50,4 @@ https://github.com/cfpb/retirement/releases/download/0.10.3/retirement-0.10.3-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.12/ccdb5_api-1.1.12-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.3.4/ccdb5_ui-1.3.4-py2.py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.12.1/comparisontool-1.12.1-py2.py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.1.8/teachers_digital_platform-1.1.8-py2.py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.1.9/teachers_digital_platform-1.1.9-py2.py3-none-any.whl


### PR DESCRIPTION
Bumping release version of TDP

## Additions

- Added Similar Resources block to TDP Activity Detail page

## Removals

- Removed Age Range from TDP Activity search results

## Reviewers
@Scotchester @chosak @willbarton @higs4281 
