### PR TITLE
Update TDP to 1.2.4

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -60,4 +60,4 @@ https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.2.2/ccdb5_api-1.2.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.1/comparisontool-1.13.1-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.3/teachers_digital_platform-1.2.3-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.3/teachers_digital_platform-1.2.4-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -60,4 +60,4 @@ https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.2.2/ccdb5_api-1.2.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.1/comparisontool-1.13.1-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.3/teachers_digital_platform-1.2.4-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.4/teachers_digital_platform-1.2.4-py3-none-any.whl


### PR DESCRIPTION
TDP 1.2.4 restores Wagtail 1.13 as supported in setup.py. This will fix warnings about installing it with Wagtail 1.13.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: