### PR TITLE
Remove pinned django-modelcluster requirement

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -11,17 +11,6 @@ django-haystack==2.7.0
 # django-js-asset is required by teachers-digital-platform
 django-js-asset==1.1.0
 django-localflavor==1.6.2
-# Normally django-modelcluster==3.1 is installed by Wagtail 1.13. Here we
-# instead force installation of django-modelcluster==4.0.
-
-# This conflicts with the dependencies of Wagtail 1.13, which specifies
-# django-localflavor>=3.1,<4.0, but in practice is still compatible. Wagtail
-# 1.13 (and Python 2) support isn't removed until django-modelcluster 5.0.
-# This specific version is needed to support nested InlinePanels in Wagtail.
-# See https://github.com/wagtail/wagtail/issues/5511.
-#
-# Once we're on wagtail>=2.0, this won't be needed.
-django-modelcluster==4.4
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-overextends==0.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 # Temporarily disabling this to deliberately support conflicting versions
-# wagtail==1.13.3 with django-modelcluster==4.4.
+# of django-treebeard and djangorestframework.
 # tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
 envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113,23}-slow


### PR DESCRIPTION
Now that we're on Wagtail 2, we don't need to pin django-modelcluster to version 4+. This pin was only needed when we were still on Wagtail 1.13.

This removes one of the inconsistent packages that was preventing the restoration of tox extensions; however there are now two other ones that need to be resolved.

## Testing

This requirement relates to the use of InlinePanel in Wagtail. A good way to test compatibility is to confirm that page categories still work as expected, for example by viewing and editing categories on a blog post like [this](http://localhost:8000/admin/pages/1492/edit/).

## Todos

As of Wagtail 2 we now see these two other warnings:

> ERROR: wagtail 2.3 has requirement django-treebeard<5.0,>=4.2.0, but you'll have django-treebeard 3.0 which is incompatible.
> ERROR: wagtail 2.3 has requirement djangorestframework<4.0,>=3.7.4, but you'll have djangorestframework 3.6.4 which is incompatible.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: