### PR TITLE
Move focus to header on return to top button

### DIFF
--- a/cfgov/unprocessed/js/modules/footer-button.js
+++ b/cfgov/unprocessed/js/modules/footer-button.js
@@ -61,15 +61,8 @@ function _scrollToTop() {
  *  Move focus to the top of the page.
  */
 function _setFocus() {
-  /* To move the focus from the footer we need to move it to another
-     focusable element. This is the "skip to main content" skip link.
-     Since we don't want this highlighted right away when
-     returning to the top of the page, we then need to blur it.
-     Unfortunately, this means the next hit of the tab key
-     will focus on the next element after the skip link,
-     since that link is the first focusable element on the page. */
-  document.querySelector( '.skip-nav_link' ).focus();
-  document.activeElement.blur();
+  document.documentElement.tabIndex = 0;
+  document.documentElement.focus();
 }
 
 export { init };

--- a/cfgov/unprocessed/js/modules/footer-button.js
+++ b/cfgov/unprocessed/js/modules/footer-button.js
@@ -33,6 +33,7 @@ function _scrollToTop() {
   // If requestAnimationFrame is not supported, return to top immediately.
   if ( 'requestAnimationFrame' in window === false ) {
     window.scrollTo( 0, 0 );
+    _setFocus();
     return;
   }
 
@@ -42,7 +43,9 @@ function _scrollToTop() {
    * Decrement scroll Y position.
    */
   function _step() {
-    if ( window.scrollY !== 0 ) {
+    if ( window.scrollY === 0 ) {
+      _setFocus();
+    } else {
       window.setTimeout( () => {
         scrollCount += 1;
         const adjustVal = cosParameter * Math.cos( scrollCount * scrollStep );
@@ -52,6 +55,21 @@ function _scrollToTop() {
       }, SCROLL_STEP_DURATION );
     }
   }
+}
+
+/**
+ *  Move focus to the top of the page.
+ */
+function _setFocus() {
+  /* To move the focus from the footer we need to move it to another
+     focusable element. This is the "skip to main content" skip link.
+     Since we don't want this highlighted right away when
+     returning to the top of the page, we then need to blur it.
+     Unfortunately, this means the next hit of the tab key
+     will focus on the next element after the skip link,
+     since that link is the first focusable element on the page. */
+  document.querySelector( '.skip-nav_link' ).focus();
+  document.activeElement.blur();
 }
 
 export { init };

--- a/test/unit_tests/js/modules/footer-button-spec.js
+++ b/test/unit_tests/js/modules/footer-button-spec.js
@@ -6,6 +6,11 @@ import { simulateEvent } from '../../../util/simulate-event';
 let footerBtnDom;
 
 const HTML_SNIPPET = `
+<div class="skip-nav">
+    <a class="skip-nav_link" href="#main">
+        Skip to main content
+    </a>
+</div>
 <a class="a-btn a-btn__secondary o-footer_top-button"
    data-gtm_ignore="true" data-js-hook="behavior_return-to-top"
    href="#">


### PR DESCRIPTION
## Changes

- Set focus on header element when return to top button is clicked.

## Testing

1. Pull branch, run `gulp clean && gulp build`
2. Resize window to mobile size.
3. Scroll to bottom of the page and click "Back to top" button.
4. Press tab to see that the focus is in the header, not the footer (compare to behavior on production).

## Notes

- ~Ideally the focus should be BEFORE the skip link, so that the first click of the tab key ends up on the skip link. However, to move the focus from the footer, we need to move focus to another focusable element. The skip link is the first of these on the page. We don't want the skip link to show (I don't think?) when returning to the top as the user has not yet hit the tab key, so we set it to the skip link and then blur the `activeElement`. The consequence of this is that the next hit of the tab key will not be on the skip link, as it'll have already moved past it.~
