### PR TITLE
Adjust housing counselor links to remove extended underline

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -67,11 +67,13 @@
                             There is also a
                             <a class="a-link a-link__icon"
                                href="{{ signed_redirect( 'https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm' ) }}">
-                               <span class="a-link_text">
-                                   list of nationwide
-                                   HUD-approved counseling agencies
-                               </span>
-                               {{ svg_icon( 'external-link' ) }}</a>.
+                                {#
+                                    The following link text can't be
+                                    broken across lines as it'll create
+                                    a space after the link text.
+                                #}
+                                <span class="a-link_text">list of nationwide HUD-approved counseling agencies</span>
+                                {{ svg_icon( 'external-link' ) }}</a>.
                         </p>
                     </div>
 
@@ -124,8 +126,13 @@
                                                     This tool is powered by
                                                     <a class="a-link a-link__icon"
                                                        href="{{ signed_redirect( 'https://data.hud.gov/housing_counseling.html' ) }}">
-                                                    <span class="a-link_text">HUD's</span>
-                                                    {{ svg_icon( 'external-link' ) }}</a>
+                                                        {#
+                                                            The following link text can't be
+                                                            broken across lines as it'll create
+                                                            a space after the link text.
+                                                        #}
+                                                        <span class="a-link_text">HUD's</span>
+                                                        {{ svg_icon( 'external-link' ) }}</a>
                                                     official list of housing counselors.
                                                 </p>
                                                 <p>
@@ -170,9 +177,12 @@
                                               a-link__icon"
                                        id="hud_print-page-link"
                                        href="#">
-                                        <span class="a-link_text">
-                                            Print list
-                                        </span>
+                                        {#
+                                            The following link text can't be
+                                            broken across lines as it'll create
+                                            a space after the link text.
+                                        #}
+                                        <span class="a-link_text">Print list</span>
                                         {{ svg_icon( 'print' ) }}
                                     </a>
                                 </li>
@@ -182,22 +192,22 @@
                                        href="{{ pdf_url }}"
                                        target="_blank"
                                        rel="noopener noreferrer">
-                                        <span class="a-link_text">
-                                            Save list as
-                                            <abbr title="Portable Document Format">
-                                              PDF
-                                            </abbr>
-                                        </span>
+                                        {#
+                                            The following link text can't be
+                                            broken across lines as it'll create
+                                            a space after the link text.
+                                        #}
+                                        <span class="a-link_text">Save list as <abbr title="Portable Document Format">PDF</abbr></span>
                                         {{ svg_icon( 'download' ) }}
                                     </a>
                                 </li>
                             </ul>
 
                             <h2 class="h4">
-                              Displaying the
-                              {{ api_json.counseling_agencies | length }}
-                              locations closest to ZIP code
-                              {{ zipcode | escape }}
+                                Displaying the
+                                {{ api_json.counseling_agencies | length }}
+                                locations closest to ZIP code
+                                {{ zipcode | escape }}
                             </h2>
                         </div>
 
@@ -224,10 +234,13 @@
                                                     {% if counselor.weburl %}
                                                     <a class="a-link a-link__icon"
                                                        href="{{ signed_redirect( counselor.weburl ) }}">
-                                                      <span class="a-link_text">
-                                                          <b itemprop="name">{{ counselor.nme }}</b>
-                                                      </span>
-                                                      {{ svg_icon( 'external-link' ) }}
+                                                        {#
+                                                            The following link text can't be
+                                                            broken across lines as it'll create
+                                                            a space after the link text.
+                                                        #}
+                                                        <span class="a-link_text"><b itemprop="name">{{ counselor.nme }}</b></span>
+                                                        {{ svg_icon( 'external-link' ) }}
                                                     </a>
                                                     {% else %}
                                                     <b itemprop="name">{{ counselor.nme }}</b>
@@ -254,9 +267,12 @@
                                                     <a class="a-link a-link__icon"
                                                        href="{{ signed_redirect( counselor.weburl ) }}"
                                                        itemprop="url">
-                                                        <span class="a-link_text">
-                                                            {{ counselor.weburl }}
-                                                        </span>
+                                                        {#
+                                                            The following link text can't be
+                                                            broken across lines as it'll create
+                                                            a space after the link text.
+                                                        #}
+                                                        <span class="a-link_text">{{ counselor.weburl }}</span>
                                                         {{ svg_icon( 'external-link' ) }}
                                                     </a>
                                                     </dd>
@@ -331,11 +347,13 @@
                                     collection is
                                     <a class="a-link a-link__icon"
                                        href="{{ signed_redirect( 'https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025' ) }}">
-                                       <span class="a-link_text"
-                                             aria-label="The OMB control number for this collection is 3170-0025">
-                                           3170-0025
-                                       </span>
-                                       {{ svg_icon( 'external-link' ) }}</a>.
+                                        {#
+                                            The following link text can't be
+                                            broken across lines as it'll create
+                                            a space after the link text.
+                                        #}
+                                        <span class="a-link_text" aria-label="The OMB control number for this collection is 3170-0025">3170-0025</span>
+                                        {{ svg_icon( 'external-link' ) }}</a>.
                                     It expires on 04/30/2016. Using this tool
                                     to generate a list of HUD-Approved Housing
                                     Counseling Agencies is voluntary however,

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -67,20 +67,17 @@
                             There is also a
                             <a class="a-link a-link__icon"
                                href="{{ signed_redirect( 'https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm' ) }}">
-                                {#
-                                    The following link text can't be
-                                    broken across lines as it'll create
-                                    a space after the link text.
-                                #}
                                 <span class="a-link_text">list of nationwide HUD-approved counseling agencies</span>
                                 {{ svg_icon( 'external-link' ) }}</a>.
                         </p>
                     </div>
 
                     <div class="block block__border u-screen-only">
-                        {# Set the `no-js` class on page load,
-                           which is reverted if and when the map is
-                           loaded via JavaScript. #}
+                        {#
+                            Set the `no-js` class on page load,
+                            which is reverted if and when the map is
+                            loaded via JavaScript.
+                        #}
                         <section id="hud_search_container"
                                  class="no-js
                                         hud-search-container">
@@ -126,11 +123,6 @@
                                                     This tool is powered by
                                                     <a class="a-link a-link__icon"
                                                        href="{{ signed_redirect( 'https://data.hud.gov/housing_counseling.html' ) }}">
-                                                        {#
-                                                            The following link text can't be
-                                                            broken across lines as it'll create
-                                                            a space after the link text.
-                                                        #}
                                                         <span class="a-link_text">HUD's</span>
                                                         {{ svg_icon( 'external-link' ) }}</a>
                                                     official list of housing counselors.
@@ -177,11 +169,6 @@
                                               a-link__icon"
                                        id="hud_print-page-link"
                                        href="#">
-                                        {#
-                                            The following link text can't be
-                                            broken across lines as it'll create
-                                            a space after the link text.
-                                        #}
                                         <span class="a-link_text">Print list</span>
                                         {{ svg_icon( 'print' ) }}
                                     </a>
@@ -192,11 +179,6 @@
                                        href="{{ pdf_url }}"
                                        target="_blank"
                                        rel="noopener noreferrer">
-                                        {#
-                                            The following link text can't be
-                                            broken across lines as it'll create
-                                            a space after the link text.
-                                        #}
                                         <span class="a-link_text">Save list as <abbr title="Portable Document Format">PDF</abbr></span>
                                         {{ svg_icon( 'download' ) }}
                                     </a>
@@ -234,11 +216,6 @@
                                                     {% if counselor.weburl %}
                                                     <a class="a-link a-link__icon"
                                                        href="{{ signed_redirect( counselor.weburl ) }}">
-                                                        {#
-                                                            The following link text can't be
-                                                            broken across lines as it'll create
-                                                            a space after the link text.
-                                                        #}
                                                         <span class="a-link_text"><b itemprop="name">{{ counselor.nme }}</b></span>
                                                         {{ svg_icon( 'external-link' ) }}
                                                     </a>
@@ -267,11 +244,6 @@
                                                     <a class="a-link a-link__icon"
                                                        href="{{ signed_redirect( counselor.weburl ) }}"
                                                        itemprop="url">
-                                                        {#
-                                                            The following link text can't be
-                                                            broken across lines as it'll create
-                                                            a space after the link text.
-                                                        #}
                                                         <span class="a-link_text">{{ counselor.weburl }}</span>
                                                         {{ svg_icon( 'external-link' ) }}
                                                     </a>
@@ -347,11 +319,6 @@
                                     collection is
                                     <a class="a-link a-link__icon"
                                        href="{{ signed_redirect( 'https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025' ) }}">
-                                        {#
-                                            The following link text can't be
-                                            broken across lines as it'll create
-                                            a space after the link text.
-                                        #}
                                         <span class="a-link_text" aria-label="The OMB control number for this collection is 3170-0025">3170-0025</span>
                                         {{ svg_icon( 'external-link' ) }}</a>.
                                     It expires on 04/30/2016. Using this tool


### PR DESCRIPTION
## Changes

- Moves housing counselor links with accompanying icon to one line so that space between icon and text is not included in the link underline.

## Testing

1. Pull branch and compare links with icons between http://localhost:8000/find-a-housing-counselor/?zipcode=20002 and https://www.consumerfinance.gov/find-a-housing-counselor/?zipcode=20002 

## Screenshots

Examples:

Before:
<img width="257" alt="Screen Shot 2020-01-17 at 10 37 39 AM" src="https://user-images.githubusercontent.com/704760/72626048-f410e380-3917-11ea-94f0-d2e321abac2d.png">

After:
<img width="250" alt="Screen Shot 2020-01-17 at 10 41 25 AM" src="https://user-images.githubusercontent.com/704760/72626049-f410e380-3917-11ea-861c-7d7b1239f3e0.png">


Before:
<img width="351" alt="Screen Shot 2020-01-17 at 10 45 40 AM" src="https://user-images.githubusercontent.com/704760/72626074-fffca580-3917-11ea-9a2c-ccb3270147eb.png">

After:
<img width="350" alt="Screen Shot 2020-01-17 at 10 45 53 AM" src="https://user-images.githubusercontent.com/704760/72626075-fffca580-3917-11ea-888e-1bbc1bc2d63c.png">
