### PR TITLE
Redirect bare calls to /askcfpb/search/

### DIFF
--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -413,20 +413,26 @@ class RedirectAskSearchTestCase(TestCase):
 
     def test_redirect_search_no_facets(self):
         request = HttpRequest()
-        with self.assertRaises(Http404):
-            redirect_ask_search(request)
+        result = redirect_ask_search(request)
+        self.assertEqual(
+            result.get('location'),
+            '/ask-cfpb/search/')
 
     def test_redirect_search_blank_facets(self):
         request = HttpRequest()
         request.GET['selected_facets'] = ''
-        with self.assertRaises(Http404):
-            redirect_ask_search(request)
+        result = redirect_ask_search(request)
+        self.assertEqual(
+            result.get('location'),
+            '/ask-cfpb/search/')
 
     def test_redirect_search_no_query(self):
         request = HttpRequest()
         request.GET['q'] = ' '
-        with self.assertRaises(Http404):
-            redirect_ask_search(request)
+        result = redirect_ask_search(request)
+        self.assertEqual(
+            result.get('location'),
+            '/ask-cfpb/search/')
 
     def test_redirect_search_with_category(self):
         category_querystring = (


### PR DESCRIPTION
Our [Ask CFPB search redirect view](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/ask_cfpb/views.py#L145)
was tasked with handling many legacy knowledgebase combinations, but one was left out: a search with no query string.

We don't normally send users to the bare search page, but rather send requests there, with a query string, from search boxes on the Ask landing page and on all answer pages.

But the bare search page exists and is functional, and we get requests for it, so this change routes those requests to /ask-cfpb/serach/, even if it has no query string, or a blank one like `/?q=`

## Testing
The legacy bare search URL should return 404 without a query string: <http://localhost:8000/askcfpb/search/>

After loading this branch, the legacy request above (and a legacy request with a blank query string) should permanently redirect to **/ask-cfpb/search/**

