### PR TITLE
Homepage cards: Fix left margin regression on small screens

### DIFF
--- a/cfgov/unprocessed/css/organisms/card-group.less
+++ b/cfgov/unprocessed/css/organisms/card-group.less
@@ -24,10 +24,15 @@
             flex-direction: column;
 
             & .m-card {
-                margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+                margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+                margin-left: 0;
                 // Overrides flex-basis:1 to prevent card content from overflowing container
                 // when flex-direction is set to column at small screen sizes
                 flex-basis: auto;
+            }
+
+            & .m-card:first-child {
+                margin-top: 0;
             }
         } );
     }


### PR DESCRIPTION
Also fixes excessive space at the bottom of the WWTHFY box.

Fixes https://GHE/CFPB/el-camino/issues/68

## Testing

1. Pull branch
1. `yarn gulp styles`
1. Reload

## Screenshots

Before | After
------ | -----
![Screenshot of bugged display in production](https://user-images.githubusercontent.com/1044670/70635197-84655580-1c01-11ea-92e9-60b9322e7479.png) | ![Screenshot of corrected display running locally](https://user-images.githubusercontent.com/1044670/70634861-f4bfa700-1c00-11ea-8ec1-fd7c12cab77f.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android
