### PR TITLE
Stack homepage carousel items at 900px instead of 600px

### DIFF
--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -10,7 +10,7 @@
     border: 1px solid @gray-40;
     border-bottom: none;
 
-    .respond-to-max( @bp-xs-max, {
+    .respond-to-max( @bp-sm-max, {
       display: none;
     } );
   }
@@ -147,10 +147,6 @@
 
     // Change stacking behavior of thumbnails.
     .respond-to-max( @bp-sm-max, {
-      width: 50%;
-    } );
-
-    .respond-to-max( @bp-xs-max, {
       width: 100%;
     } );
 
@@ -191,7 +187,7 @@
   }
 
   // Mobile view.
-  .respond-to-max( @bp-xs-max, {
+  .respond-to-max( @bp-sm-max, {
     &_thumbnails {
       display: none;
     }
@@ -208,7 +204,7 @@
   } );
 
   // Desktop view.
-  .respond-to-min( @bp-sm-min, {
+  .respond-to-min( @bp-med-min, {
     &_thumbnails__mobile {
       display: none;
     }


### PR DESCRIPTION
Removes the intermediary 50/50 carousel layout that occurred betwixt 600px and 900px. It now jumps straight to mobile layout at 900px.

## Testing

1. Pull down branch.
2. `gulp build`
3. Verify the carousel items stack at 900px.

## Screenshots

| before | after |
|------|------|
| ![carousel2](https://user-images.githubusercontent.com/1060248/74364033-bfb70880-4d99-11ea-9dd8-8c19741d4b35.gif)  | ![carousel](https://user-images.githubusercontent.com/1060248/74363911-8c747980-4d99-11ea-869d-46bf688d23cf.gif)  |


## Notes

- GHE/CFPB/el-camino/issues/119

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
