### PR TITLE
Homepage: Make cards fully clickable at mobile size

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/card.html
+++ b/cfgov/jinja2/v1/_includes/molecules/card.html
@@ -25,4 +25,19 @@
         <a href="{{ value.link_url }}">{{ value.link_text }}</a>
     </div>
 </article>
+
+{#
+    We want to make the whole card clickable on mobile
+    so we make a redundant card only for mobile
+    and hide the desktop version when we are on mobile.
+#}
+<a href="{{ value.link_url }}" class="m-card m-card__mobile">
+    <article>
+        <div class="m-card_icon">{{ svg_icon( value.icon ) }}</div>
+        <p>{{ value.text }}</p>
+        <div class="m-card_footer">
+            <span>{{ value.link_text }}</span>
+        </div>
+    </article>
+</a>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/card.html
+++ b/cfgov/jinja2/v1/_includes/molecules/card.html
@@ -18,26 +18,14 @@
    ========================================================================== #}
 
 {% macro render( value ) %}
+{# We want to make the whole card clickable. #}
 <article class="m-card">
-    <div class="m-card_icon">{{ svg_icon( value.icon ) }}</div>
-    <p>{{ value.text }}</p>
-    <div class="m-card_footer">
-        <a href="{{ value.link_url }}">{{ value.link_text }}</a>
-    </div>
-</article>
-
-{#
-    We want to make the whole card clickable on mobile
-    so we make a redundant card only for mobile
-    and hide the desktop version when we are on mobile.
-#}
-<a href="{{ value.link_url }}" class="m-card m-card__mobile">
-    <article>
+    <a href="{{ value.link_url }}">
         <div class="m-card_icon">{{ svg_icon( value.icon ) }}</div>
         <p>{{ value.text }}</p>
         <div class="m-card_footer">
             <span>{{ value.link_text }}</span>
         </div>
-    </article>
-</a>
+    </a>
+</article>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -29,18 +29,18 @@
         <div class="o-carousel_item-text">
             <h2>{{ item.title }}</h2>
             <p>{{ item.body }}</p>
-            <a class="a-link__jump" href="{{ item.link_url }}">
+            <a class="a-link a-link__jump" href="{{ item.link_url }}">
                 <span class="a-link_text">{{ item.link_text }}</span>
             </a>
         </div>
-        <div class="o-carousel_item-visual">
+        <a href="{{ item.link_url }}" class="o-carousel_item-visual">
             <div class="o-carousel_item-visual-wrapper">
-                {% set rendition = image( item.image, 'original' ) %}
-                <img class="o-carousel_item-img"
-                     src="{{ rendition.url }}"
-                     alt="{{ item.image.alt }}">
+                    {% set rendition = image( item.image, 'original' ) %}
+                    <img class="o-carousel_item-img"
+                        src="{{ rendition.url }}"
+                        alt="{{ item.image.alt }}">
             </div>
-        </div>
+        </a>
     </div>
 </section>
 {% endmacro %}

--- a/cfgov/unprocessed/css/molecules/card.less
+++ b/cfgov/unprocessed/css/molecules/card.less
@@ -33,3 +33,52 @@
         margin-bottom: 0;
     }
 }
+
+.m-card__mobile {
+    display: none;
+}
+
+.respond-to-max( @bp-xs-max, {
+    .m-card {
+        display: none;
+    }
+
+    .m-card__mobile {
+        display: block;
+        border: @black;
+
+        &,
+        &:visited {
+            border: 1px solid @gray-20;
+            border-bottom-width: 3px;
+        }
+
+        &:visited .m-card_footer > span {
+            color: @teal;
+        }
+
+        &:hover .m-card_footer > span {
+            border-style: solid;
+            color: @dark-pacific;
+        }
+
+        &:focus {
+            outline-offset: 2px;
+        }
+
+        .m-card_icon,
+        p {
+            color: @black;
+        }
+
+        .m-card_footer > span {
+            border-width: 0;
+            border-bottom-width: 1px;
+            border-color: @pacific;
+            border-style: dotted;
+            color: @pacific;
+            font-weight: 500;
+            text-decoration: none;
+        }
+    }
+} );

--- a/cfgov/unprocessed/css/molecules/card.less
+++ b/cfgov/unprocessed/css/molecules/card.less
@@ -53,6 +53,12 @@
             border-bottom-width: 3px;
         }
 
+        &:hover {
+            box-shadow: 0 8px 0 0 inset @green,
+                        2px 0 0 0 inset @gray-20,
+                        -2px 0 0 0 inset @gray-20;
+        }
+
         &:visited .m-card_footer > span {
             color: @teal;
         }

--- a/cfgov/unprocessed/css/molecules/card.less
+++ b/cfgov/unprocessed/css/molecules/card.less
@@ -47,7 +47,7 @@
         display: block;
         border: @black;
 
-        &,
+        &:link,
         &:visited {
             border: 1px solid @gray-20;
             border-bottom-width: 3px;

--- a/cfgov/unprocessed/css/molecules/card.less
+++ b/cfgov/unprocessed/css/molecules/card.less
@@ -1,14 +1,16 @@
 .m-card {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    flex-basis: 0;
-    box-sizing: border-box;
     width: 100%;
     background: @white;
-    border: 1px solid @gray-20;
-    border-bottom-width: 3px;
-    padding: unit( @grid_gutter-width / @base-font-size-px, em );
+
+    > a {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        flex-basis: 0;
+        box-sizing: border-box;
+        padding: unit( @grid_gutter-width / @base-font-size-px, em );
+        height: 100%;
+    }
 
     &_icon {
         font-size: unit( 48px / @base-font-size-px, em );
@@ -19,9 +21,15 @@
         margin-top: auto;
     }
 
-    &_footer > a {
-        font-weight: 500;
+    &_footer > span {
+        display: inline-block;
+        border-width: 0;
         border-bottom-width: 1px;
+        border-color: @pacific;
+        border-style: dotted;
+        font-weight: 500;
+        color: @pacific;
+        text-decoration: none;
     }
 
     // TODO: Check if heading and body is used anywhere?
@@ -32,59 +40,35 @@
     &_body {
         margin-bottom: 0;
     }
-}
 
-.m-card__mobile {
-    display: none;
-}
-
-.respond-to-max( @bp-xs-max, {
-    .m-card {
-        display: none;
+    & > a:link,
+    & > a:visited {
+        border: 1px solid @gray-20;
+        border-bottom-width: 3px;
     }
 
-    .m-card__mobile {
-        display: block;
-        border: @black;
-
-        &:link,
-        &:visited {
-            border: 1px solid @gray-20;
-            border-bottom-width: 3px;
-        }
-
-        &:hover {
-            box-shadow: 0 8px 0 0 inset @green,
-                        2px 0 0 0 inset @gray-20,
-                        -2px 0 0 0 inset @gray-20;
-        }
-
-        &:visited .m-card_footer > span {
-            color: @teal;
-        }
-
-        &:hover .m-card_footer > span {
-            border-style: solid;
-            color: @dark-pacific;
-        }
-
-        &:focus {
-            outline-offset: 2px;
-        }
-
-        .m-card_icon,
-        p {
-            color: @black;
-        }
-
-        .m-card_footer > span {
-            border-width: 0;
-            border-bottom-width: 1px;
-            border-color: @pacific;
-            border-style: dotted;
-            color: @pacific;
-            font-weight: 500;
-            text-decoration: none;
-        }
+    &:hover {
+        box-shadow: 0 8px 0 0 inset @green,
+                    2px 0 0 0 inset @gray-20,
+                    -2px 0 0 0 inset @gray-20;
     }
-} );
+
+    & > a:visited &_footer > span {
+        color: @teal;
+        border-color: @teal !important;
+    }
+
+    &:hover &_footer > span {
+        border-style: solid;
+        color: @dark-pacific;
+    }
+
+    & a:focus {
+        outline-offset: 2px;
+    }
+
+    &_icon,
+    p {
+        color: @black;
+    }
+}

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -304,3 +304,15 @@
     display: none !important;
   }
 }
+
+// TODO: move to the Design System.
+a.o-carousel_item-visual:after {
+  content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    box-shadow: 0 -4px 5px 0 #afd2f2 inset;
+}


### PR DESCRIPTION
## Changes

- Make cards on homepage fully clickable at mobile size.

## Testing

1. Pull branch and build. Visit homepage and resize the page to see the behavior of the cards at desktop and mobile.
2. Use the tab key to tab through content and see where the focus falls on the cards.

## Screenshots

Mobile card with focus rectangle:

<img width="331" alt="Screen Shot 2020-01-31 at 3 17 55 PM" src="https://user-images.githubusercontent.com/704760/73571728-34ef1900-443d-11ea-869a-5c5db78aa464.png">
