### PR TITLE
Redirect legacy Ask URLs with uppercase categories

### DIFF
--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -426,6 +426,17 @@ class RedirectAskSearchTestCase(TestCase):
             result.get('location'),
             '/ask-cfpb/search/')
 
+    def test_redirect_search_uppercase_facet(self):
+        """Handle odd requests with uppercase, spaced category names."""
+        category_querystring = 'selected_facets=category_exact:Prepaid Cards'
+        request = HttpRequest()
+        request.GET = QueryDict(category_querystring)
+        result = redirect_ask_search(request)
+        self.assertEqual(
+            result.get('location'),
+            '/ask-cfpb/category-prepaid-cards/'
+        )
+
     def test_redirect_search_no_query(self):
         request = HttpRequest()
         request.GET['q'] = ' '

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -214,7 +214,8 @@ def redirect_ask_search(request, language='en'):
             if category_facet in facet:
                 category = facet.replace(category_facet, '')
                 if category:
-                    return redirect_to_category(category, language)
+                    slug = slugify(category)  # handle uppercase and spaces
+                    return redirect_to_category(slug, language)
 
         for facet in facets:
             if audience_facet in facet:

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -437,91 +437,91 @@ urlpatterns = [
 
 # Ask CFPB category and subcategory redirects
 category_redirects = [
-    url(r'^ask-cfpb/category-auto-loans/(.*)$',
+    url(r'^(?i)ask-cfpb/category-auto-loans/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/auto-loans/',
             permanent=True)),
-    url(r'^ask-cfpb/category-bank-accounts-and-services/(.*)$',
+    url(r'^(?i)ask-cfpb/category-bank-accounts-and-services/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/bank-accounts/',
             permanent=True)),
-    url(r'^ask-cfpb/category-credit-cards/(.*)$',
+    url(r'^(?i)ask-cfpb/category-credit-cards/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/credit-cards/answers/',
             permanent=True)),
-    url(r'^ask-cfpb/category-credit-reporting/(.*)$',
+    url(r'^(?i)ask-cfpb/category-credit-reporting/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/credit-reports-and-scores/',
             permanent=True)),
-    url(r'^ask-cfpb/category-debt-collection/(.*)$',
+    url(r'^(?i)ask-cfpb/category-debt-collection/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/debt-collection/',
             permanent=True)),
-    url(r'^ask-cfpb/category-families-money/(.*)$',
+    url(r'^(?i)ask-cfpb/category-families-money/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/money-as-you-grow/',
             permanent=True)),
-    url(r'^ask-cfpb/category-money-transfers/(.*)$',
+    url(r'^(?i)ask-cfpb/category-money-transfers/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/money-transfers/answers/',
             permanent=True)),
-    url(r'^ask-cfpb/category-mortgages/(.*)$',
+    url(r'^(?i)ask-cfpb/category-mortgages/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/mortgages/',
             permanent=True)),
-    url(r'^ask-cfpb/category-payday-loans/(.*)$',
+    url(r'^(?i)ask-cfpb/category-payday-loans/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/payday-loans/answers',
             permanent=True)),
-    url(r'^ask-cfpb/category-prepaid-cards/(.*)$',
+    url(r'^(?i)ask-cfpb/category-prepaid-cards/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/prepaid-cards/',
             permanent=True)),
-    url(r'^ask-cfpb/category-student-loans/(.*)$',
+    url(r'^(?i)ask-cfpb/category-student-loans/(.*)$',
         RedirectView.as_view(
             url='/consumer-tools/student-loans/',
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-comprar-un-vehiculo/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-comprar-un-vehiculo/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/prestamos-para-vehiculos/respuestas/',  # noqa: E501
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-manejar-una-cuenta-bancaria/(.*)$',  # noqa: E501
+    url(r'^(?i)es/obtener-respuestas/categoria-manejar-una-cuenta-bancaria/(.*)$',  # noqa: E501
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/cuentas-bancarias/',
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-obtener-una-tarjeta-de-credito/(.*)$',  # noqa: E501
+    url(r'^(?i)es/obtener-respuestas/categoria-obtener-una-tarjeta-de-credito/(.*)$',  # noqa: E501
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/tarjetas-de-credito/respuestas/',  # noqa: E501
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-adquirir-credito/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-adquirir-credito/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/informes-y-puntajes-de-credito/',  # noqa: E501
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-manejar-una-deuda/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-manejar-una-deuda/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/cobro-de-deudas/',
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-ensenar-a-otros/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-ensenar-a-otros/(.*)$',
         RedirectView.as_view(
             url='/es/el-dinero-mientras-creces/',
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-enviar-dinero/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-enviar-dinero/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/transferencias-de-dinero/respuestas/',  # noqa: E501
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-comprar-una-casa/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-comprar-una-casa/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/hipotecas/',
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-prestamos-de-dia-de-pago/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-prestamos-de-dia-de-pago/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/prestamos-del-dia-de-pago/',  # noqa: E501
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-escoger-una-tarjeta-prepagada/(.*)$',  # noqa: E501
+    url(r'^(?i)es/obtener-respuestas/categoria-escoger-una-tarjeta-prepagada/(.*)$',  # noqa: E501
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/tarjetas-prepagadas/respuestas/',  # noqa: E501
             permanent=True)),
-    url(r'^es/obtener-respuestas/categoria-pagar-la-universidad/(.*)$',
+    url(r'^(?i)es/obtener-respuestas/categoria-pagar-la-universidad/(.*)$',
         RedirectView.as_view(
             url='/es/herramientas-del-consumidor/prestamos-estudiantiles/',  # noqa: E501
             permanent=True))


### PR DESCRIPTION
Some of our broken internal links originate as knowledgebase-era
querystring-based category searches, which we routed to category pages
in 2016. But Some links request uppercase category names with spaces, and
the redirects break down.

This change slugifies the requested category so that the redirects can complete.

## Local testing

Two legacy URLs that currently return 404:
- [http://localhost:8000/askcfpb/search/?selected_facets=category_exact:Prepaid Cards](http://localhost:8000/askcfpb/search/?selected_facets=category_exact:Prepaid%20Cards)
- [http://localhost:8000/askcfpb/search/?selected_facets=category_exact:Student Loans](http://localhost:8000/askcfpb/search/?selected_facets=category_exact:Student%20Loans)

After pulling in this branch, the URLs above should relevant to portal pages under
**/consumer-tools/**.

## Note
You may need to clear your browser cache after switching to the PR branch to get your browser to follow the fixed redirect.