### PR TITLE
Remove Python 2.7 from Tox and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 
 python:
-- 2.7
 - 3.6
 
 git:
@@ -44,12 +43,6 @@ env:
   matrix:
     - RUNTEST=backend
     - RUNTEST=frontend
-
-matrix:
-  exclude:
-    # We only want to run the frontend build once.
-    - python: 2.7
-      env: RUNTEST=frontend
 
 jobs:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist=True
 # wagtail==1.13.3 with django-modelcluster==4.4.
 # tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
+envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 
 
 [testenv]
@@ -16,7 +16,6 @@ envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
 #   lint:               Lint Python files with flake8 and isort
 #   unittest:           Run Python unittests
 #   acceptance:         Run a Django server and acceptance tests
-#   py27:               Use Python 2.7
 #   py36:               Use Python 3.6
 #   dj111:              Use Django 1.11
 #   dj20:               Use Django 2.0
@@ -25,23 +24,18 @@ envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
 #
 # These factors are expected to combine into the follow generative environments:
 #
-#   lint-py{27,36}
-#   unittest-py{27,36}-dj{111}-wag{113}-{fast,slow}
+#   lint-py{36}
+#   unittest-py{36}-dj{111}-wag{113}-{fast,slow}
 #   unittest-py{36}-dj{20}-wag{20}-{fast,slow}
-#   acceptance-py{27,36}-dj{111}-wag{113}-fast
+#   acceptance-py{36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
 #
-#   tox -e lint-py27
 #   tox -e lint-py36
-#   tox -e unittest-py27-dj111-wag113-fast
-#   tox -e unittest-py27-dj111-wag113-slow
 #   tox -e unittest-py36-dj111-wag113-fast
 #   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj20-wag20-fast
 #   tox -e unittest-py36-dj20-wag20-slow
-#   tox -e acceptance-py27-dj111-wag113-fast
-#   tox -e acceptance-py36-dj111-wag113-fast
 
 recreate=False
 
@@ -52,7 +46,6 @@ changedir=
     acceptance:         {[acceptance]changedir}
 
 basepython=
-    py27: python2.7
     py36: python3.6
 
 deps=
@@ -78,7 +71,6 @@ setenv=
 
 commands=
     lint:               {[lint]commands}
-    py27-slow:          {[missing-migrations]commands}
     py36-slow:          {[missing-migrations]commands}
     unittest:           {[unittest]commands}
     acceptance:         {[acceptance]commands}
@@ -88,7 +80,7 @@ commands=
 # Configuration values necessary to lint Python files.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e lint-py{27,36}
+#   tox -e lint-py{36}
 #
 # To run Python linting.
 deps=
@@ -103,7 +95,7 @@ commands=
 # Configuration values necessary to run unittests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{27,36}-dj{111,20}-wag{113,20}-{fast,slow}
+#   tox -e unittest-py{36}-dj{111,20}-wag{113,20}-{fast,slow}
 #
 # To run unit tests.
 changedir=
@@ -130,7 +122,7 @@ commands=
 # Configuration values necessary to run unittests without migrations.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{27,36}-dj{111}-wag{113}-fast
+#   tox -e unittest-py{36}-dj{111}-wag{113}-fast
 #
 # To run unit tests.
 setenv=
@@ -141,7 +133,7 @@ setenv=
 # Configuration values necessary to run unittests with migrations.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{27,36}-dj{111}-wag{113}-slow
+#   tox -e unittest-py{36}-dj{111}-wag{113}-slow
 #
 # To run unit tests.
 setenv=
@@ -166,7 +158,7 @@ commands=
 # virtualenv as backend tests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   acceptance-py{27,36}-dj{111}-wag{113}-fast
+#   acceptance-py{36}-dj{111}-wag{113}-fast
 #
 # To run acceptance tests.
 changedir=
@@ -193,21 +185,21 @@ commands=
 
 [testenv:lint]
 # Invoke with: tox -e lint
-# This should run identically to tox -e lint-py27
+# This should run identically to tox -e lint-py36
 recreate=False
-basepython=python2.7
-envdir={toxworkdir}/lint-py27
+basepython=python3.6
+envdir={toxworkdir}/lint-py36
 deps={[lint]deps}
 commands={[lint]commands}
 
 
 [testenv:fast]
 # Invoke with: tox -e fast
-# This should run identically to tox -e unittest-py27-dj111-wag113-fast
+# This should run identically to tox -e unittest-py36-dj111-wag113-fast
 recreate=False
 changedir={[unittest]changedir}
-basepython=python2.7
-envdir={toxworkdir}/unittest-py27-dj111-wag113-fast
+basepython=python3.6
+envdir={toxworkdir}/unittest-py36-dj111-wag113-fast
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt
@@ -221,8 +213,8 @@ commands={[unittest]commands}
 [testenv:acceptance]
 recreate=False
 changedir={[acceptance]changedir}
-basepython=python2.7
-envdir={toxworkdir}/acceptance-py27-dj111-wag113
+basepython=python3.6
+envdir={toxworkdir}/acceptance-py36-dj111-wag113
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt
@@ -240,7 +232,7 @@ commands={[acceptance]commands}
 # Ensure all assets are generated without error.
 recreate=False
 changedir={toxinidir}
-basepython=python2.7
+basepython=python3.6
 deps=-r{toxinidir}/requirements/base.txt
 setenv=
     DJANGO_SETTINGS_MODULE=cfgov.settings.production


### PR DESCRIPTION
This change removes Python 2.7 from our Tox environments and from our Travis tests.

Note: https://github.com/cfpb/cfgov-refresh/pull/5439 removes the Tox environments from the unit testing documentation.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
