### PR TITLE
Info unit group accessibility improvements

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -61,7 +61,8 @@
 {%- if value.image.upload %}
     {%- set img = image(value.image.upload, 'original') %}
     {% if link_image_and_heading %}
-        <a href="{{ value.links[0].url | safe }}">
+        <a class="m-info-unit_image-link"
+           href="{{ value.links[0].url | safe }}">
     {% endif %}
         {%- if image_alt_value(value.image) %}
             <img class="m-info-unit_image

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -84,7 +84,7 @@
                 {% endif %}
         {%- endif %}
 
-        {%- if value.heading %}
+        {%- if value.heading.text %}
             <div class="m-info-unit_heading-text">
                 {% include_block value.heading %}
             </div>

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -61,7 +61,7 @@
 {%- if value.image.upload %}
     {%- set img = image(value.image.upload, 'original') %}
     {% if link_image_and_heading %}
-        <a class="m-info-unit_image-link"
+        <a class="m-info-unit_heading-link"
            href="{{ value.links[0].url | safe }}">
     {% endif %}
         {%- if image_alt_value(value.image) %}
@@ -77,23 +77,15 @@
                             if not img.is_square else '' }}">
             </div>
         {% endif %}
+            <div class="m-info-unit_heading-text">
+                {% include_block value.heading %}
+            </div>
     {%- if link_image_and_heading %}
         </a>
     {%- endif -%}
 {%- endif %}
 
         <div class="m-info-unit_content">
-
-    {%- if value.heading %}
-        {% if link_image_and_heading %}
-            <a class="m-info-unit_heading-link"
-               href="{{ value.links[0].url | safe }}">
-        {%- endif %}
-                {% include_block value.heading %}
-        {%- if link_image_and_heading %}
-            </a>
-        {%- endif -%}
-    {%- endif %}
 
             {{ value.body | safe }}
 

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -49,41 +49,50 @@
 {%- macro info_unit(value, format, link_image_and_heading) -%}
 
 {# Confirm that not only is link_image_and_heading set, but that this
-   particular info unit has a link in its list. #}
+   particular info unit has a link in its list and there's either an
+   image or heading to wrap in a link. #}
 {%- set link_image_and_heading = link_image_and_heading
                                  and value.links
                                  and value.links[0]
-                                 and value.links[0].url %}
+                                 and value.links[0].url
+                                 and (value.image.upload or value.heading) %}
 
 <div class="m-info-unit
             {{- ' m-info-unit__inline' if format == '25-75' else '' }}">
 
-{%- if value.image.upload %}
-    {%- set img = image(value.image.upload, 'original') %}
     {% if link_image_and_heading %}
         <a class="m-info-unit_heading-link"
            href="{{ value.links[0].url | safe }}">
     {% endif %}
-        {%- if image_alt_value(value.image) %}
-            <img class="m-info-unit_image
-                        {{- ' m-info-unit_image__square' if img.is_square else '' }}"
-                 src="{{ img.url }}"
-                 alt="{{ image_alt_value(value.image) }}">
-        {%- else %}
-            <div class="m-info-unit_image
-                        {{- ' m-info-unit_image__square' if img.is_square else '' }}"
-                 style="background-image: url( '{{ img.url }}' );
-                        {{- ' padding-bottom: ' ~ ( img.height / img.width * 100 ) ~ '%;'
-                            if not img.is_square else '' }}">
-            </div>
-        {% endif %}
+
+        {%- if value.image.upload %}
+            {%- set img = image(value.image.upload, 'original') %}
+            {# Empty alt attribute if header text is present to prevent screen reader repetition #}
+            {%- set img_alt_text = '' if value.heading.text else image_alt_value(value.image) %}
+                {%- if image_alt_value(value.image) %}
+                    <img class="m-info-unit_image
+                                {{- ' m-info-unit_image__square' if img.is_square else '' }}"
+                        src="{{ img.url }}"
+                        alt="{{ img_alt_text }}">
+                {%- else %}
+                    <div class="m-info-unit_image
+                                {{- ' m-info-unit_image__square' if img.is_square else '' }}"
+                        style="background-image: url( '{{ img.url }}' );
+                                {{- ' padding-bottom: ' ~ ( img.height / img.width * 100 ) ~ '%;'
+                                    if not img.is_square else '' }}">
+                    </div>
+                {% endif %}
+        {%- endif %}
+
+        {%- if value.heading %}
             <div class="m-info-unit_heading-text">
                 {% include_block value.heading %}
             </div>
+        {%- endif %}
+
     {%- if link_image_and_heading %}
         </a>
     {%- endif -%}
-{%- endif %}
 
         <div class="m-info-unit_content">
 

--- a/cfgov/unprocessed/css/molecules/info-unit.less
+++ b/cfgov/unprocessed/css/molecules/info-unit.less
@@ -150,6 +150,10 @@
 .m-info-unit {
     .u-info-unit-base();
 
+    &_image-link {
+        display: block;
+    }
+
     &__inline {
         .respond-to-range( @bp-sm-min, @bp-sm-max, {
             .u-info-unit-base__inline( @m-info-unit_img__sm );

--- a/cfgov/unprocessed/css/molecules/info-unit.less
+++ b/cfgov/unprocessed/css/molecules/info-unit.less
@@ -144,7 +144,8 @@
         margin-bottom: 0;
     }
 
-    .m-info-unit_content {
+    .m-info-unit_content,
+    .m-info-unit_heading-text {
         margin-left: unit( ( @img_size + @grid_gutter-width ) / @base-font-size-px, em );
     }
 }

--- a/cfgov/unprocessed/css/molecules/info-unit.less
+++ b/cfgov/unprocessed/css/molecules/info-unit.less
@@ -116,6 +116,8 @@
     }
 
     &_heading-link {
+        display: block;
+
         .u-link__colors( @black, @pacific-80 );
     }
 
@@ -149,10 +151,6 @@
 
 .m-info-unit {
     .u-info-unit-base();
-
-    &_image-link {
-        display: block;
-    }
 
     &__inline {
         .respond-to-range( @bp-sm-min, @bp-sm-max, {


### PR DESCRIPTION
Fixes lack of focus state for info unit images and groups their images and headings so there's only one link in

## Changes

- Wraps info unit image and heading text in a single anchor tag.
- Removes image alt text if heading text is provided to prevent redundant screen reading.
- Only renders heading if text is provided (to prevent empty `h2`s).

## Testing

1. Pull down branch
1. `gulp build`
1. Visit pages with 50/50 and 25/75 info unit groups like the ones listed in the [original issue](GHE/CFGOV/platform/issues/2936).

## Screenshots

From https://www.consumerfinance.gov/practitioner-resources/your-money-your-goals/booklets-talk-about-money/

| before | after |
|------|------|
| ![before](https://user-images.githubusercontent.com/1060248/74113933-3de69580-4b75-11ea-80e0-20cbca059c86.gif)  | ![after](https://user-images.githubusercontent.com/1060248/74113934-417a1c80-4b75-11ea-8ef2-9e7edea65693.gif)  |

## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
