### PR TITLE
Disable Codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ codecov:
   notify:
     require_ci_to_pass: no
 
-comment: off
+comment: false
 
 coverage:
   status:


### PR DESCRIPTION
Per [https://docs.codecov.io/docs/pull-request-comments#section-disable-comment](the documentation), Codecov might be commenting because we're using `comment: off` instead of `comment: false`.

This is an attempt to fix that.