### PR TITLE
Remove disparity between mobile/desktop side nav colors

### DIFF
--- a/cfgov/unprocessed/css/molecules/nav-link.less
+++ b/cfgov/unprocessed/css/molecules/nav-link.less
@@ -56,10 +56,6 @@
         display: block;
 
         padding: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
-
-        .u-link__colors(@dark-gray, @dark-gray, @dark-gray, @dark-gray,
-                        @dark-gray, transparent, transparent, @green,
-                        @green, @green);
     });
 
     .respond-to-min(@bp-med-min, {


### PR DESCRIPTION
Our side nav links are blue on large screens but gray on mobile. We no longer want this to be the case. This PR makes them black/blue on all screen sizes.

See: GHE/CFGOV/platform/issues/3691

## Removals

- Mixin within media query.

## Testing

1. Pull down branch.
1. Go to http://0.0.0.0:8000/about-us/the-bureau/about-director/
1. Resize your screen and click "In this section" to see blue links.

## Screenshots

| Desktop | Mobile |
|---|------|
| <img width="614" alt="Screen Shot 2020-02-27 at 12 33 47 PM" src="https://user-images.githubusercontent.com/1060248/75469856-b3b47480-595d-11ea-8eea-7a241af9ec9d.png"> | <img width="372" alt="Screen Shot 2020-02-27 at 12 34 01 PM" src="https://user-images.githubusercontent.com/1060248/75469864-b7e09200-595d-11ea-86a0-7cb86d1a8c94.png"> |

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
