### PR TITLE
Update ccdb5-api version to 1.2.2

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -57,7 +57,7 @@ wagtail-treemodeladmin==1.0.4
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.13.0/owning_a_home_api-0.13.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.2.0/ccdb5_api-1.2.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.2.2/ccdb5_api-1.2.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.0/comparisontool-1.13.0-py3-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.1/teachers_digital_platform-1.2.1-py3-none-any.whl


### PR DESCRIPTION
Released a new tagged version of `ccdb5-api` and updated the tagged version in `libraries.txt`

## Changes

- Use version 1.2.2 of ccdb5-api

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
