### PR TITLE
[TDP] Bump version to 1.2.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -60,4 +60,4 @@ https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.2.2/ccdb5_api-1.2.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.1/comparisontool-1.13.1-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.2/teachers_digital_platform-1.2.2-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.3/teachers_digital_platform-1.2.3-py3-none-any.whl


### PR DESCRIPTION
Bumping the TDP app to version 1.2.3

## Additions

- Added a modal confirmation to the Remove Efficacy Study Link in the CR Tool

## Code Changes

- https://github.com/cfpb/teachers-digital-platform/compare/1.2.2...1.2.3

## Reviewers

- @Scotchester 