### PR TITLE
Remove unneeded parameter from Docker-based build

### DIFF
--- a/docker/deployable-zipfile/_build.sh
+++ b/docker/deployable-zipfile/_build.sh
@@ -28,7 +28,6 @@ build_args=(
     "$cfgov_refresh_volume/cfgov"
     "$cfgov_refresh_volume/requirements/deployment.txt"
     "$build_artifact_name"
-    "--extra-python" "python3"
 )
 
 if [ -d "$webfonts_path" ]; then


### PR DESCRIPTION
The changes in #5434 removed Python 2 from the Docker process to build a deployable zipfile, documented at http://cfpb.github.io/cfgov-refresh/deployment/#generating-a-deployment-artifact.

However, that change neglected to remove the parameter that made the build script run with two versions of Python (now both Python 3), leaving behind an unnecessary step.

This change removes that extra parameter. The build still successfully builds artifacts with Python 3 support. To test, run `./docker/deployable-zipfile/build.sh`.

See internal Jenkins PR 562 for a similar change there.

## Notes

This process isn't used in the production build, but is a way of locally generating deploy artifacts.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: