### PR TITLE
Ask CFPB: Track null results in Analytics

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -74,7 +74,7 @@
 
         <section class="search-results block
                         block__flush-top">
-            <div class="no-results-message">
+            <div class="no-results-message" data-gtm_ask-no-results="true">
                 {% if tag %}
                     <h3 class="results-header">{{ _('No results found for') }} “{{ tag }}”</h3>
                 {% else %}

--- a/cfgov/unprocessed/js/routes/ask-cfpb/single.js
+++ b/cfgov/unprocessed/js/routes/ask-cfpb/single.js
@@ -1,3 +1,4 @@
 import '../../modules/util/add-email-popup';
 import '../on-demand/ask-autocomplete';
 import '../on-demand/read-more';
+import '../on-demand/ask-analytics';

--- a/cfgov/unprocessed/js/routes/on-demand/ask-analytics.js
+++ b/cfgov/unprocessed/js/routes/on-demand/ask-analytics.js
@@ -1,0 +1,13 @@
+/* ==========================================================================
+   Scripts for Ask analytics.
+   ========================================================================== */
+
+import Analytics from '../../modules/Analytics';
+
+const noResults = document.querySelectorAll( '[data-gtm_ask-no-results="true"]' ).length > 0;
+
+if ( noResults ) {
+  const search = document.getElementById( 'o-search-bar_query' ).value;
+  const eventData = Analytics.getDataLayerOptions( 'noSearchResults', search + ':0', 'Ask Search' );
+  Analytics.sendEvent( eventData );
+}


### PR DESCRIPTION
This adds code to help our Analytics team track search requests for Ask CFPB which have no results.

## Additions
- Add ask-analytics.js, which adds an event to the Google Tag Manager dataLayer object when it finds an element with a specific data attribute. (Data attributes are preferable to classes for Google analytics functions.)

- Add 'data-gtm_ask-no-results' data attribute to the "No results" element so that the analytics JavaScript can identify "No results" content.

## Testing
1. When you load an Ask CFPB with null results, you can open the JS console and check the contents of the `window.dataLayer` Array. You should see an Object in that Array, with properties like: `{event: "Complaint Search", action: "noSearchResults", ...}`. The `label` property of that Object should be the search term which resulted in no results (and it should end with `:0`).

Also, this will only work on "no results" pages, not the "Did you mean...?" style pages which show results for an alternate search term.

## Notes
- To be reviewed by @kelleyholden before merging

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### ~~Accessibility~~ (N/A)

- [ ] ~~Keyboard friendly~~
- [ ] ~~Screen reader friendly~~

### Other
- [ ] ~~Is useable without CSS~~ (N/A)
- [ ] ~~Is useable without JS~~ (N/A, is absolutely unusable without JS, but that is not an issue here)
- [ ] ~~Flexible from small to large screens~~ (N/A)
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
