### PR TITLE
Let middleware decorate links

### DIFF
--- a/cfgov/agreements/jinja2/agreements/index.html
+++ b/cfgov/agreements/jinja2/agreements/index.html
@@ -50,274 +50,154 @@
                 </p>
                 <ul class="m-list m-list__links u-mt15 cc-links">
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2019_Q3.zip">
-                            <span class="a-link_text">
-                                Download all most recent agreements (Q3-2019)
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2019_Q3.zip">
+                            Download all most recent agreements (Q3-2019)
                         </a>
                     </li>
                     <li class="m-list m-list__links">
                       <span>Q2 agreements are incomplete due to technical submission issues at the Bureau.</span><br/>
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2019_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2019 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2019_Q2.zip">
+                            Archived Q2-2019 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2019_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2019 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2019_Q1.zip">
+                            Archived Q1-2019 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2018 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q4.zip">
+                            Archived Q4-2018 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2018 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q3.zip">
+                            Archived Q3-2018 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2018 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q2.zip">
+                            Archived Q2-2018 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2018 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q1.zip">
+                            Archived Q1-2018 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2017 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q4.zip">
+                            Archived Q4-2017 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2017 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q3.zip">
+                            Archived Q3-2017 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2017 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q2.zip">
+                            Archived Q2-2017 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2017 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2017_Q1.zip">
+                            Archived Q1-2017 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2016_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2016 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2016_Q4.zip">
+                            Archived Q4-2016 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2016_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2016 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2016_Q3.zip">
+                            Archived Q3-2016 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2016_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2016 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2016_Q2.zip">
+                            Archived Q2-2016 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2016_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2016 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2016_Q1.zip">
+                            Archived Q1-2016 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2015_Q4.zip">
-                            <span class="a-link_text">
-                                Archived January 2016 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2015_Q4.zip">
+                            Archived January 2016 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2014 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q4.zip">
+                            Archived Q4-2014 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2014 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q3.zip">
+                            Archived Q3-2014 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2014 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q2.zip">
+                            Archived Q2-2014 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2014 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2014_Q1.zip">
+                            Archived Q1-2014 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2013 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q4.zip">
+                            Archived Q4-2013 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2013 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q3.zip">
+                            Archived Q3-2013 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2013 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q2.zip">
+                            Archived Q2-2013 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2013 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2013_Q1.zip">
+                            Archived Q1-2013 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2012 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q4.zip">
+                            Archived Q4-2012 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2012 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q3.zip">
+                            Archived Q3-2012 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q2.zip">
-                            <span class="a-link_text">
-                                Archived Q2-2012 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q2.zip">
+                            Archived Q2-2012 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q1.zip">
-                            <span class="a-link_text">
-                                Archived Q1-2012 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2012_Q1.zip">
+                            Archived Q1-2012 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2011_Q4.zip">
-                            <span class="a-link_text">
-                                Archived Q4-2011 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2011_Q4.zip">
+                            Archived Q4-2011 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">
-                        <a class="a-link a-link__icon"
-                        href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2011_Q3.zip">
-                            <span class="a-link_text">
-                                Archived Q3-2011 agreements
-                            </span>
-                            {{ svg_icon('download') }}
+                        <a href="https://files.consumerfinance.gov/a/assets/CCADB_Snapshot_2011_Q3.zip">
+                            Archived Q3-2011 agreements
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
We have some Django middleware that adds necessary decorations to links (wraps them in a span and adds the download icon if it is a PDF link)

This is better than hardcoding the decorations everywhere.