### PR TITLE
Mega menu: Add hardcoded external link icon to variation 1

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -178,7 +178,7 @@
                         <li>
                             <a class="{{ _classes( nav_depth, '-link' ) }}" href="https://pueblo.gpo.gov/CFPBPubs/CFPBPubs.php">
                                 <span>{{ svg_icon( 'complaint' ) }}</span>
-                                Order free brochures
+                                Order free brochures {{ svg_icon( 'external-link' ) }}
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Changes

- Add hardcoded external link icon to variation 1 menu.

## Testing

1. Enable `MEGA_MENU_VAR_1` flag and visit homepage and go to the second tab.

## Screenshots

<img width="275" alt="Screen Shot 2020-01-14 at 12 23 23 PM" src="https://user-images.githubusercontent.com/704760/72366768-e9144400-36c8-11ea-8f7e-2d27cf769dd5.png">

<img width="296" alt="Screen Shot 2020-01-14 at 12 23 20 PM" src="https://user-images.githubusercontent.com/704760/72366767-e9144400-36c8-11ea-9327-6551a6b065be.png">
