### PR TITLE
Fix link markup for links containing SVGs

### DIFF
--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -167,3 +167,35 @@ class TestParseLinks(TestCase):
         output = parse_links(s)
         soup = BeautifulSoup(output, 'html.parser')
         self.assertEqual(len(soup.find_all('a')), 2)
+
+    def check_after_parse_links_has_a_single_svg(self, s):
+        output = parse_links(s)
+        soup = BeautifulSoup(output, 'html.parser')
+        self.assertEqual(len(soup.find_all('svg')), 1)
+
+    def test_link_ending_with_svg_doesnt_get_another_svg(self):
+        self.check_after_parse_links_has_a_single_svg(
+            '<a href="https://external.gov">'
+            '<span>Text before icon</span> '
+            '<svg>something</svg>'
+            '</a>'
+        )
+
+    def test_link_ending_with_svg_and_whitespace_doesnt_get_another_svg(self):
+        self.check_after_parse_links_has_a_single_svg(
+            '<a href="https://external.gov">'
+            '<span>Text before icon</span> '
+            '<svg>something</svg>   \n\t'
+            '</a>'
+        )
+
+    def test_with_svg_not_at_the_end_still_gets_svg(self):
+        s = (
+            '<a href="https://external.gov">'
+            '<span><svg>something</svg> Text after icon</span>'
+            '</a>'
+        )
+
+        output = parse_links(s)
+        soup = BeautifulSoup(output, 'html.parser')
+        self.assertEqual(len(soup.find_all('svg')), 2)

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -38,7 +38,7 @@ A_TAG = re.compile(
 
 # If a link contains these elements, it should *not* get an icon
 ICONLESS_LINK_CHILD_ELEMENTS = [
-    'img', 'svg', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
+    'img', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
 ]
 
 
@@ -127,6 +127,12 @@ def add_link_markup(tag):
     elif DOWNLOAD_LINKS.search(tag['href']):
         # Sets the icon to indicate you're downloading a file
         icon = 'download'
+
+    # If the already ends in an SVG, we never want to append an icon.
+    # If it has an SVG but other content comes after it, we still add one.
+    svgs = tag.find_all('svg')
+    if svgs and not all((svg.next_sibling or '').strip() for svg in svgs):
+        return str(tag)
 
     if tag.select(', '.join(ICONLESS_LINK_CHILD_ELEMENTS)):
         # If this tag has any children that are in our list of child elements

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -28,10 +28,10 @@ LINK_ICON_TEXT_CLASSES = 'a-link_text'
 A_TAG = re.compile(
     # Match an <a containing any attributes
     r'<a [^>]*?>'
-    # And match everything inside
-    r'.+?'
-    # As long as it's not a </a>, then match '</a>'
-    r'(?=</a>)</a>'
+    # And match everything inside before the closing </a>
+    r'.+?(?=</a>)'
+    # Then match the closing </a>
+    r'</a>'
     # Make '.' match new lines, ignore case
     r'(?s)(?i)'
 )


### PR DESCRIPTION
Our link markup logic adds download and external link icons to links, but it doesn't work right for links that already contain SVGs, like these:

```html
<a class="a-link a-link__icon" href="[external link]"
    <span><svg ... ></span>
    <span class="a-link_text">some text</span>
</a>
```

We want the logic to do this:

```html
<a class="a-link a-link__icon" href="[external link]">
    <span><svg ... ></span>
    <span class="a-link_text">some text <svg ...></span>
</a>
```

But currently links like these get skipped because they already contain an SVG. On the other hand, we don't want to markup links that already end with an SVG.

This commit fixes the logic so that links containing SVGs get marked up as long as they don't end with an SVG.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
