### PR TITLE
Revert mobile menu in variation 1 mega menu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu-var-1.html
@@ -284,6 +284,7 @@
              if has_children else ''
            }}>
               {{ text }}
+              {{ svg_icon('right') }}
               {% if has_children %}
               <span class="{{- _classes( nav_depth, '-link-icon-closed' ) -}}">{{ svg_icon( 'down' ) }}</span>
               <span class="{{- _classes( nav_depth, '-link-icon-open' ) -}}">{{ svg_icon( 'up' ) }}</span>

--- a/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
@@ -195,6 +195,30 @@ body {
             font-size: unit( @base-font-size-px / @base-font-size-px, em );
             font-weight: normal;
         }
+
+        // Featured menu content is link items with icons.
+        &-list__featured {
+
+            // Hide the featured menu content area at smaller screen sizes.
+            display: table-cell;
+
+            & .cf-icon-svg {
+                display: inline;
+                color: @pacific;
+                margin-right: 10px;
+            }
+        }
+
+        &-list__featured li {
+            // Align the icon and text.
+            display: flex;
+            align-items: baseline;
+
+            // Hide link bottom line from Design System link styles.
+            & .a-link_text {
+                border-bottom-width: 0;
+            }
+        }
     }
 
     &_content-link {
@@ -660,25 +684,6 @@ body {
             position: absolute;
             left: 0;
             z-index: 10;
-
-            // Featured menu content is link items with icons.
-            &-list__featured {
-
-                // Hide the featured menu content area at smaller screen sizes.
-                display: table-cell;
-
-                & .cf-icon-svg {
-                    display: inline;
-                    color: @pacific;
-                    margin-right: 10px;
-                }
-            }
-
-            &-list__featured li {
-                // Align the icon and text.
-                display: flex;
-                align-items: baseline;
-            }
 
             &-list__featured li:not( &-list__featured-item ) {
                 padding-left: 13px;

--- a/cfgov/unprocessed/js/organisms/MegaMenuVar1.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuVar1.js
@@ -163,19 +163,6 @@ function MegaMenu( element ) {
    */
   function _handleEvent( event ) {
     const activeNav = isInDesktop() ? _desktopNav : _mobileNav;
-
-    /* ------------------------------------------------------------------
-        TODO: This temporarily disables the mobile menu submenu clicking
-        and will be used for testing a new version of the menu. */
-    if ( !isInDesktop() && event.target.getDom().container.tagName !== 'NAV' ) {
-      const triggerDom = event.target.getDom().trigger;
-      if ( typeof triggerDom.href !== 'undefined' ) {
-        window.location.assign( triggerDom.href );
-      }
-      return;
-    }
-    //------------------------------------------------------------------
-
     activeNav.handleEvent( event );
   }
 


### PR DESCRIPTION
## Changes

- Revert mobile menu in variation 1 mega menu to that on production.

## Testing

1. Pull branch and build `gulp clean && gulp build`
2. Run site and go to mobile menu and see that you can click into the levels.