### PR TITLE
Attempt to stop sessionStorage quota exceeded errors

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/tab-navigation-tracking.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/tab-navigation-tracking.js
@@ -4,6 +4,7 @@
  * for tracking tab navigation of the site.
  */
 
+// eslint-disable-next-line max-lines-per-function, complexity, max-statements
 const TabNavigationTracking = ( () => {
 
   if ( !window.Storage ) {
@@ -157,7 +158,11 @@ const TabNavigationTracking = ( () => {
     } else {
       navPath.push( curPage );
     }
-    sessionStorage.setItem( '_nav_path', JSON.stringify( navPath ) );
+    try {
+      sessionStorage.setItem( '_nav_path', JSON.stringify( navPath ) );
+    } catch ( exception ) {
+      console.log( exception );
+    }
   }
 
   window.addEventListener( 'beforeunload', removeTabOnUnload );


### PR DESCRIPTION
We've got an ongoing situation where the following JS error is being thrown frequently:

> Failed to execute `setItem` on 'Storage': Setting the value of `_nav_path` exceeded the quota.

[View the alert in New Relic](https://alerts.newrelic.com/accounts/670562/incidents/98587488/violations)

It seems like someone (or more likely some bot) is trying to hit tons of our pages with limited `sessionStorage` and it's unable to update that value each time a new page is visited.

Based on [a little](https://www.raymondcamden.com/2015/04/14/blowing-up-localstorage-or-what-happens-when-you-exceed-quota) [research](https://michalzalecki.com/why-using-localStorage-directly-is-a-bad-idea/), it seems like wrapping that `setItem` call in a `try`/`catch` might be the best way to handle the error for now.

Taking a longer view, I'm not entirely sure how we could be writing enough to `sessionStorage` to exceed the typical 5 MB quota for our domain. I'd love to hear thoughts on how to investigate that.

## Changes

- Wrap our tab navigation tracking script's `setItem( '_nav_path' )` call in a `try`/`catch` block.

## Testing

I have no idea how to test this. There doesn't appear to be an easy way to change the quota in Chrome to something very low. Maybe I could try manually dumping a 4.999 MB text file into the `sessionStorage` field and then try getting it to update again?

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
