### PR TITLE
Improve homepage carousel hierarchy

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/carousel.html
+++ b/cfgov/jinja2/v1/_includes/organisms/carousel.html
@@ -27,7 +27,7 @@
 <section class="o-carousel_item">
     <div class="o-carousel_item-wrapper">
         <div class="o-carousel_item-text">
-            <h2>{{ item.title }}</h2>
+            <h3 class="h2">{{ item.title }}</h3>
             <p>{{ item.body }}</p>
             <a class="a-link a-link__jump" href="{{ item.link_url }}">
                 <span class="a-link_text">{{ item.link_text }}</span>
@@ -85,14 +85,14 @@
 {% endmacro %}
 
 {% macro render( value ) %}
-<div class="o-carousel u-hidden">
-    <h5>{{ _( 'Featured' ) }}</h5>
+<div class="o-carousel u-hidden" aria-labelledby="o-carousel_heading">
+    <h2 class="h5" id="o-carousel_heading" aria-label="Featured content">{{ _( 'Featured' ) }}</h2>
     <div class="o-carousel_navigator">
 
-        <button class="o-carousel_btn o-carousel_btn-prev a-btn" aria-label="Previous showcase item">
+        <button class="o-carousel_btn o-carousel_btn-prev a-btn" aria-label="Previous featured content item">
             {{ svg_icon( 'left' ) }}
         </button>
-        <button class="o-carousel_btn o-carousel_btn-next a-btn" aria-label="Next showcase item">
+        <button class="o-carousel_btn o-carousel_btn-next a-btn" aria-label="Next featured content item">
             {{ svg_icon( 'right' ) }}
         </button>
 

--- a/cfgov/unprocessed/css/organisms/carousel.less
+++ b/cfgov/unprocessed/css/organisms/carousel.less
@@ -209,9 +209,10 @@
       display: none;
     }
 
-    // Hide "featured" heading at desktop size.
-    & h5 {
-      display: none;
+    // Hide "featured content" heading at desktop size but keep it available
+    // to screen readers.
+    & .h5 {
+      .u-visually-hidden;
     }
 
     // We can't do a straight top border because it gets included in the


### PR DESCRIPTION
It's unclear to screen readers that the carousel is a set of featured items. Grouping them under a visually hidden heading and improving the hierarchy helps distinguish it.

https://www.w3.org/WAI/tutorials/carousels/structure/

## Changes

- Changes `h5` above carousel to an `h2` and makes its visually hidden but available to screen readers.
- Changes `Featured` heading to read `Featured content`.

## Testing

1. Pull down branch.
1. Load homepage.
1. Everything should visually look the same as https://www.consumerfinance.gov/ except small screens should now read `Featured content` above the featured content.

## Screenshots

<img width="372" alt="Screen Shot 2020-02-25 at 12 57 31 PM" src="https://user-images.githubusercontent.com/1060248/75273686-55598b80-57cf-11ea-90fa-644cea02cb51.png">

## Notes

- Not sure if "Featured content" is the correct language. "Featured items", "Showcase items", etc. might be more appropriate.
