### PR TITLE
Restore answer snippets to search-by-tag pages

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -45,7 +45,7 @@
                 {% if tag %}
                     <article class="question_summary question_summary__full">
                         <p class="question_title"><a href="{{ question.url }}" class="kbq">{{ question.question|safe }}</a></p>
-                        <p class="qans">{{ question.answer | safe | striptags | truncate }}</p>
+                        <p class="qans">{{ question.answer_content | safe | striptags | truncate }}</p>
                     </article>
                 {% else %}
                     <article class="question_summary question_summary__full">


### PR DESCRIPTION
### NOTE: This should not be merged until code freeze lifts Jan. 2.

The search-by-tag Ask CFPB page has been subtly broken since the last code refactoring, hiding parts of the search results. This change restores the full intended results list.

The URLs for search-by-tag have not been actively used, but were preserved to maintain legacy links to them. Two new links are being added (see internal issue 3646 for more context).

- In [production](https://www.consumerfinance.gov/ask-cfpb/search-by-tag/money-as-you-grow/), result snippets silently fail to render:

<img width="834" alt="missing_snippets" src="https://user-images.githubusercontent.com/515885/71626943-c14bb900-2bbd-11ea-8316-631102e79efb.png">

- If you render the page [locally](http://localhost:8000/ask-cfpb/search-by-tag/money-as-you-grow/), with DEBUG=True, the error can be seen:

<img width="792" alt="snippet_errors" src="https://user-images.githubusercontent.com/515885/71627014-27d0d700-2bbe-11ea-96a7-33feefcf8ed0.png">

- And with the fix, the snippets render as intended:

<img width="811" alt="snippets_render" src="https://user-images.githubusercontent.com/515885/71627064-6797be80-2bbe-11ea-90d3-df3125124e65.png">



 