### PR TITLE
Dynamically change language of "complaint" link

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
@@ -11,14 +11,18 @@
    is_horizontal: Whether the molecule appears horizontally or vertically.
                   defaults to false.
 
+   language:      The page's language value (used to display different
+                  information on Spanish pages). Defaults to English.
+
    ========================================================================== #}
 
 
-{% macro render( is_horizontal=false ) %}
+{% macro render( is_horizontal=false, language='en' ) %}
+    {% set complaint_link = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
     {# TODO: Padding should be on link, not CTA itself #}
     <div class="m-global-header-cta
                 m-global-header-cta__{{ 'horizontal' if is_horizontal else 'list' }}">
-        <a href="/complaint/">
+        <a href="{{ complaint_link }}">
             {{ svg_icon('complaint') }}
             {{ _('Submit a Complaint') }}
         </a>

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -62,7 +62,7 @@
 
         <div class="wrapper wrapper__match-content">
             {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-            {{ global_header_cta.render( true ) }}
+            {{ global_header_cta.render( true, language ) }}
 
             {% import 'molecules/global-search.html' as global_search with context %}
             {{ global_search.render() }}

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -99,15 +99,15 @@
 
             {% block primary_nav %}
                 {% if flag_enabled('MEGA_MENU_BACKEND_V2') %}
-                    {{ mega_menu() }}
+                    {{ mega_menu( language=language ) }}
                 {% else %}
                     {% from mega_menu_template() import mega_menu with context %}
                     {% if language == 'es' %}
                         {% import '_vars-mega-menu-spanish.html' as vars with context %}
-                        {{ mega_menu( vars.menu_items ) }}
+                        {{ mega_menu( vars.menu_items, language=language ) }}
                     {% else %}
                         {% cache 'mega_menu', 'default_fragment_cache' %}
-                            {{ mega_menu( get_menu_items( request ) ) }}
+                            {{ mega_menu( get_menu_items( request ), language=language ) }}
                         {% endcache %}
                     {% endif %}
                 {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -99,7 +99,7 @@
 
             {% block primary_nav %}
                 {% if flag_enabled('MEGA_MENU_BACKEND_V2') %}
-                    {{ mega_menu( language=language ) }}
+                    {{ mega_menu() }}
                 {% else %}
                     {% from mega_menu_template() import mega_menu with context %}
                     {% if language == 'es' %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -39,13 +39,15 @@
 
    Creates a mega menu sub menu list markup when given:
 
-   nav_depth: Level of menu nesting. 1 equals the root menu.
+   nav_depth:  Level of menu nesting. 1 equals the root menu.
 
    nav_groups: List of nav item groups.
 
+   language:   The page's language. Defaults to English.
+
    ========================================================================== #}
 
-{% macro _nav_list( nav_depth, nav_groups ) %}
+{% macro _nav_list( nav_depth, nav_groups, language='en' ) %}
     {% for nav_group in nav_groups %}
     {% set group = nav_group.value %}
     <div class="{{ _classes( nav_depth, '-list' ) }}">
@@ -67,7 +69,7 @@
             {%- endif %}
             {%- for item in group.nav_items %}
                 {% if ( request.show_draft_megamenu and item.state != 'live' ) or ( not request.show_draft_megamenu and item.state != 'draft' ) %}
-                    {{ _nav_item( nav_depth, item ) }}
+                    {{ _nav_item( nav_depth, item, language ) }}
                 {% endif %}
             {%- endfor %}
         </ul>
@@ -134,7 +136,7 @@
 
             {% if nav_item.nav_groups %}
             <div class="{{ _classes( nav_depth, '-lists' ) }}">
-                {{ _nav_list( nav_depth, nav_item.nav_groups ) }}
+                {{ _nav_list( nav_depth, nav_item.nav_groups, language=language ) }}
 
                 {% if flag_enabled( 'MEGA_MENU_BACKEND_V2' ) and ( nav_item.featured_links or nav_item.other_links ) %}
                 {# New mega menu backend #}
@@ -255,11 +257,13 @@
 
    nav_depth: Level of menu nesting. 1 equals the root menu.
 
-   nav_item: A nav menu item.
+   nav_item:  A nav menu item.
+
+   language:  The page's language. Defaults to English.
 
    ========================================================================== #}
 
-{% macro _nav_item( nav_depth, nav_item ) %}
+{% macro _nav_item( nav_depth, nav_item, language='en' ) %}
 {% set link = nav_item.link if nav_item.link else nav_item %}
 {% if link %}
     {% set url = pageurl(link.page_link) if link.page_link else link.external_link | default('#') %}
@@ -286,7 +290,7 @@
               {% endif %}
         </a>
         {% if has_children %}
-            {{ _nav_level( nav_depth | int + 1, nav_item, url, text ) }}
+            {{ _nav_level( nav_depth | int + 1, nav_item, url, text, language ) }}
         {% endif %}
     </li>
 {% endif %}
@@ -302,6 +306,8 @@
    Description:
 
    Creates a mega menu primary navigation menu.
+
+   language: The page's language. Defaults to English.
 
    ========================================================================== #}
 {% macro mega_menu( menu_items, language='en' ) %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -62,7 +62,7 @@
             {% if nav_depth == 1 -%}
             <li class="m-list_item {{ _classes( nav_depth, '-item' ) }}">
                 {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-                {{ global_header_cta.render() }}
+                {{ global_header_cta.render( language=language ) }}
             </li>
             {%- endif %}
             {%- for item in group.nav_items %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -40,13 +40,15 @@
 
    Creates a mega menu sub menu list markup when given:
 
-   nav_depth: Level of menu nesting. 1 equals the root menu.
+   nav_depth:  Level of menu nesting. 1 equals the root menu.
 
    nav_groups: List of nav item groups.
 
+   language:   The page's language. Defaults to English.
+
    ========================================================================== #}
 
-{% macro _nav_list( nav_depth, nav_groups ) %}
+{% macro _nav_list( nav_depth, nav_groups, language='en' ) %}
 <div class="{{ _classes( nav_depth, '-lists' ) }}">
     {% for nav_group in nav_groups %}
     {% set group = nav_group.value %}
@@ -69,7 +71,7 @@
             {%- endif %}
             {%- for item in group.nav_items %}
                 {% if ( request.show_draft_megamenu and item.state != 'live' ) or ( not request.show_draft_megamenu and item.state != 'draft' ) %}
-                    {{ _nav_item( nav_depth, item ) }}
+                    {{ _nav_item( nav_depth, item, language ) }}
                 {% endif %}
             {%- endfor %}
         </ul>
@@ -151,7 +153,7 @@
                 {% set temp = nav_item.update({'nav_groups': [{'value': {'nav_items': nav_item.nav_items}}]}) %}
             {% endif %}
             {% if nav_item.nav_groups %}
-                {{ _nav_list( nav_depth, nav_item.nav_groups ) }}
+                {{ _nav_list( nav_depth, nav_item.nav_groups, language=language ) }}
             {% endif %}
             {% if nav_item.footer %}
             <div class="{{ base_class ~ '_footer' }}">
@@ -183,11 +185,13 @@
 
    nav_depth: Level of menu nesting. 1 equals the root menu.
 
-   nav_item: A nav menu item.
+   nav_item:  A nav menu item.
+
+   language:  The page's language. Defaults to English.
 
    ========================================================================== #}
 
-{% macro _nav_item( nav_depth, nav_item ) %}
+{% macro _nav_item( nav_depth, nav_item, language='en' ) %}
 {% set link = nav_item.link if nav_item.link else nav_item %}
 {% if link %}
     {% set url = pageurl(link.page_link) if link.page_link else link.external_link | default('#') %}
@@ -211,7 +215,7 @@
               {{ svg_icon('right') }}
         </a>
         {% if has_children %}
-            {{ _nav_level( nav_depth | int + 1, nav_item, url, text ) }}
+            {{ _nav_level( nav_depth | int + 1, nav_item, url, text, language ) }}
         {% endif %}
     </li>
 {% endif %}
@@ -227,6 +231,8 @@
    Description:
 
    Creates a mega menu primary navigation menu.
+
+   language: The page's language. Defaults to English.
 
    ========================================================================== #}
 {% macro mega_menu( menu_items, language='en' ) %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -64,7 +64,7 @@
             {% if nav_depth == 1 -%}
             <li class="m-list_item {{ _classes( nav_depth, '-item' ) }}">
                 {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-                {{ global_header_cta.render() }}
+                {{ global_header_cta.render( language=language ) }}
             </li>
             {%- endif %}
             {%- for item in group.nav_items %}


### PR DESCRIPTION
Pass the page's language to the global header macro to link Spanish-speaking users to the Spanish version of "Submit a complaint".

## Additions

- `language` parameter and conditional statement added to global header macro.

## Testing

1. Pull down branch.
2. Go to http://0.0.0.0:8000/es/ and see if "Enviar una queja" in the header links to the correct page.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
