### PR TITLE
Unskip Python 3 test for feedback handling

### DIFF
--- a/cfgov/v1/handlers/blocks/feedback.py
+++ b/cfgov/v1/handlers/blocks/feedback.py
@@ -41,6 +41,7 @@ class FeedbackHandler(Handler):
         self.block_value = block_value
 
     def sanitize_referrer(self):
+        """Skip referrer URLs that fail to encode or decode."""
         referrer = self.request.META.get('HTTP_REFERER', '')
         try:
             referrer.encode('utf8')


### PR DESCRIPTION
This change restores a Python 3 test for handling non-ascii referrer values
in v1 feedback. The previous test was trying too hard to manage string types,
and we were skipping the test in Python 3.

The solution was to leave the Python unicode sandwich alone.
With unicode_literals turned on, both Python versions happily pass
unicode to the request object for handling downstream.
This addresses platform issue 3613.

## Testing

22 unit tests for v1/handler code should succeed in Python 2 and 3, and there
should be no skips.

```bash
tox -e fast v1.tests.handlers.blocks
tox -e unittest-py36-dj111-wag113-fast v1.tests.handlers.blocks
```
## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
