### PR TITLE
Fix URL to disclosure PDF

### DIFF
--- a/cfgov/legacy/templates/students/knowbeforeyouowe/index.html
+++ b/cfgov/legacy/templates/students/knowbeforeyouowe/index.html
@@ -26,7 +26,7 @@
     <div class="two-col">
     <div class="col">
         <h3>October 2011: Project launch</h3>
-        <p>In 2011, we released <a href="https://s3.amazonaws.com/a/students/disclosure.pdf">a prototype</a> of a model financial aid offer form. We asked the public to react and tell us what was most helpful when comparing aid offers. Thousands of students, parents, guidance counselors, and college officials provided input.
+        <p>In 2011, we released <a href="https://files.consumerfinance.gov/a/students/disclosure.pdf">a prototype</a> of a model financial aid offer form. We asked the public to react and tell us what was most helpful when comparing aid offers. Thousands of students, parents, guidance counselors, and college officials provided input.
     </div>
     <div class="col">
         <a href="https://files.consumerfinance.gov/f/201306_cfpb_kbyo_graphic1.png">


### PR DESCRIPTION
##  Changes

- Fixes incorrect AWS bucket URL

## Testing

1. Fixes link URL on https://www.consumerfinance.gov/practitioner-resources/students/knowbeforeyouowe/ page.
