### PR TITLE
Restore metaclass for HomePageForm class

### DIFF
--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -33,7 +33,7 @@ class HomePageFormMetaclass(WagtailAdminModelFormMetaclass):
         return HomePageForm
 
 
-class HomePageForm(HomePageFormMetaclass, WagtailAdminPageForm):
+class HomePageForm(WagtailAdminPageForm, metaclass=HomePageFormMetaclass):
     pass
 
 


### PR DESCRIPTION
#5452 improperly removed the metaclass for the HomePageForm class as part of Python 2 cleanup. This broke the ability to edit HomePage model instances in the Wagtail editor. This commit corrects that.

Note [this specific change](https://github.com/cfpb/cfgov-refresh/pull/5452/files#diff-3af357132db430d649cd7e73b69b113fL38). Previously this code was using [`six.with_metaclass`](https://six.readthedocs.io/#six.with_metaclass) to define a metaclass; the PR incorrectly made the metaclass one of the base classes.

## Testing

Try to edit the site homepage at http://localhost:8000/admin/pages/319/edit/; this causes a TypeError on master but works properly on this branch.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: