### PR TITLE
Shorten beta banner text

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -28,9 +28,7 @@
             {{ notification.render(
                 'warning',
                 true,
-                'This beta site is a work in progress.',
-                'We’re prototyping new designs. Things may not work as expected.
-                Our regular site continues to be at
+                'This beta site is a work in progress. Our regular site continues to be
                 <a href="https://www.consumerfinance.gov/">www.consumerfinance.gov</a>.' | safe
             ) }}
         </div>


### PR DESCRIPTION
## Changes

- Shortens beta banner text to one line.

## Testing

1. Pull branch, enable BETA_NOTICE flag, check site to see new banner.

## Screenshots
<img width="1075" alt="Screen Shot 2020-01-14 at 12 10 26 PM" src="https://user-images.githubusercontent.com/704760/72365844-0516e600-36c7-11ea-86f4-47ab8d55bd51.png">
