### PR TITLE
Fix job listings with multiple USAJobs links

### DIFF
--- a/cfgov/jobmanager/models/django.py
+++ b/cfgov/jobmanager/models/django.py
@@ -23,6 +23,12 @@ class ApplicantType(models.Model):
     class Meta:
         ordering = ['applicant_type']
 
+    def __lt__(self, other):
+        return self.applicant_type < other.applicant_type
+
+    def __gt__(self, other):
+        return self.applicant_type > other.applicant_type
+
 
 class Grade(models.Model):
     grade = models.CharField(max_length=32)

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -6,10 +6,10 @@ from mock import patch
 from model_mommy import mommy
 
 from jobmanager.models.django import (
-    City, Grade, JobCategory, Office, Region, State
+    ApplicantType, City, Grade, JobCategory, Office, Region, State
 )
 from jobmanager.models.pages import JobListingPage
-from jobmanager.models.panels import GradePanel
+from jobmanager.models.panels import GradePanel, USAJobsApplicationLink
 from v1.models.snippets import ReusableText
 from v1.tests.wagtail_pages.helpers import save_new_page
 
@@ -163,3 +163,21 @@ class JobListingPageTestCase(TestCase):
             test_context['about_us'],
             about_us_snippet
         )
+
+    def test_usajobs_application_link_ordering(self):
+        page = self.prepare_job_listing_page()
+        save_new_page(page)
+
+        page.usajobs_application_links = [
+            USAJobsApplicationLink(
+                announcement_number='1',
+                applicant_type=mommy.make(ApplicantType, applicant_type='1'),
+            ),
+            USAJobsApplicationLink(
+                announcement_number='2',
+                applicant_type=mommy.make(ApplicantType, applicant_type='2'),
+            ),
+        ]
+
+        result = page.usajobs_application_links.order_by('applicant_type')
+        self.assertEqual(result.first().announcement_number, '1')


### PR DESCRIPTION
This is a fix for job listings that have multiple USAJobs links in them. With Python 3's stricter comparisons, attempting to order the `USAJobsApplicationLink` objects using `applicant_type` was failing with `ApplicantType` not supporting `<` operations.

This fix adds `__gt__` and `__lt__` to `ApplicantType` to support `>` and `<` operations.

Generally this appears to come from django-modelcluster and behavior that differs from the Django expectation, possibly related to https://github.com/wagtail/django-modelcluster/issues/45.

## Testing

1. Create or edit a job listing to have multiple USAJobs application links
2. Try to preview the page and notice a 500
3. Checkout this branch
4. Preview the job listing again and notice it works as expected

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: