### PR TITLE
Whitelist a mouseflow domain to allow the Live Heatmaps feature to load

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -529,6 +529,7 @@ CSP_SCRIPT_SRC = (
     'universal.iperceptions.com',
     'cdn.mouseflow.com',
     'n2.mouseflow.com',
+    'us.mouseflow.com',
     'geocoding.geo.census.gov',
     'tigerweb.geo.census.gov',
     'about:',


### PR DESCRIPTION
Data team was unable to view the Mouseflow Live Heatmaps feature because it was blocked by our CSP. Add that domain to the whitelist, as requested by the Mouseflow support contact.

## Additions

- add `us.mouseflow.com` to the CSP whitelist

## Todos

- There are several different CSP whitelists. Let's confirm that I've added the domain to the correct list.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: