### PR TITLE
Bump TDP and Wagtail libraries and test against Wagtail 2.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -49,10 +49,10 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1
-wagtail-flags==4.1.0b2
-wagtail-inventory==0.8
-wagtail-sharing==0.8
-wagtail-treemodeladmin==1.0.4
+wagtail-flags==4.1.0
+wagtail-inventory==1.0
+wagtail-sharing==1.0
+wagtail-treemodeladmin==1.1.1
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.13.0/owning_a_home_api-0.13.0-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -60,4 +60,4 @@ https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.2.2/ccdb5_api-1.2.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.1/comparisontool-1.13.1-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.1/teachers_digital_platform-1.2.1-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.2/teachers_digital_platform-1.2.2-py3-none-any.whl

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist=True
 # wagtail==1.13.3 with django-modelcluster==4.4.
 # tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113}-slow
+envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113,23}-slow
 
 
 [testenv]


### PR DESCRIPTION
This PR adds the 1.2.2 release of TDP to cfgov-refresh so that the tests can pass against Wagtail 2.3.

It also bumps the versions of our custom Wagtail libraries to ones that are unittested with Wagtail 2.3.

Finally, it adds Wagtail 2.3 to the default `tox` environment list so that when we run `tox` and when `tox` runs in Travis test will be required to pass in Wagtail 2.3.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
