### PR TITLE
Raise an exception when running in Python 2

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -1,9 +1,19 @@
+import sys
 import warnings
 
 from unipath import DIRS
 
 from .base import *
 
+
+if sys.version_info[0] < 3:
+    raise Exception(
+        "Python 2 is no longer supported. "
+        "If you are running in a virtual environment, please see "
+        "http://cfpb.github.io/cfgov-refresh/running-virtualenv/"
+        "#reinstalling-the-virtual-environment "
+        "for how to reinstall."
+    )
 
 DEBUG = True
 SECRET_KEY = 'not-secret-key-for-testing'

--- a/docs/running-virtualenv.md
+++ b/docs/running-virtualenv.md
@@ -132,3 +132,23 @@ yarn run gulp test:unit       # Run only unit tests on source code.
 yarn run gulp test:acceptance # Run only acceptance (in-browser) tests on production code.
 yarn run gulp audit           # Run code quality audits.
 ```
+
+### Reinstalling the virtual environment
+
+To remove an existing virtual environment for 
+[a reinstall of cfgov-refresh](installation/#stand-alone-installation), 
+first deactivate the virtual environment if it is active:
+
+```bash
+deactivate
+```
+
+Then remove the existing virtual environment:
+
+```bash
+rmvirtualenv cfgov-refresh
+```
+
+After this, you may follow 
+[the installation instructions](installation/#stand-alone-installation)
+again.

--- a/docs/running-virtualenv.md
+++ b/docs/running-virtualenv.md
@@ -1,7 +1,7 @@
 # Running in a Virtual Environment
 
 First, follow
-[the standalone installation instructions](installation/#stand-alone-installation)
+[the standalone installation instructions](../installation/#stand-alone-installation)
 to create your virtual environment, install required dependencies, and run
 the setup scripts.
 
@@ -136,7 +136,7 @@ yarn run gulp audit           # Run code quality audits.
 ### Reinstalling the virtual environment
 
 To remove an existing virtual environment for 
-[a reinstall of cfgov-refresh](installation/#stand-alone-installation), 
+[a reinstall of cfgov-refresh](../installation/#stand-alone-installation), 
 first deactivate the virtual environment if it is active:
 
 ```bash


### PR DESCRIPTION
This change will cause an exception to be raised if the local settings are loaded with Python 2. This is intended to prevent local development from continuing with Python 2.

This change also adds documentation on how to remove and reinstall a local virtualenv-based installation of cfgov-refresh.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: