### PR TITLE
Break words in secondary nav when text is too long

### DIFF
--- a/cfgov/unprocessed/css/molecules/nav-link.less
+++ b/cfgov/unprocessed/css/molecules/nav-link.less
@@ -43,6 +43,9 @@
 .m-nav-link {
     display: inline-block;
 
+    // Break the menu word when it is too wide to fit in the sidebar area.
+    word-break: break-word;
+
     .u-link__colors(@pacific, @pacific, @black, @black, @black,
                     transparent, transparent, @green, @green, @green);
 


### PR DESCRIPTION
## Changes

- Breaks secondary nav items when word is too long and gets truncated.

## Testing

1. Open a Browse Page like https://www.consumerfinance.gov/policy-compliance/guidance/supervision-examinations/ in Chrome.
2. Open Settings (Chrome > Preferences…)
3. Search for "appearance"
4. Change font size to a larger size or go into Customize fonts and move the Font size slider to the right until it indicates under “Standard font” that the base size is 32 (200% of the default of 16)
5. Return to the page and observe the sidenav

## Screenshots

Before:
<img width="286" alt="Screen Shot 2020-01-13 at 2 22 40 PM" src="https://user-images.githubusercontent.com/704760/72285172-970fe780-3610-11ea-9f39-2f9b8864a9d7.png">

After:
<img width="299" alt="Screen Shot 2020-01-13 at 2 25 07 PM" src="https://user-images.githubusercontent.com/704760/72285186-9c6d3200-3610-11ea-9149-64df41fa2974.png">