### PR TITLE
Remove Python 2 code from six import

### DIFF
--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -8,7 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
-from six import StringIO
+from io import StringIO
 
 from django.apps import apps
 from django.conf import settings

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import datetime
-from six import BytesIO
+from io import BytesIO
 
 from django.conf import settings
 

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 import logging
-from six import BytesIO
+from io import BytesIO
 
 import unicodecsv
 from dateutil import parser

--- a/cfgov/data_research/tests/management/commands/test_conference_delete.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_delete.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from six import StringIO
+from io import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase

--- a/cfgov/data_research/tests/management/commands/test_conference_notify.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_notify.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from six import StringIO
+from io import StringIO
 
 from django.core import mail
 from django.core.management import call_command

--- a/cfgov/data_research/tests/test_s3_utils.py
+++ b/cfgov/data_research/tests/test_s3_utils.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import csv
-from six import BytesIO, StringIO
+from io import BytesIO, StringIO
 
 from django.test import TestCase, override_settings
 

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import datetime
 import tempfile
 import unittest
-from six import BytesIO
+from io import BytesIO
 
 import django
 

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -1,5 +1,3 @@
-from six import string_types as basestring
-
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest
 from django.test import TestCase
@@ -100,7 +98,7 @@ class JobListingPageTestCase(TestCase):
     def test_ordered_grades_returns_strings(self):
         page = self.make_page_with_grades('3', '2', '1')
         for grade in page.ordered_grades:
-            self.assertIsInstance(grade, basestring)
+            self.assertIsInstance(grade, str)
 
     def test_context_for_page_with_region_location(self):
         region = mommy.make(

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlencode
 
+from django.utils.six import iterlists
+
 from jinja2.ext import Extension
 
 
@@ -11,7 +13,7 @@ def remove_url_parameter(request, discards):
          {param: [values]}
     """
     query = request.GET.copy()
-    params = dict.lists(query)
+    params = dict(iterlists(query))
     items = {}
     for key in params:
         if key in discards:

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -14,8 +14,9 @@ def remove_url_parameter(request, discards):
     """
     query = request.GET.copy()
     params = dict(iterlists(query))
+    # params = iter(query)
     items = {}
-    for key in params:
+    for key in list(dict.keys(query)):
         if key in discards:
             items[key.encode('utf-8')] = [
                 item.encode('utf-8') for item in params[key]

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -1,7 +1,5 @@
 from urllib.parse import urlencode
 
-from django.utils.six import iterlists
-
 from jinja2.ext import Extension
 
 
@@ -13,7 +11,7 @@ def remove_url_parameter(request, discards):
          {param: [values]}
     """
     query = request.GET.copy()
-    params = dict(iterlists(query))
+    params = dict.lists(query)
     items = {}
     for key in params:
         if key in discards:

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -1,7 +1,5 @@
 from urllib.parse import urlencode
 
-from django.utils.six import iterlists
-
 from jinja2.ext import Extension
 
 
@@ -12,11 +10,9 @@ def remove_url_parameter(request, discards):
     Discards should be a dict of lists:
          {param: [values]}
     """
-    query = request.GET.copy()
-    params = dict(iterlists(query))
-    # params = iter(query)
+    params = dict(request.GET.lists())
     items = {}
-    for key in list(dict.keys(query)):
+    for key in params.keys():
         if key in discards:
             items[key.encode('utf-8')] = [
                 item.encode('utf-8') for item in params[key]

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -5,7 +5,6 @@ from django.core.paginator import InvalidPage, Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.six import iterlists
 
 from prepaid_agreements.models import PrepaidProduct
 from v1.models.snippets import ReusableText
@@ -97,7 +96,7 @@ def get_support_text():
 
 def index(request):
     query = request.GET.copy()
-    params = dict(iterlists(query))
+    params = dict.lists(query)
     available_filters = {}
     search_term = None
     search_field = None

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -96,7 +96,7 @@ def get_support_text():
 
 def index(request):
     query = request.GET.copy()
-    params = dict.lists(query)
+    params = dict.items(query)
     available_filters = {}
     search_term = None
     search_field = None

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -95,8 +95,7 @@ def get_support_text():
 
 
 def index(request):
-    query = request.GET.copy()
-    params = dict.items(query)
+    params = request.GET.lists()
     available_filters = {}
     search_term = None
     search_field = None

--- a/cfgov/v1/admin_forms.py
+++ b/cfgov/v1/admin_forms.py
@@ -1,5 +1,5 @@
 import zipfile
-from six import BytesIO, StringIO
+from io import BytesIO, StringIO
 
 from django import forms
 from django.core.management import call_command

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -2,7 +2,6 @@ import itertools
 import json
 from collections import Counter
 from functools import partial
-from six import string_types as basestring
 from urllib.parse import urlencode
 
 from django import forms
@@ -584,7 +583,7 @@ class ModelBlock(blocks.StructBlock):
 
         ordering = self.get_ordering(value)
         if ordering:
-            if isinstance(ordering, basestring):
+            if isinstance(ordering, str):
                 ordering = (ordering,)
 
             qs = qs.order_by(*ordering)

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -1,6 +1,4 @@
 # -*- coding: utf8 -*-
-import six
-
 from django.db import models
 from django.utils.safestring import mark_safe
 
@@ -35,9 +33,7 @@ class HomePageFormMetaclass(WagtailAdminModelFormMetaclass):
         return HomePageForm
 
 
-class HomePageForm(
-    six.with_metaclass(HomePageFormMetaclass, WagtailAdminPageForm)
-):
+class HomePageForm(HomePageFormMetaclass, WagtailAdminPageForm):
     pass
 
 

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.six import string_types
 
 from wagtail.wagtailimages.image_operations import (
     DoNothingOperation, MinMaxOperation, WidthHeightOperation
@@ -41,7 +40,7 @@ class CFGOVImage(AbstractImage):
         <img> tag with appropriate size parameters, following logic from
         wagtail.wagtailimages.image_operations.
         """
-        if isinstance(rendition_filter, string_types):
+        if isinstance(rendition_filter, str):
             rendition_filter = Filter(spec=rendition_filter)
 
         width = self.width

--- a/cfgov/v1/tests/management/commands/test_export_feedback.py
+++ b/cfgov/v1/tests/management/commands/test_export_feedback.py
@@ -3,7 +3,7 @@ import argparse
 import io
 import tempfile
 from datetime import date, datetime, timedelta
-from six import StringIO, ensure_text
+from io import StringIO
 
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
@@ -102,7 +102,7 @@ class TestExportFeedback(TestCase):
     def call_command(self, *args, **kwargs):
         stdout = StringIO()
         call_command('export_feedback', *args, stdout=stdout, **kwargs)
-        return ensure_text(stdout.getvalue())
+        return str(stdout.getvalue())
 
     def test_export_no_feedback_header_only(self):
         Feedback.objects.all().delete()

--- a/cfgov/v1/util/datetimes.py
+++ b/cfgov/v1/util/datetimes.py
@@ -1,5 +1,4 @@
 import datetime
-from six import string_types as basestring
 
 from dateutil import parser
 from pytz import timezone
@@ -12,7 +11,7 @@ def convert_date(date, tz):
     datetime. Then (and if `date` was already a datetime), it takes the passed
     timezone and converts the datetime to one that is in that timezone.
     """
-    if date and isinstance(date, basestring):
+    if date and isinstance(date, str):
         date = parser.parse(
             date,
             default=datetime.datetime.today().replace(day=1)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,5 +12,4 @@ mkdocs-rtd-dropdown==1.0.2
 pymdown-extensions==5.0
 PyYAML==3.13
 singledispatch==3.4.0.3
-six==1.12.0
 tornado==5.1.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -45,7 +45,6 @@ regdown==1.0.1
 requests==2.22.0
 requests_toolbelt==0.8.0
 sha3==0.2.1
-six==1.12.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2


### PR DESCRIPTION
Remove Python 2 code relating to six library

## Removals

- from six import

## Changes

- basestr -> str
- Use from io import StringIO

## Testing

$ tox
...
unittest-py36-dj111-wag113-slow runtests: commands[2] | coverage run --source=. manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...
Ran 1511 tests in 74.149s

OK (skipped=9)
Destroying test database for alias 'default'...
______________________________________________________ summary _______________________________________________________
  lint-py36: commands succeeded
  unittest-py36-dj111-wag113-slow: commands succeeded
  congratulations :)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
