### PR TITLE
[TDP] Bump TDP to version 1.2.1

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -60,4 +60,4 @@ https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.2.0/ccdb5_api-1.2.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.0/comparisontool-1.13.0-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.0/teachers_digital_platform-1.2.0-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.1/teachers_digital_platform-1.2.1-py3-none-any.whl


### PR DESCRIPTION
Various CR Tool updates: https://github.com/cfpb/teachers-digital-platform/releases/tag/1.2.1

## Reviewers:
@Scotchester 