### PR TITLE
Fix Ask CFPB data export in Python 3

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -75,7 +75,8 @@ def assemble_output():
                 lambda item: item['type'] == 'how_to_schema' or
                 item['type'] == 'faq_schema', answer_streamfield)
             if answer_schema:
-                answer = answer_schema[0].get('value').get('description')
+                answer = next(answer_schema).get('value').get('description')
+
         output['Answer'] = clean_and_strip(answer).replace('\x81', '')
         output['ShortAnswer'] = clean_and_strip(page['short_answer'])
         output['URL'] = page['url_path'].replace('/cfgov', '')


### PR DESCRIPTION
This change fixes the Ask CFPB data export that was broken in Python 3 because of a difference in the way the `filter()` function works.

`filter()` in Python 2 returns a list, and so could be called with list indices. `filter()` in Python 3 returns an iterable `filter` object that cannot be treated like a list.

Since we want to first object resulting from the filter, the fix is a single call to `next()` in place of `[0]`.

## Testing

1. Visit http://localhost:8000/admin/export-ask on `master` and try to export data. You'll see an error with a traceback that ends with:

   ```
   answer = answer_schema[0].get('value').get('description')
   TypeError: 'filter' object is not subscriptable
   ```

2. Checkout this branch and try again. You should successfully get a CSV export of Ask data.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: