### PR TITLE
Correct width of mega menu horizontal rule

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -529,9 +529,9 @@ body {
             position: absolute;
             bottom: 0;
             left: -@grid_gutter-width;
+            right: -@grid_gutter-width;
             display: block;
             z-index: 20;
-            width: @menu_max_width_px + ( @grid_gutter-width * 2 );
             height: 1px;
             content: '';
             box-shadow: 0px 1px 0px 0px @gray-40;


### PR DESCRIPTION
The mm's horizontal rule should have a fluid width instead of a fixed width to avoid hanging off the side of the viewport. Currently, every page of cf.gov has a long bar on the right side of the screen for widths between 900px and 1260px.

## Testing

1. Pull down and build.
1. Set your browser width to 1000px and compare consumerfinance.gov to localhost.

## Screenshots

Before:

<img width="705" alt="Screen Shot 2020-03-06 at 8 45 03 PM" src="https://user-images.githubusercontent.com/1060248/76134339-6a15fa80-5feb-11ea-920c-bb29a04bf091.png">

@anselmbradford 