### PR TITLE
Fix spacing and commas for multi-author post previews

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -189,19 +189,9 @@
             {% if post.get_authors() %}
                 <div class="o-post-preview_byline-group">
                 {% for author in post.get_authors() %}
-                    {% if loop.index == 1  %}
-                        By <a href="{{ url }}?authors={{ author.slug }}">
-                           {{ author.name }}
-                           </a>
-                    {% elif loop.last == true %}
-                        and <a href="{{ url }}?authors={{ author.slug }}">
-                            {{ author.name }}
-                            </a>
-                    {% else %}
-                        , <a href="{{ url }}?authors={{ author.slug }}">
-                          {{ author.name }}
-                          </a>
-                    {% endif %}
+                    {% if loop.first %}By {% elif loop.last %}and {% endif %}
+                    <a href="{{ url }}?authors={{ author.slug }}">{{ author.name }}</a>
+                    {%- if loop.length > 2 and loop.index < loop.length %}, {% endif %}
                 {% endfor %}
                 </div>
             {% endif %}


### PR DESCRIPTION
Post previews for posts with multiple authors [currently have extra spacing](https://www.consumerfinance.gov/about-us/blog/) around the commas. In addition, per the CFPB Voice and Style Guide (internal wiki page), we should be using the Oxford comma here.

This change fixes post preview author display so it works like this:

One author: By Daisy Duck
Two authors: By Daisy Duck and Donald Duck
Three or more authors: By Daisy Duck, Donald Duck, and Mickey Mouse

## Testing

With a recent production dump, going through the pages on http://localhost:8000/about-us/blog/ should show some examples of all of these.

## Screenshots

Current production site:
![image](https://user-images.githubusercontent.com/654645/73777295-354a2580-4757-11ea-8813-c632fe2b6659.png)

This fix:
![image](https://user-images.githubusercontent.com/654645/73777321-4004ba80-4757-11ea-8790-a4e5d6735831.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: