### PR TITLE
Fix data-snapshot parsing of BrowsePage data

### DIFF
--- a/cfgov/v1/management/commands/update_data_snapshot_values.py
+++ b/cfgov/v1/management/commands/update_data_snapshot_values.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         snapshots = []
         for page in BrowsePage.objects.all():
             stream_data = page.content.stream_data
-            if stream_data[0]['type'] == 'data_snapshot':
+            if stream_data and stream_data[0]['type'] == 'data_snapshot':
                 stream_data[0]['value']['page'] = page.pk
                 snapshots.append(stream_data)
         return snapshots


### PR DESCRIPTION
The management command `update_data_snapshot_values` is failing because
it now encounters a BrowsePage that has no content.streamfield content.

This change skips a page if it has no such content.

## Testing
- Store a local copy of this json file: https://github.com/cfpb/consumer-credit-trends-data/blob/master/data_snapshot.json in your develop-apps/ directory.
- Change the dates in the json file to 2020
- Check the current state of the Credit Cards browse page locally: http://localhost:8000/data-research/consumer-credit-trends/credit-cards/
- run the management command: `./cfgov/manage.py update_data_snapshot_values --snapshot_file develop-apps/data_snapshot.json`
- Note that four pages get changed and published, then check the local credit card page again to see that dates have changed to 2020.
