### PR TITLE
New Homepage: Fix link font weight in carousel and cards

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/card.html
+++ b/cfgov/jinja2/v1/_includes/molecules/card.html
@@ -21,8 +21,8 @@
 <article class="m-card">
     <div class="m-card_icon">{{ svg_icon( value.icon ) }}</div>
     <p>{{ value.text }}</p>
-    <p class="m-card_footer">
+    <div class="m-card_footer">
         <a href="{{ value.link_url }}">{{ value.link_text }}</a>
-    </p>
+    </div>
 </article>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -29,7 +29,9 @@
         <div class="o-carousel_item-text">
             <h2>{{ item.title }}</h2>
             <p>{{ item.body }}</p>
-            <p><a href="{{ item.link_url }}">{{ item.link_text }}</a></p>
+            <a class="a-link__jump" href="{{ item.link_url }}">
+                <span class="a-link_text">{{ item.link_text }}</span>
+            </a>
         </div>
         <div class="o-carousel_item-visual">
             <div class="o-carousel_item-visual-wrapper">

--- a/cfgov/unprocessed/css/molecules/card.less
+++ b/cfgov/unprocessed/css/molecules/card.less
@@ -19,6 +19,11 @@
         margin-top: auto;
     }
 
+    &_footer > a {
+        font-weight: 500;
+        border-bottom-width: 1px;
+    }
+
     // TODO: Check if heading and body is used anywhere?
     &_heading {
         color: @green;


### PR DESCRIPTION
They should be medium, not regular.

Addresses https://GHE/CFPB/el-camino/issues/60#issuecomment-232097

## Testing

1. Pull branch
1. `yarn gulp styles`
1. Reload the homepage (open it in a new tab & toggle between to see the difference more clearly)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
