### PR TITLE
Fix minor typo in deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,9 +5,9 @@ archives to deploy the site to a Linux server.
 # Generating a deployment artifact
 
 Running the script at `./docker/deployable-zipfile/build.sh` will start a CentOS 6
-container, generate the artifact(via
-[this script](https://github.com/cfpb/cfgov-refresh/blob/master/docker/deployable-zipfile/_build.sh))
-, and save it to `./cfgov_current_build.zip`.
+container, generate the artifact (via
+[this script](https://github.com/cfpb/cfgov-refresh/blob/master/docker/deployable-zipfile/_build.sh)),
+and save it to `./cfgov_current_build.zip`.
 
 We use CentOS 6 here, so that the Python modules that include compiled code, will
 be compiled for the same environment they will be run in.


### PR DESCRIPTION
Fix minor typo in deployment docs.

## Screenshots

Current:

![image](https://user-images.githubusercontent.com/654645/70275391-0b3aae00-177c-11ea-9f0d-75a33410a726.png)

Fixed:

![image](https://user-images.githubusercontent.com/654645/70275432-20afd800-177c-11ea-8e5f-e340f45486dd.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: