### PR TITLE
Remove or update Python3-incompatible tests

### DIFF
--- a/cfgov/v1/tests/models/test_resources.py
+++ b/cfgov/v1/tests/models/test_resources.py
@@ -7,12 +7,6 @@ from v1.models.resources import Resource
 
 
 class TestUnicodeCompatibility(TestCase):
-    @skipIf(six.PY3, "all strings are unicode")
-    def test_unicode_resource_title_str(self):
-        resource = Resource(title=u'Unicod\xeb')
-        self.assertEqual(str(resource), 'Unicod\xc3\xab')
-        self.assertIsInstance(str(resource), str)
-
     def test_unicode_resource_title_unicode(self):
         resource = Resource(title=u'Unicod\xeb')
         self.assertEqual(six.text_type(resource), u'Unicod\xeb')

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -13,12 +13,6 @@ from v1.models.snippets import Contact, RelatedResource, ReusableText
 
 
 class TestUnicodeCompatibility(TestCase):
-    @skipIf(six.PY3, "all strings are unicode")
-    def test_unicode_contact_heading_str(self):
-        contact = Contact(heading=u'Unicod\xeb')
-        self.assertEqual(str(contact), 'Unicod\xc3\xab')
-        self.assertIsInstance(str(contact), str)
-
     def test_unicode_contact_heading_unicode(self):
         contact = Contact(heading=u'Unicod\xeb')
         self.assertEqual(six.text_type(contact), u'Unicod\xeb')

--- a/cfgov/v1/tests/templatetags/test_app_urls.py
+++ b/cfgov/v1/tests/templatetags/test_app_urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import six
-from unittest import skipIf
+from unittest import skipUnless
 
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
@@ -16,12 +16,12 @@ class TestAppUrlTags(TestCase):
         response = template.render(Context({'request': request}))
         self.assertEqual(response, 'app')
 
-    @skipIf(six.PY3, "Unicode workaround is unnecessary")
+    @skipUnless(six.PY3, "Unicode in path doesn't work in python 2")
     def test_app_url_unicode(self):
         template = Template('{% load app_urls %}{% app_url request %}')
         request = RequestFactory().get('/äpp/path')
         response = template.render(Context({'request': request}))
-        self.assertEqual(response, 'pp')
+        self.assertEqual(response, 'äpp')
 
     def test_app_page_url(self):
         template = Template('{% load app_urls %}{% app_page_url request %}')
@@ -29,9 +29,9 @@ class TestAppUrlTags(TestCase):
         response = template.render(Context({'request': request}))
         self.assertEqual(response, 'app/with/page/path')
 
-    @skipIf(six.PY3, "Unicode workaround is unnecessary")
+    @skipUnless(six.PY3, "Unicode in path doesn't work in python 2")
     def test_app_page_url_unicode(self):
         template = Template('{% load app_urls %}{% app_page_url request %}')
         request = RequestFactory().get('/ápp/with/päge/path')
         response = template.render(Context({'request': request}))
-        self.assertEqual(response, 'pp/with/pge/path')
+        self.assertEqual(response, 'ápp/with/päge/path')


### PR DESCRIPTION
Since are transitioning to Python 3 and stopping support of Python 2, update the specs to remove any tests that are skipped in Python 3.

🚧  Do not merge until after January 3. 🚧 


## Removals

- Remove Python 2-specific tests for Resources and Snippets.

## Changes

- Update templatetags tests to test Python 3 functionality instead of Python 2.

## Testing

1. `tox`

## Notes

- I believe this addresses all tests that were being skipped in Python 3.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: