### PR TITLE
Fix HUD HTML generation in Python 3

### DIFF
--- a/cfgov/housing_counselor/generator.py
+++ b/cfgov/housing_counselor/generator.py
@@ -135,7 +135,7 @@ def generate_counselor_html(source_dir, target_dir):
         html_filename = os.path.join(target_dir, '{}.html'.format(zipcode))
 
         with open(html_filename, 'w') as f:
-            f.write(html.encode('utf-8'))
+            f.write(html)
 
 
 def get_counselor_json_files(directory):


### PR DESCRIPTION
This is a quick fix for HTML generation from HUD JSON. Previously, to ensure we were writing out UTF-8 HTML, we would encode the result from the Django template's `render()` method as UTF-8. This is not necessary in Python 3, as the returned HTML is UTF-8 encoded already.

Prior to this change attempting to generate the HTML (in our Jenkins jobs as well as locally) would result in:

```
$ ./cfgov/manage.py hud_generate_html ./jsons ./htmls
Found 41140 input files
Traceback (most recent call last):
  File "./cfgov/manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/src/cfgov-refresh/cfgov/housing_counselor/management/commands/hud_generate_html.py", line 16, in handle
    generate_counselor_html(options['source'], options['target'])
  File "/src/cfgov-refresh/cfgov/housing_counselor/generator.py", line 138, in generate_counselor_html
    f.write(html.encode('utf-8'))
TypeError: write() argument must be str, not SafeBytes
```

## Testing

1. Download the generated JSON from `http://[JENKINS]/job/cf.gov-housing-counselor-data/ws/jsons/*zip*/jsons.zip` and unzip it.
  
   ```shell
   unzip ~/Downloads/jsons.zip
   Archive:  /Users/bartonw/Downloads/jsons.zip
     inflating: jsons/13054.json
   …
   ```
2. Make a destination for the HTML

   ```shell
   mkdir htmls
   ```

3. Generate the HTML from the JSON:

   ```
   ./cfgov/manage.py hud_generate_html ./jsons ./htmls
   ```

   This may take a while — you don't have to generate all the JSON, just see that it starts writing some HTML files. You could open an inspect any of them you wish.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
