### PR TITLE
New Homepage: Fix card layout in IE 8 & 9

### DIFF
--- a/cfgov/unprocessed/css/organisms/card-group.less
+++ b/cfgov/unprocessed/css/organisms/card-group.less
@@ -6,10 +6,17 @@
         flex: 1;
 
         & .m-card {
-            margin-right: unit( 20px / @base-font-size-px, em );
+            margin-left: unit( 20px / @base-font-size-px, em );
 
-            &:last-child {
-                margin-right: 0;
+            .lt-ie10 & {
+                display: block;
+                width: 32%;
+                margin-left: 2%;
+                float: left;
+            }
+
+            &:first-child {
+                margin-left: 0;
             }
         }
 
@@ -27,5 +34,9 @@
 
     &__bg-green {
         background: @green-20;
+    }
+
+    .lt-ie10 & {
+        .u-clearfix();
     }
 }


### PR DESCRIPTION
These browsers don't support flexbox and needed some fallback styling.

Fixes https://GHE/CFPB/el-camino/issues/50

## Additions

- Float-based layout for homepage cards in IE < 10

## Changes

- Switches to left margin and overriding that on `:first-child` because older IEs don't support `:last-child`

## Testing

1. Pull branch
1. `yarn gulp styles`
1. Load page in IE 8 or 9 (or their emulation modes)
1. See cards appearing in columns again

## Notes

- The icons are still missing on IE 8, as are all of our SVG icons.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [x] Internet Explorer 8 & 9
- [ ] Safari on iOS
- [ ] Chrome on Android
