### PR TITLE
Mega Menu: Fix top padding. Fix brochure icon. Hide menu column header.

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -177,7 +177,7 @@
                         </li>
                         <li>
                             <a class="{{ _classes( nav_depth, '-link' ) }}" href="https://pueblo.gpo.gov/CFPBPubs/CFPBPubs.php">
-                                <span>{{ svg_icon( 'complaint' ) }}</span>
+                                <span>{{ svg_icon( 'document' ) }}</span>
                                 Order free brochures {{ svg_icon( 'external-link' ) }}
                             </a>
                         </li>

--- a/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
@@ -719,7 +719,7 @@ body {
                 box-shadow: 0 5px 5px 0px rgba( 0, 0, 0, 0.2 );
 
                 padding: unit( @grid_gutter-width / @base-font-size-px, em );
-                padding-top: unit( 20 / @base-font-size-px, em );
+                padding-top: unit( 20px / @base-font-size-px, em );
                 padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
             }
@@ -744,6 +744,7 @@ body {
 
             &-lists {
                 display: table;
+                margin-top: unit( 10px / @base-font-size-px, em );
             }
 
             &-list {

--- a/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
@@ -495,6 +495,10 @@ body {
         &_group-heading {
             margin-top: @grid_gutter-width;
 
+            &__hidden {
+                .u-visually-hidden;
+            }
+
             // add border between title and following list
             &:not(&__hidden) + ul {
                 border-top: 1px solid @gray-40;
@@ -561,7 +565,7 @@ body {
                 &:active,
                 &:focus,
                 &:visited {
-                    border-color: @white;
+                    border-color: transparent;
                     border-bottom: none;
                 }
 
@@ -715,6 +719,7 @@ body {
                 box-shadow: 0 5px 5px 0px rgba( 0, 0, 0, 0.2 );
 
                 padding: unit( @grid_gutter-width / @base-font-size-px, em );
+                padding-top: unit( 20 / @base-font-size-px, em );
                 padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
             }
@@ -780,20 +785,15 @@ body {
                     cursor: default;
                 }
             }
-
-            &-overview-link {
-                padding-top: 0;
-            }
-
-            &_group-heading {
-                margin-bottom: @grid_gutter-width;
-            }
-
         }
 
         // 3rd-level menu - Desktop.
         &_content-3 {
             display: none;
+        }
+
+        &_group-heading__hidden {
+            visibility: hidden;
         }
 
         // Hide global header CTA container and eyebrow at desktop size.
@@ -820,19 +820,6 @@ body {
         &_content-2 {
             left: -@grid_gutter-width;
             width: @menu_max_width_px + ( @grid_gutter-width * 2 );
-
-            &-overview-link {
-                padding-top: 0;
-            }
-        }
-
-        // Group heading - Tablet/Mobile
-        &_group-heading {
-
-            &__hidden {
-                opacity: 0;
-                cursor: default;
-            }
         }
 
     } );

--- a/cfgov/unprocessed/css/organisms/mega-menu-var-2.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-2.less
@@ -753,7 +753,7 @@ body {
                 box-shadow: 0 5px 5px 0px rgba( 0, 0, 0, 0.2 );
 
                 padding: unit( @grid_gutter-width / @base-font-size-px, em );
-                padding-top: unit( 20 / @base-font-size-px, em );
+                padding-top: unit( 20px / @base-font-size-px, em );
                 padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
             }
@@ -786,6 +786,7 @@ body {
 
             &-lists {
                 display: table;
+                margin-top: unit( 10px / @base-font-size-px, em );
             }
 
             &-list {

--- a/cfgov/unprocessed/css/organisms/mega-menu-var-2.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-2.less
@@ -486,6 +486,10 @@ body {
         &_group-heading {
             margin-top: @grid_gutter-width;
 
+            &__hidden {
+                .u-visually-hidden;
+            }
+
             // add border between title and following list
             &:not(&__hidden) + ul {
                 border-top: 1px solid @gray-40;
@@ -553,7 +557,7 @@ body {
                 &:active,
                 &:focus,
                 &:visited {
-                    border-color: @white;
+                    border-color: transparent;
                     border-bottom: none;
                 }
 
@@ -749,6 +753,7 @@ body {
                 box-shadow: 0 5px 5px 0px rgba( 0, 0, 0, 0.2 );
 
                 padding: unit( @grid_gutter-width / @base-font-size-px, em );
+                padding-top: unit( 20 / @base-font-size-px, em );
                 padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
             }
@@ -822,20 +827,15 @@ body {
                     cursor: default;
                 }
             }
-
-            &-overview-link {
-                padding-top: 0;
-            }
-
-            &_group-heading {
-                margin-bottom: @grid_gutter-width;
-            }
-
         }
 
         // 3rd-level menu - Desktop.
         &_content-3 {
             display: none;
+        }
+
+        &_group-heading__hidden {
+            visibility: hidden;
         }
 
         // Hide global header CTA container and eyebrow at desktop size.
@@ -887,17 +887,6 @@ body {
         &_content-2 {
             left: -@grid_gutter-width;
             width: @menu_max_width_px + ( @grid_gutter-width * 2 );
-
-            &-overview-link {
-                padding-top: 0;
-            }
-        }
-
-        &_group-heading {
-            &__hidden {
-                opacity: 0;
-                cursor: default;
-            }
         }
 
     } );


### PR DESCRIPTION
##  Changes

- Fix top padding above the overview link, so that the hover has correct height.
- Change order brochure link icon to be a document instead of a complaint.
- Hide redundant menu item group header.

## Testing

1. Pull branch and `gulp clean && gulp build`
2. Enable `MEGA_MENU_VAR_1` flag.
3. Visit homepage and resize desktop to view extra large and regular desktop sizes and see that hover for overview link is equal height on the top and bottom. Also see that second column in menu item groups has a hidden heading. Also see that the Order Brochures icon has changed to a document.

## Screenshots

<img width="1148" alt="Screen Shot 2020-01-14 at 3 27 15 PM" src="https://user-images.githubusercontent.com/704760/72379934-69936e80-36e2-11ea-913c-14b551556298.png">
<img width="1146" alt="Screen Shot 2020-01-14 at 3 27 22 PM" src="https://user-images.githubusercontent.com/704760/72379935-69936e80-36e2-11ea-893a-eae30ac6704c.png">
