### PR TITLE
Mega menu: Fix focus state

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu-var-1.less
@@ -618,18 +618,29 @@ body {
 
                 &:hover {
                     padding-bottom: ( @grid_gutter-width / 2) - 6px;
+                    border-bottom: 6px solid transparent;
+                    cursor: pointer;
+
+                    // This creates the hover line.
                     // We can't use a border here as it will get a slant on
                     // the edges because there are transparent left/right
                     // borders.
-                    box-shadow: 0 6px 0 0 @gray-40;
-                    cursor: pointer;
+                    &:after {
+                        position: absolute;
+                        left: 0;
+                        top: unit( 46px / @base-font-size-px, em );
+                        content: '';
+                        background: @gray-40;
+                        width: 100%;
+                        height: unit( 6px / @base-font-size-px, em );
+                    }
                 }
 
                 // Don't show hover when menu is expanded.
                 &[aria-expanded="true"]:hover,
                 &:active:hover {
-                    box-shadow: none;
-                    padding-bottom: @grid_gutter-width / 2
+                    border-bottom: none;
+                    padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 }
 
                 &:focus {
@@ -642,6 +653,10 @@ body {
                                 -5px -2px 5px 0 @pacific-40,
                                 5px -2px 5px 0 @pacific-40;
 
+                }
+
+                &[aria-expanded="true"]:hover,
+                &[aria-expanded="true"]:focus {
                     &:after {
                         position: absolute;
                         bottom: -5px;
@@ -649,7 +664,7 @@ body {
                         display: block;
                         content: '';
                         width: 100%;
-                        height: 5px;
+                        height: unit( 10px / @base-font-size-px, em );
                         background: @gray-5;
                     }
                 }
@@ -696,8 +711,8 @@ body {
             &-list__featured-item {
                 // Style the featured item box.
                 padding: 10px;
-                padding-top: 30px;
-                padding-bottom: 30px;
+                padding-top: 20px;
+                padding-bottom: 20px;
                 margin-bottom: 30px;
                 border: 1px solid @gray-40;
                 border-top: 6px solid @gold;


### PR DESCRIPTION
When hovering, the focus state rectangle was too short. This fixes that by moving the hover from a box-shadow to an absolutely positioned `:after` selector.

## Changes

- Changes `box-shadow` hover to an `:after` hover.
- Adjusts height of featured link area to better match specs.

## Testing

1. Pull branch and build.
2. Test var 1 menu.
3. When clicking a menu item, the focus rectangle should be offset outside 2px around all edges. Hover should work across states of hover, active, and focus and combinations of each.

## Screenshots

<img width="228" alt="Screen Shot 2020-02-21 at 5 51 54 PM" src="https://user-images.githubusercontent.com/704760/75078177-edefc300-54d2-11ea-97cd-16ba69573974.png">
