### PR TITLE
Mega menu variation 1: hide caret if no items

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -257,8 +257,10 @@
              if has_children else ''
            }}>
               {{ text }}
+              {% if has_children %}
               <span class="{{- _classes( nav_depth, '-link-icon-closed' ) -}}">{{ svg_icon( 'down' ) }}</span>
               <span class="{{- _classes( nav_depth, '-link-icon-open' ) -}}">{{ svg_icon( 'up' ) }}</span>
+              {% endif %}
         </a>
         {% if has_children %}
             {{ _nav_level( nav_depth | int + 1, nav_item, url, text ) }}

--- a/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
@@ -572,7 +572,6 @@ body {
                 position: relative;
                 z-index: 30;
                 padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-                padding-right: unit( 24px / @base-font-size-px, em );
                 border-top: 1px solid transparent;
                 border-right: 1px solid transparent;
                 border-left: 1px solid transparent;
@@ -646,6 +645,11 @@ body {
 
                 &[aria-expanded="true"] &-icon-closed .cf-icon-svg {
                     display: none;
+                }
+
+                // Add padding to accommodate caret.
+                &__has-children {
+                    padding-right: unit( 24px / @base-font-size-px, em );
                 }
             }
         }


### PR DESCRIPTION
Currently proposed mega menu variation 1 always shows the caret even if the menu has no child items, as would happen with the Spanish menu.

This change hides the up/down carets if no children exist.

## Testing

This can't be tested on the Spanish menu without using #5471, but can be tested in English by deleting all contents from one of the submenus.

First, enable the proposed menu variation 1:

1. Go to http://localhost:8000/admin/flags/create/ and create a feature flag named `MEGA_MENU_VAR_1`.
1. Enable it at http://localhost:8000/admin/flags/MEGA_MENU_VAR_1/ by clicking "ENABLE MEGA_MENU_VAR_1 FOR ALL REQUESTS".
1. Visiting a page on the site like http://localhost:8000/ should show the proposed variation 1, including down and up carets when menus are opened.

Now, delete all content from one of the menus to see how this change looks:

1. Edit the "Consumer Tools" menu at http://localhost:8000/admin/v1/menuitem/edit/2/ and delete all menu items by clicking the trash can icon to the right of COLUMN 1, COLUMN 2, COLUMN 3, COLUMN 4, and NAV FOOTER:
   ![image](https://user-images.githubusercontent.com/654645/73662031-1f5e3700-4669-11ea-96d5-cbc5b768cd17.png)
1. Now revisit a page and notice that the Consumer Tools item no longer shows a caret, but does function as expected:
   ![menu-no-items-no-caret](https://user-images.githubusercontent.com/654645/73662169-57657a00-4669-11ea-99e2-a59d8b97bdeb.gif)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: