### PR TITLE
Better handle header layout with no mega menu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -8,17 +8,22 @@
 
    Creates markup for Header organism.
 
-   show_banner: Whether the global banner molecule is included.
-                Default is true.
+   show_banner:     Whether the global banner molecule is included.
+                    Default is false.
 
-   language:    The page's language value (used to display different
-                information on Spanish pages). Defaults to English.
+   show_mega_menu:  Whether the mega menu is included. Default is true.
+
+   language:        The page's language value (used to display different
+                    information on Spanish pages). Defaults to 'en' for
+                    English.
 
    ========================================================================== #}
 
-{% macro render( show_banner=false, language='en' ) %}
+{% macro render( show_banner=false, show_mega_menu=true, language='en' ) %}
 
-<header class="o-header">
+{% set mega_menu_content = show_mega_menu and get_mega_menu_content() %}
+
+<header class="o-header{% if mega_menu_content %} o-header__mega-menu{% endif %}">
 
     {% if flag_enabled('BETA_NOTICE', request) and show_banner %}
     {% import 'molecules/notification.html' as notification with context %}
@@ -97,21 +102,16 @@
             </a>
             {% endif %}
 
-            {% block primary_nav %}
-                {% if flag_enabled('MEGA_MENU_BACKEND_V2') %}
-                    {{ mega_menu() }}
+            {% if mega_menu_content %}
+                {% if flag_enabled('MEGA_MENU_VAR_1', request) %}
+                    {% set mega_menu_template = 'mega-menu-var-1.html' %}
                 {% else %}
-                    {% from mega_menu_template() import mega_menu with context %}
-                    {% if language == 'es' %}
-                        {% import '_vars-mega-menu-spanish.html' as vars with context %}
-                        {{ mega_menu( vars.menu_items, language=language ) }}
-                    {% else %}
-                        {% cache 'mega_menu', 'default_fragment_cache' %}
-                            {{ mega_menu( get_menu_items( request ), language=language ) }}
-                        {% endcache %}
-                    {% endif %}
+                    {% set mega_menu_template = 'mega-menu.html' %}
                 {% endif %}
-            {% endblock primary_nav %}
+
+                {% from 'organisms/' ~ mega_menu_template import mega_menu with context %}
+                {{ mega_menu ( mega_menu_content ) }}
+            {% endif %}
         </div>
 
     </div>

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -250,7 +250,11 @@
 
     {% block header %}
         {% import 'organisms/header.html' as o_header with context %}
-        {{ o_header.render( true, language ) }}
+        {{ o_header.render(
+            show_banner=true,
+            show_mega_menu=true,
+            language=language
+        ) }}
     {% endblock header %}
 
     {# WAGTAILUSERBAR IN-PAGE VIEW CONTROLS #}

--- a/cfgov/mega_menu/jinja2tags.py
+++ b/cfgov/mega_menu/jinja2tags.py
@@ -1,22 +1,10 @@
 from django.conf import settings
-from django.template import loader
 from django.utils.translation import get_language_from_request
 
-from flags.state import flag_enabled
-from jinja2 import Markup, contextfunction
+from jinja2 import contextfunction
 from jinja2.ext import Extension
 
-from mega_menu.frontend_conversion import FrontendConverter
 from mega_menu.models import Menu
-
-
-def mega_menu_template(context):
-    request = context.get('request')
-
-    if flag_enabled('MEGA_MENU_VAR_1', request=request):
-        return '_includes/organisms/mega-menu-var-1.html'
-    else:
-        return '_includes/organisms/mega-menu.html'
 
 
 def select_menu_for_context(context):
@@ -26,23 +14,29 @@ def select_menu_for_context(context):
         request = context['request']
         language = get_language_from_request(request, check_path=True)
 
+    # First try to find a menu for the language from the context.
     try:
         return Menu.objects.get(language=language[:2])
     except Menu.DoesNotExist:
+        pass
+
+    # Next try to find a menu for the default Django language.
+    try:
         return Menu.objects.get(language=settings.LANGUAGE_CODE[:2])
+    except Menu.DoesNotExist:
+        pass
+
+    # If we can't find a menu, return None.
+    return None
 
 
-def mega_menu(context):
-    frontend_converter = FrontendConverter(
-        select_menu_for_context(context),
-        request=context.get('request')
-    )
+def get_mega_menu_content(context):
+    menu = select_menu_for_context(context)
 
-    new_context = context.get_all()
-    new_context['menu_items'] = frontend_converter.get_menu_items()
+    if not menu:
+        return None
 
-    template = loader.get_template(mega_menu_template(context))
-    return Markup(template.render(new_context))
+    return menu.get_content_for_frontend(request=context.get('request'))
 
 
 class MegaMenuExtension(Extension):
@@ -50,6 +44,5 @@ class MegaMenuExtension(Extension):
         super().__init__(environment)
 
         self.environment.globals.update({
-            'mega_menu': contextfunction(mega_menu),
-            'mega_menu_template': contextfunction(mega_menu_template),
+            'get_mega_menu_content': contextfunction(get_mega_menu_content),
         })

--- a/cfgov/mega_menu/models.py
+++ b/cfgov/mega_menu/models.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 
 from mega_menu.blocks import MenuStreamBlock
+from mega_menu.frontend_conversion import FrontendConverter
 
 
 try:
@@ -31,3 +32,6 @@ class Menu(models.Model):
 
     def __str__(self):
         return str(dict(settings.LANGUAGES)[self.language])
+
+    def get_content_for_frontend(self, request=None):
+        return FrontendConverter(self, request=request).get_menu_items()

--- a/cfgov/mega_menu/tests/test_jinja2tags.py
+++ b/cfgov/mega_menu/tests/test_jinja2tags.py
@@ -1,32 +1,9 @@
 import json
 
-from django.template import engines
-from django.test import (
-    RequestFactory, SimpleTestCase, TestCase, override_settings
-)
+from django.test import RequestFactory, TestCase
 
+from mega_menu.jinja2tags import get_mega_menu_content
 from mega_menu.models import Menu
-
-
-class MegaMenuTemplateTests(SimpleTestCase):
-    def render_template_name(self):
-        jinja_engine = engines['wagtail-env']
-        template = jinja_engine.from_string('{{ mega_menu_template() }}')
-        return template.render()
-
-    @override_settings(FLAGS={})
-    def test_default_template(self):
-        self.assertEqual(
-            self.render_template_name(),
-            '_includes/organisms/mega-menu.html'
-        )
-
-    @override_settings(FLAGS={'MEGA_MENU_VAR_1': [('boolean', True)]})
-    def test_template_variation_1(self):
-        self.assertEqual(
-            self.render_template_name(),
-            '_includes/organisms/mega-menu-var-1.html'
-        )
 
 
 class MegaMenuTests(TestCase):
@@ -39,48 +16,42 @@ class MegaMenuTests(TestCase):
             {'type': 'submenu', 'value': {'title': 'Spanish'}},
         ]))
 
-    def render_mega_menu(self, context):
-        jinja_engine = engines['wagtail-env']
-        template = jinja_engine.from_string('{{ mega_menu() }}')
-        return template.render(context)
-
     def test_empty_context_fails_due_to_missing_request(self):
         with self.assertRaises(KeyError):
-            self.render_mega_menu({})
+            get_mega_menu_content({})
 
-    def test_raises_exception_if_default_menu_does_not_exist(self):
+    def test_returns_none_if_no_menus_exist(self):
         Menu.objects.all().delete()
 
         request = RequestFactory().get('/')
-        with self.assertRaises(Menu.DoesNotExist):
-            self.render_mega_menu({'request': request})
+        self.assertIsNone(get_mega_menu_content({'request': request}))
 
     def test_uses_request_falls_back_to_default_language(self):
         request = RequestFactory().get('/')
-        html = self.render_mega_menu({'request': request})
-        self.assertIn('English', html)
+        content = get_mega_menu_content({'request': request})
+        self.assertIn('English', json.dumps(content))
 
     def test_uses_request_language_if_set(self):
         request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='es')
-        html = self.render_mega_menu({'request': request})
-        self.assertIn('Spanish', html)
+        content = get_mega_menu_content({'request': request})
+        self.assertIn('Spanish', json.dumps(content))
 
     def test_unsupported_language_falls_back_to_default_language(self):
         request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='fr')
-        html = self.render_mega_menu({'request': request})
-        self.assertIn('English', html)
+        content = get_mega_menu_content({'request': request})
+        self.assertIn('English', json.dumps(content))
 
     def test_uses_language_from_context_instead_of_request(self):
         request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='en')
-        html = self.render_mega_menu({'request': request, 'language': 'es'})
-        self.assertIn('Spanish', html)
+        content = get_mega_menu_content({'request': request, 'language': 'es'})
+        self.assertIn('Spanish', json.dumps(content))
 
     def test_unsupported_language_in_context_falls_back_to_default(self):
         request = RequestFactory().get('/')
-        html = self.render_mega_menu({'request': request, 'language': 'fr'})
-        self.assertIn('English', html)
+        content = get_mega_menu_content({'request': request, 'language': 'fr'})
+        self.assertIn('English', json.dumps(content))
 
     def test_renders_in_single_database_query(self):
         request = RequestFactory().get('/')
         with self.assertNumQueries(1):
-            self.render_mega_menu({'request': request})
+            get_mega_menu_content({'request': request})

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -79,13 +79,6 @@
     .respond-to-min( @bp-lg-min, {
         min-width: @bp-lg-min;
     } );
-
-    .respond-to-min( @bp-med-min, {
-        // Setting the minimum height allocates room for the mega menu
-        // so the header height doesn't change when it loads in.
-        min-height: 167px;
-    } );
-
     &_content {
         position: relative;
 
@@ -146,17 +139,6 @@
 
     &_logo {
 
-        // Tablet/mobile sizes.
-        .respond-to-max( @bp-sm-max, {
-            .js & {
-                // Offset logo by width of mega menu trigger + 15px gap.
-                // The margin-left starts inside the 15px padding of the page
-                // already, so a value that matches the width of the trigger
-                // will give it the desired spacing to the right of the trigger.
-                margin-left: @mobile_trigger_ht__px;
-            }
-        } );
-
         &-img {
             // Size is to fit 320px minimum width for older iPhones, etc.
             height: @mobile_trigger_ht__px - 20px;
@@ -174,7 +156,32 @@
             } );
         }
     }
+
+    &__mega-menu {
+
+        // Setting the minimum height allocates room for the mega menu
+        // so the header height doesn't change when it loads in.
+        .respond-to-min( @bp-med-min, {
+            min-height: 167px;
+        } );
+
+    }
+
+    &__mega-menu &_logo  {
+
+        // Tablet/mobile sizes.
+        .respond-to-max( @bp-sm-max, {
+            .js & {
+                // Offset logo by width of mega menu trigger + 15px gap.
+                // The margin-left starts inside the 15px padding of the page
+                // page already, so a value that matches the width of the trigger
+                // will give it the desired spacing to the right of the trigger.
+                margin-left: @mobile_trigger_ht__px;
+            }
+        } );
+    }
 }
+
 
 // Used on /external-site/ template, where the header has no nav and eyebrow.
 .o-header__no-nav {

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -50,24 +50,22 @@ function Header( element ) {
     _overlay = overlay;
 
     _globalSearch = new GlobalSearch( _dom );
-    _globalSearch.addEventListener( 'expandBegin', _searchExpandBegin );
-    _globalSearch.init();
 
-    _megaMenu = new MegaMenu( _dom );
-    _megaMenu.addEventListener( 'rootExpandBegin', _megaMenuExpandBegin );
-    _megaMenu.addEventListener( 'rootCollapseEnd', _megaMenuCollapseEnd );
-    _megaMenu.init();
+    // Don't initialize the mega menu if it isn't on the page.
+    if ( _dom.classList.contains( `${ BASE_CLASS }__mega-menu` ) ) {
+      _megaMenu = new MegaMenu( _dom );
+      _megaMenu.addEventListener( 'rootExpandBegin', _megaMenuExpandBegin );
+      _megaMenu.addEventListener( 'rootCollapseEnd', _megaMenuCollapseEnd );
+      _megaMenu.init();
+
+      // If we have a mega menu, it needs to be collapsed when search is expanded.
+      _globalSearch.addEventListener( 'expandBegin', _megaMenu.collapse );
+    }
+
+    _globalSearch.init();
 
     return this;
   }
-
-  /**
-   * Handler for opening the search.
-   */
-  function _searchExpandBegin() {
-    _megaMenu.collapse();
-  }
-
 
   /**
    * Handler for when the mega menu begins expansion.


### PR DESCRIPTION
If no mega menus have been defined in Wagtail, the new mega menu implementation (introduced in #5471 via the `MEGA_MENU_BACKEND_V2` feature flag, and now turned on in production) will raise an exception. This is problematic because it prevents us from running Python tests with defining some placeholder menu, and prevents use of cfgov-refresh on an empty database without defining a menu.

To better handle these cases, it would be better if we could instead just fallback to showing no menu if none are defined. Additionally, this opens up the possibility of deliberately hiding the menu on certain pages in an organized way, as opposed to via custom base templates.

This change makes that possible, and makes the necessary frontend code changes to handle the case where the menu is not displayed.

@contolini

## Testing

In order to test this you'll need either a very recent production dump with `MEGA_MENU_BACKEND_V2` already turned on, or you'll need to turn it on locally and run `cfgov/manage.py migrate_menu_content` to create menu content for the new backend (for example [this custom header code](https://github.com/cfpb/teachers-digital-platform/blob/d57248c839b91ac5a89c361d9c6984753effc239/teachers_digital_platform/jinja2/teachers_digital_platform/crt-base.html#L35-L60) for [this live page](https://www.consumerfinance.gov/practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/).

Run `gulp clean && gulp build` to build frontend assets.

First, run a local server and visit http://localhost:8000/ to confirm proper functionality for both desktop and mobile browser sizes.

Next, go to the [menu edit area in Wagtail](http://localhost:8000/admin/mega_menu/menu/), and delete the existing menu data.

Now, revisit http://localhost:8000/ and review the design and functionality when the menu isn't being displayed.

## Screenshots

Expected behavior:

![no-menu](https://user-images.githubusercontent.com/654645/74982417-16f45300-5402-11ea-8efb-df433c54c5f7.gif)

## Notes

- @schbetsy if you have time, I've tagged you here since you did such a thorough review on #5471, and you commented on this specific case.

## Todos

- Now that the new mega menu backend is live, there's some additional cleanup that needs to happen, which I'll propose in a future PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: