### PR TITLE
Disallow robots from Ask CFPB search pages

### DIFF
--- a/cfgov/unprocessed/root/robots.txt
+++ b/cfgov/unprocessed/root/robots.txt
@@ -8,5 +8,9 @@ Disallow: *form-id=*
 Disallow: /?page=
 Disallow: /hud-api-replace
 Disallow: /yourstory
+Disallow: /ask-cfpb/search/
+Disallow: /ask-cfpb/search-by-tag/
+Disallow: /es/obtener-respuestas/buscar/
+Disallow: /es/obtener-respuestas/buscar-por-etiqueta/
 
 sitemap: https://www.consumerfinance.gov/sitemap.xml


### PR DESCRIPTION
Our English and Spanish search pages occasionally get hammered by bots
entering nonsense searches. This doesn't help anyone, so let's disallow it.

It's OK that the base search pages will be disallowed as well, because
they aren't used as stand-alone pages without a search parameter.
In fact, the search-by-tag pages return 404 if there is no parameter.

The four pages added:
- /ask-cfpb/search/
- /ask-cfpb/search-by-tag/
- /es/obtener-respuestas/buscar/
- /es/obtener-respuestas/buscar-por-etiqueta/
