### PR TITLE
Update all satellite apps to remove python 2 compatibility

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -56,9 +56,9 @@ wagtail-sharing==0.8
 wagtail-treemodeladmin==1.0.4
 
 # These packages are installed from GitHub.
-https://github.com/cfpb/owning-a-home-api/releases/download/0.12.4/owning_a_home_api-0.12.4-py2.py3-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.10.4/retirement-0.10.4-py2.py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.1.12/ccdb5_api-1.1.12-py2.py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/1.3.5/ccdb5_ui-1.3.5-py2.py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.12.1/comparisontool-1.12.1-py2.py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.1.10/teachers_digital_platform-1.1.10-py2.py3-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.13.0/owning_a_home_api-0.13.0-py3-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.2.0/ccdb5_api-1.2.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.0/comparisontool-1.13.0-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.0/teachers_digital_platform-1.2.0-py3-none-any.whl


### PR DESCRIPTION
New releases all remove python 2 compatibility and only provide python 3 compatibility

## Changes

- Update to the latest release of all consumerfinance.gov satellite apps.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: