### PR TITLE
Mega menu: Add flags for viewing variations

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -92,7 +92,14 @@
             {% endif %}
 
             {% block primary_nav %}
-                {% from 'organisms/mega-menu.html' import mega_menu with context %}
+                {% if flag_enabled('MEGA_MENU_VAR_1', request) %}
+                    {% from 'organisms/mega-menu-var-1.html' import mega_menu with context %}
+                {% elif flag_enabled('MEGA_MENU_VAR_2', request) %}
+                    {% from 'organisms/mega-menu-var-2.html' import mega_menu with context %}
+                {% else %}
+                    {% from 'organisms/mega-menu.html' import mega_menu with context %}
+                {% endif %}
+
                 {% if language == 'es' %}
                     {% import '_vars-mega-menu-spanish.html' as vars with context %}
                     {{ mega_menu(vars.menu_items) }}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -1,0 +1,5 @@
+{% macro mega_menu( menu_items, language='en' ) %}
+<div class="o-mega-menu-var-1">
+    Mega menu var 1
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-2.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-2.html
@@ -1,0 +1,5 @@
+{% macro mega_menu( menu_items, language='en' ) %}
+<div class="o-mega-menu-var-2">
+    Mega menu var 2
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Additions

- Adds `MEGA_MENU_VAR_1` and `MEGA_MENU_VAR_2` flags for viewing mega menu variations.

## Testing

1. Add and enable `MEGA_MENU_VAR_1` flag and reload local homepage to view variation 1 menu.
2. Disable `MEGA_MENU_VAR_1` flag and enable `MEGA_MENU_VAR_2` flag and reload local homepage to view variation 2 menu.
