### PR TITLE
Removal of Wagtail 1.13 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist=True
 # of django-treebeard and djangorestframework.
 # tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113,23}-slow
+envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{23}-slow
 
 
 [testenv]
@@ -20,22 +20,19 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{113,23}-slow
 #   py38:               Use Python 3.8
 #   dj111:              Use Django 1.11
 #   dj22:               Use Django 2.2
-#   wag113:             Use Wagtail 1.13
 #   wag23:              Use Wagtail 2.3
 #   wag28:              Use Wagtail 2.8
 #
 # These factors are expected to combine into the follow generative environments:
 #
 #   lint-py{36}
-#   unittest-py{36}-dj{111}-wag{113,23}-{fast,slow}
+#   unittest-py{36}-dj{111}-wag{23}-{fast,slow}
 #   unittest-py{36}-dj{22}-wag{23,28}-{fast,slow}
-#   acceptance-py{36}-dj{111}-wag{113}-fast
+#   acceptance-py{36}-dj{111}-wag{23}-fast
 #
 # These factors are expected to combine to be invoked with:
 #
 #   tox -e lint-py36
-#   tox -e unittest-py36-dj111-wag113-fast
-#   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj111-wag23-fast
 #   tox -e unittest-py36-dj111-wag23-slow
 #   tox -e unittest-py36-dj22-wag23-fast
@@ -57,7 +54,6 @@ basepython=
 deps=
     dj111:              Django>=1.11,<1.12
     dj22:               Django>=2.2,<2.3
-    wag113:             wagtail>=1.13,<1.14
     wag23:              wagtail>=2.3,<2.4
     wag28:              wagtail>=2.8,<2.9
     lint:               {[lint]deps}
@@ -102,7 +98,7 @@ commands=
 # Configuration values necessary to run unittests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{36}-dj{111,22}-wag{113,23}-{fast,slow}
+#   tox -e unittest-py{36}-dj{111,22}-wag{23}-{fast,slow}
 #
 # To run unit tests.
 changedir=
@@ -129,7 +125,7 @@ commands=
 # Configuration values necessary to run unittests without migrations.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{36}-dj{111}-wag{113}-fast
+#   tox -e unittest-py{36}-dj{111}-wag{23}-fast
 #
 # To run unit tests.
 setenv=
@@ -140,7 +136,7 @@ setenv=
 # Configuration values necessary to run unittests with migrations.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{36}-dj{111}-wag{113}-slow
+#   tox -e unittest-py{36}-dj{111}-wag{23}-slow
 #
 # To run unit tests.
 setenv=
@@ -165,7 +161,7 @@ commands=
 # virtualenv as backend tests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   acceptance-py{36}-dj{111}-wag{113}-fast
+#   acceptance-py{36}-dj{111}-wag{23}-fast
 #
 # To run acceptance tests.
 changedir=
@@ -202,11 +198,11 @@ commands={[lint]commands}
 
 [testenv:fast]
 # Invoke with: tox -e fast
-# This should run identically to tox -e unittest-py36-dj111-wag113-fast
+# This should run identically to tox -e unittest-py36-dj111-wag23-fast
 recreate=False
 changedir={[unittest]changedir}
 basepython=python3.6
-envdir={toxworkdir}/unittest-py36-dj111-wag113-fast
+envdir={toxworkdir}/unittest-py36-dj111-wag23-fast
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt
@@ -221,7 +217,7 @@ commands={[unittest]commands}
 recreate=False
 changedir={[acceptance]changedir}
 basepython=python3.6
-envdir={toxworkdir}/acceptance-py36-dj111-wag113
+envdir={toxworkdir}/acceptance-py36-dj111-wag23
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt


### PR DESCRIPTION
Remove the ability to run unit tests with Wagtail 1.13

## Additions

- None

## Removals

- `wag113: wagtail>=1.13,<1.14`

## Changes

- replaced `wag113` with `wag23`
- replaced `wag{113,23}` with `wag{23}`

## Testing

1. tox

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: