### PR TITLE
Add Wagtail 2.3, Wagtail 2.7, and Django 2.2 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,12 +21,16 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   dj20:               Use Django 2.0
 #   wag113:             Use Wagtail 1.13
 #   wag20:              Use Wagtail 2.0
+#   wag23:              Use Wagtail 2.3
+#   wag27:              Use Wagtail 2.7
 #
 # These factors are expected to combine into the follow generative environments:
 #
 #   lint-py{36}
 #   unittest-py{36}-dj{111}-wag{113}-{fast,slow}
 #   unittest-py{36}-dj{20}-wag{20}-{fast,slow}
+#   unittest-py{36}-dj{20}-wag{23}-{fast,slow}
+#   unittest-py{36}-dj{20}-wag{27}-{fast,slow}
 #   acceptance-py{36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
@@ -36,6 +40,10 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj20-wag20-fast
 #   tox -e unittest-py36-dj20-wag20-slow
+#   tox -e unittest-py36-dj20-wag23-fast
+#   tox -e unittest-py36-dj20-wag23-slow
+#   tox -e unittest-py36-dj20-wag27-fast
+#   tox -e unittest-py36-dj20-wag27-slow
 
 recreate=False
 
@@ -53,6 +61,8 @@ deps=
     dj20:               Django>=2.0,<2.1
     wag113:             wagtail>=1.13,<1.14
     wag20:              wagtail>=2.0,<2.1
+    wag23:              wagtail>=2.3,<2.4
+    wag27:              wagtail>=2.7,<2.8
     lint:               {[lint]deps}
     unittest:           {[unittest]deps}
     acceptance:         {[acceptance]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -20,17 +20,14 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   dj111:              Use Django 1.11
 #   dj20:               Use Django 2.0
 #   wag113:             Use Wagtail 1.13
-#   wag20:              Use Wagtail 2.0
 #   wag23:              Use Wagtail 2.3
 #   wag27:              Use Wagtail 2.7
 #
 # These factors are expected to combine into the follow generative environments:
 #
 #   lint-py{36}
-#   unittest-py{36}-dj{111}-wag{113}-{fast,slow}
-#   unittest-py{36}-dj{20}-wag{20}-{fast,slow}
-#   unittest-py{36}-dj{20}-wag{23}-{fast,slow}
-#   unittest-py{36}-dj{20}-wag{27}-{fast,slow}
+#   unittest-py{36}-dj{111}-wag{113,23}-{fast,slow}
+#   unittest-py{36}-dj{20}-wag{23,27}-{fast,slow}
 #   acceptance-py{36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
@@ -38,8 +35,8 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   tox -e lint-py36
 #   tox -e unittest-py36-dj111-wag113-fast
 #   tox -e unittest-py36-dj111-wag113-slow
-#   tox -e unittest-py36-dj20-wag20-fast
-#   tox -e unittest-py36-dj20-wag20-slow
+#   tox -e unittest-py36-dj111-wag23-fast
+#   tox -e unittest-py36-dj111-wag23-slow
 #   tox -e unittest-py36-dj20-wag23-fast
 #   tox -e unittest-py36-dj20-wag23-slow
 #   tox -e unittest-py36-dj20-wag27-fast
@@ -60,7 +57,6 @@ deps=
     dj111:              Django>=1.11,<1.12
     dj20:               Django>=2.0,<2.1
     wag113:             wagtail>=1.13,<1.14
-    wag20:              wagtail>=2.0,<2.1
     wag23:              wagtail>=2.3,<2.4
     wag27:              wagtail>=2.7,<2.8
     lint:               {[lint]deps}
@@ -105,7 +101,7 @@ commands=
 # Configuration values necessary to run unittests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{36}-dj{111,20}-wag{113,20}-{fast,slow}
+#   tox -e unittest-py{36}-dj{111,20}-wag{113,23}-{fast,slow}
 #
 # To run unit tests.
 changedir=

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   acceptance:         Run a Django server and acceptance tests
 #   py36:               Use Python 3.6
 #   dj111:              Use Django 1.11
-#   dj20:               Use Django 2.0
+#   dj22:               Use Django 2.2
 #   wag113:             Use Wagtail 1.13
 #   wag23:              Use Wagtail 2.3
 #   wag27:              Use Wagtail 2.7
@@ -27,7 +27,7 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #
 #   lint-py{36}
 #   unittest-py{36}-dj{111}-wag{113,23}-{fast,slow}
-#   unittest-py{36}-dj{20}-wag{23,27}-{fast,slow}
+#   unittest-py{36}-dj{22}-wag{23,27}-{fast,slow}
 #   acceptance-py{36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
@@ -37,10 +37,10 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj111-wag23-fast
 #   tox -e unittest-py36-dj111-wag23-slow
-#   tox -e unittest-py36-dj20-wag23-fast
-#   tox -e unittest-py36-dj20-wag23-slow
-#   tox -e unittest-py36-dj20-wag27-fast
-#   tox -e unittest-py36-dj20-wag27-slow
+#   tox -e unittest-py36-dj22-wag23-fast
+#   tox -e unittest-py36-dj22-wag23-slow
+#   tox -e unittest-py36-dj22-wag27-fast
+#   tox -e unittest-py36-dj22-wag27-slow
 
 recreate=False
 
@@ -55,7 +55,7 @@ basepython=
 
 deps=
     dj111:              Django>=1.11,<1.12
-    dj20:               Django>=2.0,<2.1
+    dj22:               Django>=2.2,<2.3
     wag113:             wagtail>=1.13,<1.14
     wag23:              wagtail>=2.3,<2.4
     wag27:              wagtail>=2.7,<2.8
@@ -101,7 +101,7 @@ commands=
 # Configuration values necessary to run unittests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{36}-dj{111,20}-wag{113,23}-{fast,slow}
+#   tox -e unittest-py{36}-dj{111,22}-wag{113,23}-{fast,slow}
 #
 # To run unit tests.
 changedir=


### PR DESCRIPTION
Add support in tox.ini for unit testing with Wagtail 2.3 and Wagtail 2.7
Remove support in tox.ini for unit testing with Wagtail 2.0
Update Django from 2.0 to 2.2 in tox.ini

## Additions

- wag23
- wag27
- dj22

## Removed

- wag20
- dj20

## Testing

1. tox -e unittest-py36-dj111-wag23-slow
2. tox -e unittest-py36-dj111-wag27-slow
3. tox -e unittest-py36-dj22-wag23-slow
4. tox -e unittest-py36-dj22-wag27-slow

## Notes

Unit Tests are expected to fail, but will not cause Travis builds to fail
Tests will fail as code does not currently support Wagtail 2.x

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
