### PR TITLE
Prevent running unit tests on things in develop-apps

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,5 +22,9 @@ module.exports = {
   moduleNameMapper: {
     '\\.(svg)$': '<rootDir>/test/unit_tests/mocks/fileMock.js'
   },
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/develop-apps/'
+  ],
   testURL: 'http://localhost'
 };


### PR DESCRIPTION
I have teachers-digital-platform cloned within my develop-apps folder for Docker-based development. When running `gulp test:unit` from the root of cfgov-refresh, Jest was finding the unit tests inside there and trying to run them, causing failures related to bad paths.

## Additions

- `testPathIgnorePatterns` added to `jest.config.js` with the default rule of `node_modules` and the new addition of `develop-apps`

## Testing

1. To reproduce the problem:
   1. Clone teachers-digital-platform into `develop-apps/`
   1. In the TDP folder, `./setup.sh` to install all of its stuff
   1. Back in the root of cfgov-refresh, `yarn gulp test:unit`
   1. Observe the failures coming from under `develop-apps/teachers-digital-platform/`
1. Pull down this branch
1. Run `yarn gulp test:unit`
1. See no failures

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
