### PR TITLE
Rearrange footer links

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -101,11 +101,6 @@
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/plain-writing/">
-                            Plain Writing
-                        </a>
-                    </li>
-                    <li class="m-list_item">
                         <a class="m-list_link" href="/privacy/">
                             Privacy
                         </a>
@@ -114,6 +109,11 @@
                         <a class="m-list_link"
                            href="/privacy/website-privacy-policy/">
                             Website Privacy Policy & Legal Notices
+                        </a>
+                    </li>
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="/data/">
+                            Data
                         </a>
                     </li>
                     <li class="m-list_item">
@@ -137,6 +137,11 @@
                         </a>
                     </li>
                     {% endif %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="/plain-writing/">
+                            Plain Writing
+                        </a>
+                    </li>
                     <li class="m-list_item">
                         <a class="m-list_link" href="/accessibility/">
                             Accessibility


### PR DESCRIPTION
Adds a new link to `/data` in cf.gov's footer and rearranges the order of
the links.

<img width="1251" alt="footer" src="https://user-images.githubusercontent.com/1060248/74755170-bcf85f80-5240-11ea-88eb-f879ddbd697c.png">

See GHE/CFPB/el-camino/issues/127