### PR TITLE
Mega menu: Don't show broken overview links

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -115,7 +115,7 @@
         {% endif %}
         <div class="{{- _classes( nav_depth, '-grid', 'three-col' if nav_item.nav_groups | count < 4 else '' ) -}}">
 
-            {% if nav_depth > 1 and nav_overview_url != '#' %}
+            {% if nav_depth > 1 and nav_overview_url and nav_overview_url != '#' %}
             <h3 class="{{ _classes( nav_depth, '-overview' ) }}
                        {{ _classes( nav_depth, '-overview-heading' ) }}">
                 <a class="{{ _classes( nav_depth, '-overview-link' ) }}


### PR DESCRIPTION
#5564 introduced a bug where an overview link would be added even if there was no overview page for a submenu. This fixes that.

@contolini 

## Screenshots

![image](https://user-images.githubusercontent.com/654645/76545075-7a9cf980-645f-11ea-8fea-4a6f350bd0ba.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: