### PR TITLE
Fix prepaid search by wrapping query in a dict

### DIFF
--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -95,7 +95,7 @@ def get_support_text():
 
 
 def index(request):
-    params = request.GET.lists()
+    params = dict(request.GET.lists())
     available_filters = {}
     search_term = None
     search_field = None


### PR DESCRIPTION
The prepaid index view expects that query params will be in `dict` form (so that params can be `pop`ed). This change restores that.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: