### PR TITLE
Adjust rural and underserved links to remove space between text and icon

### DIFF
--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -161,8 +161,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                 To check on more than one loan, upload a Comma Separated Values (CSV) file with addresses for up to 250 properties. The file must use our CSV template:
                                 <a href="https://files.consumerfinance.gov/rural-or-underserved-tool/csv-template.csv"
                                    title="Download CSV template">
-                                    Download CSV template
-                                </a>.
+                                    Download CSV template</a>.
                             </p>
 
                             <p>
@@ -276,7 +275,7 @@ home price, down payment, and more can affect mortgage interest rates.
                 <p class="content-l_col content-l_col-1">
                     <a class="margin-right-quarter" href="#" id="print" title="Print results">Print results</a>
                     |
-                    <a class="download-link margin-left-quarter" href="#" id="download" title="Download results"><span>Download results</span>&nbsp;</a>
+                    <a class="download-link margin-left-quarter" href="#" id="download" title="Download results"><span>Download results</span></a>
                 </p>
 
                 {# Not a paragraph so that it is full-width. #}


### PR DESCRIPTION
Sibling PR to https://github.com/cfpb/cfgov-refresh/pull/5464

## Changes

- Adjusts rural and underserved links with accompanying icon to one line so that space between icon and text is not included in the link underline.
- Removes nonbreaking space from the end of link.

## Testing

1. Pull branch and compare http://localhost:8000/rural-or-underserved-tool/ to https://www.consumerfinance.gov/rural-or-underserved-tool/ (you'll need to load addresses to see the download link)

## Screenshots

Before:
<img width="238" alt="Screen Shot 2020-01-17 at 11 37 06 AM" src="https://user-images.githubusercontent.com/704760/72629327-17d72800-391e-11ea-8c1d-f555c21746f4.png">

After:
<img width="212" alt="Screen Shot 2020-01-17 at 11 37 14 AM" src="https://user-images.githubusercontent.com/704760/72629328-17d72800-391e-11ea-8ddb-6a665cd9a7cc.png">

Before:
<img width="246" alt="Screen Shot 2020-01-17 at 11 35 45 AM" src="https://user-images.githubusercontent.com/704760/72629337-1d347280-391e-11ea-8040-b28c31c3fd21.png">

After:
<img width="253" alt="Screen Shot 2020-01-17 at 11 35 25 AM" src="https://user-images.githubusercontent.com/704760/72629343-202f6300-391e-11ea-9380-acb97ec405b6.png">
