### PR TITLE
Mega menu: Clean up body click listener

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktopVar1.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktopVar1.js
@@ -127,6 +127,9 @@ function MegaMenuDesktop( baseClass, menus ) {
       _activeMenu.getTransition().animateOn();
       _activeMenu.collapse();
       _activeMenu = null;
+
+      // Clean up listeners
+      _bodyDom.removeEventListener( 'click', _handleBodyClick );
     } else if ( _activeMenu === null ) {
       // A menu is opened.
       _activeMenu = menu;


### PR DESCRIPTION
Click to close body click listener was not being removed so was throwing an error when the menu was closed. This PR fixes that.

## Changes

- Remove body click listener when a menu is closed.

## Testing

1. Pull branch and `gulp clean && gulp build`
2. Turn on `MEGA_MENU_VAR_1` flag if it is not on.
3. Open the menu and click elsewhere on the page to close it.
4. Click again elsewhere. There should NOT be an error in the dev console.
