### PR TITLE
Removes prepaid icons gulp task

### DIFF
--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -55,14 +55,6 @@ gulp.task( 'copy:icons:r3k', () => {
   return stream;
 } );
 
-gulp.task( 'copy:icons:prepaid', () => {
-  const stream = _genericCopy(
-    iconSrc,
-    `${ paths.processed }/apps/prepaid_agreements/icons/`
-  );
-  return stream;
-} );
-
 gulp.task( 'copy:lightbox2', () => {
   const stream = _genericCopy(
     `${ paths.modules }/lightbox2/dist/**/*`,
@@ -76,8 +68,7 @@ gulp.task( 'copy:icons',
   gulp.parallel(
     'copy:icons:main',
     'copy:icons:oah',
-    'copy:icons:r3k',
-    'copy:icons:prepaid'
+    'copy:icons:r3k'
   )
 );
 


### PR DESCRIPTION
This appeared to be unused.

## Removals

- Removes prepaid icons gulp task
