### PR TITLE
Fix beta banner background color

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-banner.less
+++ b/cfgov/unprocessed/css/molecules/global-banner.less
@@ -4,7 +4,7 @@
    ========================================================================== */
 .m-global-banner {
     padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;
-    background: @gold-20;
+    background: @gold-10;
     border-bottom: 1px solid @gray-40;
     font-size: 0.875em;
 


### PR DESCRIPTION
🚧Holding until after the code freeze ends on January 3. 🚧

The current beta banner's background color is set to `@gold-20`, but the background color of warning notifications is now `@gold-10`, which is causing a multi-colored beta banner. This change matches the beta banner background to the standard notification background.

## Changes

- Change beta banner background from `@gold-20` to `@gold-10`

## Testing

1. Enable the beta banner locally by going to http://localhost:8000/admin/flags/BETA_NOTICE/ and hitting the "enable BETA_NOTICE for all requests" button.
2. Visit any local page, like http://localhost:8000/, and notice the multi-colored beta banner.
3. In this branch, run `./frontend.sh`
4. Reload the local page you're looking at, and notice the beta banner should now be the same color

## Screenshots

Before | After
---- | ----
![before](https://user-images.githubusercontent.com/1862695/71381664-710f9e00-25a2-11ea-8a9d-8e24d4b9393d.png) | ![after](https://user-images.githubusercontent.com/1862695/71381667-74a32500-25a2-11ea-95bd-71179eb355dc.png)

## Notes

- I tried making the beta banner background color `@notification-bg-error` to match what's in `notifications.less`, but it looks like that variable isn't available in `global-banner.less`. Not sure if it should be, though.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing