### PR TITLE
Set the WSGI locale explicitly

### DIFF
--- a/cfgov/apache/conf.d/wsgi.conf
+++ b/cfgov/apache/conf.d/wsgi.conf
@@ -3,7 +3,7 @@ ServerName consumerfinance.gov
 LoadModule wsgi_module modules/mod_${SCL_PYTHON_VERSION}-wsgi.so
 
 WSGIApplicationGroup %{GLOBAL}
-WSGIDaemonProcess django home=${CFGOV_CURRENT} processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP}
+WSGIDaemonProcess django home=${CFGOV_CURRENT} processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP} lang='en_US.UTF-8' locale='en_US.UTF-8'
 WSGIProcessGroup django
 WSGIScriptAlias / ${CFGOV_CURRENT}/cfgov/cfgov/wsgi.py
 


### PR DESCRIPTION
This change sets the lang and locale explicitly to en_US.UTF-8 on the WSGI daemon process. This ensures that Django uses a UTF-8 locale.

This is intended to fix `UnicodeEncodeErrors` we're seeing with URLs with unicode characters in them that result in tracebacks ending like this:

```
File "/srv/cfgov/versions/20200109110904/cfgov/jinja2/v1/_layouts/base.html", line 317, in template
{% include 'js/routes/' + app_page_url(request) + 'index.js' ignore missing %}
File "/srv/cfgov/versions/20200109110904/cfgov/v1/jinja2_environment.py", line 52, in join_path
if os.path.exists(filesystem_path):
File "/srv/cfgov/current/venv/lib64/python3.6/genericpath.py", line 19, in exists
os.stat(path)
UnicodeEncodeError: 'ascii' codec can't encode character '\xf1' in position 65: ordinal not in range(128)
```

When the unicode `request.path` gets to `os.path.exists()`, it fails encoding as ASCII, suggesting that the system encoding is not set to UTF-8. This fixes that for the WSGI processes.

## Testing

1. On the `master` branch, use the [Production-like docker setup](http://cfpb.github.io/cfgov-refresh/running-docker/#docker-compose) to run with Apache and mod_wsgi:

   ```bash
   docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build
   ```

2. Once the container is built and running, visit http://localhost:8000/es/obtener-respuestas/que-hago-si-mi-vivienda-queda-dañada-o-destruida-o-si-no-puedo-hacer-mis-pagos-luego-de-un-desastre-es-1521/ and see a 500 error.

3. Checkout this branch, then connect to the container and restart Apache:

   ```
   git checkout set-wsgi-locale
   docker-compose exec python bash
   ...
   httpd -d ./cfgov/apache -k restart
   ```

4. Revisit http://localhost:8000/es/obtener-respuestas/que-hago-si-mi-vivienda-queda-dañada-o-destruida-o-si-no-puedo-hacer-mis-pagos-luego-de-un-desastre-es-1521/ and see the page as expected.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: