### PR TITLE
Change Wagtail 2.7 to 2.8 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,17 +17,18 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   unittest:           Run Python unittests
 #   acceptance:         Run a Django server and acceptance tests
 #   py36:               Use Python 3.6
+#   py38:               Use Python 3.8
 #   dj111:              Use Django 1.11
 #   dj22:               Use Django 2.2
 #   wag113:             Use Wagtail 1.13
 #   wag23:              Use Wagtail 2.3
-#   wag27:              Use Wagtail 2.7
+#   wag28:              Use Wagtail 2.8
 #
 # These factors are expected to combine into the follow generative environments:
 #
 #   lint-py{36}
 #   unittest-py{36}-dj{111}-wag{113,23}-{fast,slow}
-#   unittest-py{36}-dj{22}-wag{23,27}-{fast,slow}
+#   unittest-py{36}-dj{22}-wag{23,28}-{fast,slow}
 #   acceptance-py{36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
@@ -39,8 +40,8 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
 #   tox -e unittest-py36-dj111-wag23-slow
 #   tox -e unittest-py36-dj22-wag23-fast
 #   tox -e unittest-py36-dj22-wag23-slow
-#   tox -e unittest-py36-dj22-wag27-fast
-#   tox -e unittest-py36-dj22-wag27-slow
+#   tox -e unittest-py36-dj22-wag28-fast
+#   tox -e unittest-py36-dj22-wag28-slow
 
 recreate=False
 
@@ -58,7 +59,7 @@ deps=
     dj22:               Django>=2.2,<2.3
     wag113:             wagtail>=1.13,<1.14
     wag23:              wagtail>=2.3,<2.4
-    wag27:              wagtail>=2.7,<2.8
+    wag28:              wagtail>=2.8,<2.9
     lint:               {[lint]deps}
     unittest:           {[unittest]deps}
     acceptance:         {[acceptance]deps}


### PR DESCRIPTION
Add support for latest version of Wagtail 2.8 for tox

## Additions

- Wagtail 2.8

## Removals

- Wagtail 2.7

## Changes

- Add Python 3.8 (py38)

## Testing

1. tox

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: