### PR TITLE
Update Wagtail to 2.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -34,14 +34,14 @@ govdelivery==1.3
 Jinja2==2.10.1
 jsonfield==2.0.2
 lxml==4.2.5
-Markdown==3.1
+Markdown==3.2.1
 ntplib==0.3.3
 openpyxl==2.5.8
 psycopg2==2.7.3.2
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3
 PyYAML==3.13
-regdown==1.0.1
+regdown==1.0.2
 requests==2.22.0
 requests_toolbelt==0.8.0
 sha3==0.2.1
@@ -49,7 +49,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1
-wagtail-flags==4.1.0
+wagtail-flags==4.1.1
 wagtail-inventory==1.0
 wagtail-sharing==1.0
 wagtail-treemodeladmin==1.1.1

--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==1.13.3
+wagtail==2.3


### PR DESCRIPTION
This PR pins our version of Wagtail to version 2.3.

## Notes

Docker users will need to [update their Python containers](https://cfpb.github.io/cfgov-refresh/running-docker/#update-python-dependencies).

Virtual environment users will need [update their dependencies](https://cfpb.github.io/cfgov-refresh/running-virtualenv/#updating-all-dependencies).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: