### PR TITLE
Add flagged banner for OMWI Salesforce stuff outages

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -715,22 +715,37 @@ FLAGS = {
     # Used to hide new youth employment success pages prior to public launch.
     'YOUTH_EMPLOYMENT_SUCCESS': [],
 
-    # Release of prepaid agreements database search
+    # Release of prepaid agreements database search.
     'PREPAID_AGREEMENTS_SEARCH': [],
 
     # Used to hide CCDB landing page updates prior to public launch.
     'CCDB_CONTENT_UPDATES': [],
 
     # During a Salesforce system outage, the following flag should be enabled
-    # to alert users that the Collect community is down
+    # to alert users that the Collect community is down.
     'COLLECT_OUTAGE': [
-        {'condition': 'boolean', 'value': False},
         {
             'condition': 'path matches',
-            'value': (r'^/data-research/credit-card-data/terms-credit-card-plans-survey|'  # noqa: E501
-                      r'^/data-research/prepaid-accounts'),
+            'value': (r'^/data-research/credit-card-data/terms-credit-card-plans-survey/$|'  # noqa: E501
+                      r'^/data-research/prepaid-accounts/$'),
             'required': True
-        }
+        },
+        # Boolean to turn it off explicitly unless enabled by another condition
+        {'condition': 'boolean', 'value': False}
+    ],
+
+    # During a Salesforce system outage, the following flag
+    # should be enabled to alert users that
+    # the OMWI assessment form and inclusivity portal are down.
+    'OMWI_SALESFORCE_OUTAGE': [
+        {
+            'condition': 'path matches',
+            'value': (r'^/about-us/diversity-and-inclusion/$|'
+                      r'^/about-us/diversity-and-inclusion/self-assessment-financial-institutions/$'),  # noqa: E501
+            'required': True
+        },
+        # Boolean to turn it off explicitly unless enabled by another condition
+        {'condition': 'boolean', 'value': False}
     ],
 }
 

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -39,16 +39,20 @@
         {{ collect_outage_banner(request) }}
     {% endif %}
 
-    {% if flag_enabled('HMDA_OUTAGE', request) %}
-        {{ hmda_outage_banner(request) }}
-    {% endif %}
-
     {% if flag_enabled('COMPLAINT_INTAKE_TECHNICAL_ISSUES', request) %}
         {{ complaint_issue_banner(request) }}
     {% endif %}
 
     {% if flag_enabled('COMPLAINT_INTAKE_MAINTENANCE', request) %}
         {{ complaint_maintenance_banner(request) }}
+    {% endif %}
+
+    {% if flag_enabled('HMDA_OUTAGE', request) %}
+        {{ hmda_outage_banner(request) }}
+    {% endif %}
+
+    {% if flag_enabled('OMWI_SALESFORCE_OUTAGE', request) %}
+        {{ omwi_salesforce_outage_banner(request) }}
     {% endif %}
 
     {% import 'molecules/global-eyebrow.html' as global_eyebrow with context %}

--- a/cfgov/jinja2/v1/_includes/organisms/omwi-salesforce-outage-banner.html
+++ b/cfgov/jinja2/v1/_includes/organisms/omwi-salesforce-outage-banner.html
@@ -1,0 +1,30 @@
+{# ==========================================================================
+
+   OMWI Salesforce outage banner
+
+   ==========================================================================
+
+   Description:
+
+   Banner that displays in the event of a Salesforce system outage.
+   Should only be included on pages that prominently feature the diversity
+   assessment form or the inclusivity portal.
+
+   ========================================================================== #}
+
+{% import 'molecules/notification.html' as notification %}
+<div class="m-global-banner">
+    <div class="wrapper
+                wrapper__match-content">
+        {{ notification.render(
+            'warning',
+            true,
+            'We are currently experiencing technical difficulties with the
+             Office of Minority and Women Inclusion (OMWI) assessment form
+             and inclusivity portal.',
+            'We are actively working on the issue, so please check back later
+             if you need to submit an OMWI assessment or
+             check the status of one you have already submitted.'
+         ) }}
+    </div>
+</div>

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -12,7 +12,7 @@ from v1.models.images import CFGOVRendition
 from v1.templatetags.app_urls import app_page_url, app_url
 from v1.templatetags.banners import (
     collect_outage_banner, complaint_issue_banner,
-    complaint_maintenance_banner
+    complaint_maintenance_banner, omwi_salesforce_outage_banner
 )
 from v1.templatetags.email_popup import email_popup
 from v1.templatetags.mega_menu import get_menu_items
@@ -101,6 +101,7 @@ class V1Extension(Extension):
             'collect_outage_banner': collect_outage_banner,
             'complaint_issue_banner': complaint_issue_banner,
             'complaint_maintenance_banner': complaint_maintenance_banner,
+            'omwi_salesforce_outage_banner': omwi_salesforce_outage_banner,
             'get_menu_items': get_menu_items,
             'get_model': get_model,
             'get_unique_id': get_unique_id,

--- a/cfgov/v1/templatetags/banners.py
+++ b/cfgov/v1/templatetags/banners.py
@@ -68,3 +68,9 @@ def complaint_maintenance_banner(request):
         'date_str': date_str,
     }
     return mark_safe(render_to_string(template, context=context))
+
+
+@register.simple_tag
+def omwi_salesforce_outage_banner(request):
+    template = 'organisms/omwi-salesforce-outage-banner.html'
+    return mark_safe(render_to_string(template))

--- a/cfgov/v1/tests/templatetags/test_banners.py
+++ b/cfgov/v1/tests/templatetags/test_banners.py
@@ -97,3 +97,19 @@ class TestComplaintMaintenanceBannerTag(SimpleTestCase):
         response = self.render('/page/configured/')
         self.assertIn('m-global-banner', response)
         self.assertIn('soon', response)
+
+
+class TestOMWISalesforceOutageBannerTag(SimpleTestCase):
+
+    def render(self, path):
+        request = RequestFactory().get(path)
+        request.flag_conditions = get_flags()
+        template = Template(
+            '{% load banners %}'
+            '{% omwi_salesforce_outage_banner request %}'
+        )
+        return template.render(Context({'request': request}))
+
+    def test_banner_renders(self):
+        response = self.render('/some/other/path/')
+        self.assertIn('m-global-banner', response)


### PR DESCRIPTION
As with several other of our Salesforce things, OMWI would like to have the option to turn on a notification banner if their form/community is down. This commit adds that, toggleable with the new `OMWI_SALESFORCE_OUTAGE` flag.

Addresses GHE/CFGOV/platform/issues/3649

## Additions

- OMWI outage banner behind `OMWI_SALESFORCE_OUTAGE` flag, which gets applied to the exact paths `/about-us/diversity-and-inclusion/` and `/about-us/diversity-and-inclusion/self-assessment-financial-institutions/`

## Changes

- Adds the `$` control character to the end of @wpears's just-added `COLLECT_OUTAGE` banner path arguments (#5469), after I noticed that it wasn't there and he agreed that it should be.

## Testing

1. Pull branch
1. Visit http://localhost:8000/about-us/diversity-and-inclusion/ and see no banner
1. Enable the `OMWI_SALESFORCE_OUTAGE` flag
1. Reload the page and see the banner
1. Repeat for http://localhost:8000/about-us/diversity-and-inclusion/self-assessment-financial-institutions/
1. Visit other OMWI pages like http://localhost:8000/about-us/diversity-and-inclusion/ensuring-diverse-and-inclusive-workplace-culture/ and see no banner, even with the flag enabled

## Screenshots

![Screenshot of the banner appearing at the top of the main Diversity and Inclusion page](https://user-images.githubusercontent.com/1044670/73673015-f09d8c00-467b-11ea-9611-4f83eb3541a0.png)

## Notes

- Sure would be nice if we could get each piece of copy down to one line when the page is full width. @niqjohnson, should we inquire about this?

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
