### PR TITLE
Remove empty leading newlines from files

### DIFF
--- a/cfgov/agreements/management/commands/_util.py
+++ b/cfgov/agreements/management/commands/_util.py
@@ -1,4 +1,3 @@
-
 import os
 
 from django.utils.encoding import force_text

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -1,4 +1,3 @@
-
 import logging
 import os
 from pprint import pformat

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -1,4 +1,3 @@
-
 import argparse
 import logging
 

--- a/cfgov/alerts/send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/send_new_relic_messages_to_sqs.py
@@ -1,4 +1,3 @@
-
 import argparse
 import logging
 import sys

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -1,4 +1,3 @@
-
 import logging
 import os
 

--- a/cfgov/ask_cfpb/models/snippets.py
+++ b/cfgov/ask_cfpb/models/snippets.py
@@ -1,4 +1,3 @@
-
 from django.db import models
 
 from modelcluster.fields import ParentalKey

--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -1,4 +1,3 @@
-
 import datetime
 import html.parser as HTMLParser
 

--- a/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
+++ b/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
@@ -1,4 +1,3 @@
-
 import os
 
 from django.contrib.auth.models import User

--- a/cfgov/ask_cfpb/search_indexes.py
+++ b/cfgov/ask_cfpb/search_indexes.py
@@ -1,4 +1,3 @@
-
 from django.utils.html import strip_tags
 from django.utils.text import Truncator
 from haystack import indexes

--- a/cfgov/ask_cfpb/templatetags/accent_stripper.py
+++ b/cfgov/ask_cfpb/templatetags/accent_stripper.py
@@ -1,4 +1,3 @@
-
 import unicodedata
 
 from django import template

--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase, override_settings
 
 from ask_cfpb.models.blocks import FAQ, AskAnswerContent, HowTo, Tip

--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -1,4 +1,3 @@
-
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.test import TestCase

--- a/cfgov/ask_cfpb/tests/test_template_tags.py
+++ b/cfgov/ask_cfpb/tests/test_template_tags.py
@@ -1,4 +1,3 @@
-
 from unittest import TestCase
 
 from ask_cfpb.templatetags.accent_stripper import strip_accents

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -1,4 +1,3 @@
-
 import json
 import unittest
 

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -1,4 +1,3 @@
-
 import json
 from urllib.parse import urljoin
 

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -1,4 +1,3 @@
-
 from django.conf import settings
 from django.conf.urls import url
 from django.core.urlresolvers import reverse

--- a/cfgov/cfgov/tests/test_test.py
+++ b/cfgov/cfgov/tests/test_test.py
@@ -1,4 +1,3 @@
-
 from io import StringIO
 from unittest import TestCase, TestSuite, defaultTestLoader
 

--- a/cfgov/core/forms.py
+++ b/cfgov/core/forms.py
@@ -1,4 +1,3 @@
-
 import re
 
 from django import forms

--- a/cfgov/core/govdelivery.py
+++ b/cfgov/core/govdelivery.py
@@ -1,4 +1,3 @@
-
 import logging
 from functools import partial
 

--- a/cfgov/core/management/commands/inactive_users.py
+++ b/cfgov/core/management/commands/inactive_users.py
@@ -1,4 +1,3 @@
-
 from datetime import timedelta
 
 from django.conf import settings

--- a/cfgov/core/tests/test_forms.py
+++ b/cfgov/core/tests/test_forms.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase, override_settings
 
 from core.forms import ExternalURLForm

--- a/cfgov/core/tests/test_govdelivery.py
+++ b/cfgov/core/tests/test_govdelivery.py
@@ -1,4 +1,3 @@
-
 from unittest import TestCase
 
 from django.test import SimpleTestCase, override_settings

--- a/cfgov/data_research/blocks.py
+++ b/cfgov/data_research/blocks.py
@@ -1,4 +1,3 @@
-
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.utils.safestring import mark_safe

--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -1,4 +1,3 @@
-
 from django import forms
 from django.utils.functional import cached_property
 

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.http import HttpResponseRedirect

--- a/cfgov/data_research/management/commands/conference_delete.py
+++ b/cfgov/data_research/management/commands/conference_delete.py
@@ -1,4 +1,3 @@
-
 from django.core.management.base import BaseCommand
 
 from data_research.models import ConferenceRegistration

--- a/cfgov/data_research/management/commands/conference_export.py
+++ b/cfgov/data_research/management/commands/conference_export.py
@@ -1,4 +1,3 @@
-
 from django.core.management.base import BaseCommand
 
 from data_research.research_conference import ConferenceExporter

--- a/cfgov/data_research/management/commands/conference_notify.py
+++ b/cfgov/data_research/management/commands/conference_notify.py
@@ -1,4 +1,3 @@
-
 from django.core.management.base import BaseCommand
 
 from data_research.research_conference import (

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.db import models

--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.conf import settings

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -1,4 +1,3 @@
-
 import datetime
 from io import BytesIO
 

--- a/cfgov/data_research/research_conference.py
+++ b/cfgov/data_research/research_conference.py
@@ -1,4 +1,3 @@
-
 import re
 
 from django.core.mail import EmailMessage

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -1,4 +1,3 @@
-
 import datetime
 import logging
 from io import BytesIO

--- a/cfgov/data_research/scripts/load_mortgage_aggregates.py
+++ b/cfgov/data_research/scripts/load_mortgage_aggregates.py
@@ -1,4 +1,3 @@
-
 import datetime
 import logging
 import os

--- a/cfgov/data_research/scripts/load_mortgage_performance_csv.py
+++ b/cfgov/data_research/scripts/load_mortgage_performance_csv.py
@@ -1,4 +1,3 @@
-
 import logging
 import os
 import sys

--- a/cfgov/data_research/scripts/process_mortgage_data.py
+++ b/cfgov/data_research/scripts/process_mortgage_data.py
@@ -1,4 +1,3 @@
-
 import datetime
 import logging
 import os

--- a/cfgov/data_research/scripts/update_county_msa_meta.py
+++ b/cfgov/data_research/scripts/update_county_msa_meta.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from data_research.models import County, MetroArea, MortgageMetaData, State

--- a/cfgov/data_research/tests/management/commands/test_conference_delete.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_delete.py
@@ -1,4 +1,3 @@
-
 from io import StringIO
 
 from django.core.management import call_command

--- a/cfgov/data_research/tests/management/commands/test_conference_notify.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_notify.py
@@ -1,4 +1,3 @@
-
 from io import StringIO
 
 from django.core import mail

--- a/cfgov/data_research/tests/test_blocks.py
+++ b/cfgov/data_research/tests/test_blocks.py
@@ -1,4 +1,3 @@
-
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 

--- a/cfgov/data_research/tests/test_forms.py
+++ b/cfgov/data_research/tests/test_forms.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 
 from core.govdelivery import MockGovDelivery

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -1,4 +1,3 @@
-
 import datetime
 import unittest
 

--- a/cfgov/data_research/tests/test_mortgage_utilities.py
+++ b/cfgov/data_research/tests/test_mortgage_utilities.py
@@ -1,4 +1,3 @@
-
 import django
 
 import mock

--- a/cfgov/data_research/tests/test_research_conference.py
+++ b/cfgov/data_research/tests/test_research_conference.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 
 from data_research.research_conference import get_conference_details_from_page

--- a/cfgov/data_research/tests/test_s3_utils.py
+++ b/cfgov/data_research/tests/test_s3_utils.py
@@ -1,4 +1,3 @@
-
 import csv
 from io import BytesIO, StringIO
 

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -1,4 +1,3 @@
-
 import datetime
 import tempfile
 import unittest

--- a/cfgov/data_research/tests/test_views.py
+++ b/cfgov/data_research/tests/test_views.py
@@ -1,4 +1,3 @@
-
 import datetime
 import json
 import unittest

--- a/cfgov/data_research/views.py
+++ b/cfgov/data_research/views.py
@@ -1,4 +1,3 @@
-
 import datetime
 
 from rest_framework.renderers import JSONRenderer

--- a/cfgov/data_research/wagtail_hooks.py
+++ b/cfgov/data_research/wagtail_hooks.py
@@ -1,4 +1,3 @@
-
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, modeladmin_register
 )

--- a/cfgov/diversity_inclusion/forms.py
+++ b/cfgov/diversity_inclusion/forms.py
@@ -1,4 +1,3 @@
-
 from django import forms
 from django.conf import settings
 from django.core.mail import BadHeaderError, send_mail

--- a/cfgov/housing_counselor/cleaner.py
+++ b/cfgov/housing_counselor/cleaner.py
@@ -1,4 +1,3 @@
-
 import re
 
 

--- a/cfgov/housing_counselor/fetcher.py
+++ b/cfgov/housing_counselor/fetcher.py
@@ -1,4 +1,3 @@
-
 import logging
 
 import requests

--- a/cfgov/housing_counselor/generator.py
+++ b/cfgov/housing_counselor/generator.py
@@ -1,4 +1,3 @@
-
 import glob
 import json
 import logging

--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -1,4 +1,3 @@
-
 import csv
 import itertools
 import logging

--- a/cfgov/housing_counselor/management/commands/hud_generate_html.py
+++ b/cfgov/housing_counselor/management/commands/hud_generate_html.py
@@ -1,4 +1,3 @@
-
 from django.core.management.base import BaseCommand
 
 from housing_counselor.generator import generate_counselor_html

--- a/cfgov/housing_counselor/management/commands/hud_generate_json.py
+++ b/cfgov/housing_counselor/management/commands/hud_generate_json.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.core.management.base import BaseCommand, CommandError

--- a/cfgov/housing_counselor/management/commands/hud_geocode_zipcodes.py
+++ b/cfgov/housing_counselor/management/commands/hud_geocode_zipcodes.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.core.management.base import BaseCommand

--- a/cfgov/housing_counselor/tests/management/test_cleaner.py
+++ b/cfgov/housing_counselor/tests/management/test_cleaner.py
@@ -1,4 +1,3 @@
-
 from itertools import repeat
 from unittest import TestCase
 

--- a/cfgov/housing_counselor/tests/management/test_fetcher.py
+++ b/cfgov/housing_counselor/tests/management/test_fetcher.py
@@ -1,4 +1,3 @@
-
 from unittest import TestCase
 
 import responses

--- a/cfgov/housing_counselor/tests/management/test_generator.py
+++ b/cfgov/housing_counselor/tests/management/test_generator.py
@@ -1,4 +1,3 @@
-
 import json
 import os
 import shutil

--- a/cfgov/jobmanager/apps.py
+++ b/cfgov/jobmanager/apps.py
@@ -1,4 +1,3 @@
-
 from django.apps import AppConfig
 
 

--- a/cfgov/jobmanager/blocks.py
+++ b/cfgov/jobmanager/blocks.py
@@ -1,4 +1,3 @@
-
 from django.template.loader import render_to_string
 from django.utils import timezone
 

--- a/cfgov/jobmanager/models/django.py
+++ b/cfgov/jobmanager/models/django.py
@@ -1,4 +1,3 @@
-
 from django.db import models
 
 from modelcluster.fields import ParentalKey

--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -1,4 +1,3 @@
-
 from django.db import models
 
 from jobmanager.models.django import (

--- a/cfgov/jobmanager/models/panels.py
+++ b/cfgov/jobmanager/models/panels.py
@@ -1,4 +1,3 @@
-
 from django.db import models
 from django.utils.http import urlquote
 

--- a/cfgov/paying_for_college/data_sources/bls_processing.py
+++ b/cfgov/paying_for_college/data_sources/bls_processing.py
@@ -1,4 +1,3 @@
-
 import json
 from csv import DictReader as cdr
 

--- a/cfgov/paying_for_college/models/pages.py
+++ b/cfgov/paying_for_college/models/pages.py
@@ -1,4 +1,3 @@
-
 from paying_for_college.blocks import GuidedQuiz
 from v1.atomic_elements import molecules, organisms
 from v1.models import CFGOVPage, CFGOVPageManager

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -1,4 +1,3 @@
-
 import copy
 import datetime
 import json

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -1,4 +1,3 @@
-
 import copy
 import json
 import unittest

--- a/cfgov/paying_for_college/validators.py
+++ b/cfgov/paying_for_college/validators.py
@@ -1,5 +1,3 @@
-
-
 WHITELIST_KEYS = {
     'alias': 'string',
     'avgmonthlypay': 'float',

--- a/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
+++ b/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 
 from django.utils import timezone

--- a/cfgov/regulations3k/copyable_modeladmin.py
+++ b/cfgov/regulations3k/copyable_modeladmin.py
@@ -1,4 +1,3 @@
-
 from django.conf.urls import url
 from django.contrib.admin.utils import quote
 from django.contrib.auth.decorators import login_required

--- a/cfgov/regulations3k/management/commands/update_regulation_index.py
+++ b/cfgov/regulations3k/management/commands/update_regulation_index.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.core.management import call_command

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -1,4 +1,3 @@
-
 import logging
 import re
 import urllib

--- a/cfgov/regulations3k/parser/integer_conversion.py
+++ b/cfgov/regulations3k/parser/integer_conversion.py
@@ -1,4 +1,3 @@
-
 import string
 
 

--- a/cfgov/regulations3k/parser/payload.py
+++ b/cfgov/regulations3k/parser/payload.py
@@ -1,4 +1,3 @@
-
 import datetime
 import logging
 

--- a/cfgov/regulations3k/parser/regtable.py
+++ b/cfgov/regulations3k/parser/regtable.py
@@ -1,5 +1,3 @@
-
-
 class RegTable(object):
     """Assemble table from XML and deliver an HTML table."""
 

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -1,4 +1,3 @@
-
 import datetime
 import logging
 import re

--- a/cfgov/regulations3k/search_indexes.py
+++ b/cfgov/regulations3k/search_indexes.py
@@ -1,4 +1,3 @@
-
 from haystack import indexes
 
 from regulations3k.models import SectionParagraph

--- a/cfgov/regulations3k/tests/test_blocks.py
+++ b/cfgov/regulations3k/tests/test_blocks.py
@@ -1,4 +1,3 @@
-
 import datetime
 
 from django.test import TestCase, override_settings

--- a/cfgov/regulations3k/tests/test_copyable_modeladmin.py
+++ b/cfgov/regulations3k/tests/test_copyable_modeladmin.py
@@ -1,4 +1,3 @@
-
 from datetime import date
 
 from django.test import TestCase

--- a/cfgov/regulations3k/tests/test_hooks.py
+++ b/cfgov/regulations3k/tests/test_hooks.py
@@ -1,4 +1,3 @@
-
 from datetime import date
 
 from django.test import TestCase

--- a/cfgov/regulations3k/tests/test_search_indexes.py
+++ b/cfgov/regulations3k/tests/test_search_indexes.py
@@ -1,4 +1,3 @@
-
 from django.core.management import call_command
 from django.test import TestCase
 

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -1,4 +1,3 @@
-
 import datetime
 
 from django.test import RequestFactory, TestCase, override_settings

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -1,4 +1,3 @@
-
 import re
 
 # from django.http import Http404

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -1,4 +1,3 @@
-
 from datetime import date
 
 from wagtail.contrib.modeladmin.options import modeladmin_register

--- a/cfgov/scripts/export_enforcement_actions.py
+++ b/cfgov/scripts/export_enforcement_actions.py
@@ -1,4 +1,3 @@
-
 import datetime
 import html.parser as HTMLParser
 import re

--- a/cfgov/scripts/test_data.py
+++ b/cfgov/scripts/test_data.py
@@ -1,4 +1,3 @@
-
 from django.contrib.auth.models import User
 from django.utils.timezone import datetime, timedelta
 

--- a/cfgov/scripts/update_enforcement_categories.py
+++ b/cfgov/scripts/update_enforcement_categories.py
@@ -1,4 +1,3 @@
-
 from v1.models import CFGOVPageCategory, DocumentDetailPage
 from v1.util.migrations import get_stream_data, set_stream_data
 

--- a/cfgov/scripts/update_file_to_docket.py
+++ b/cfgov/scripts/update_file_to_docket.py
@@ -1,4 +1,3 @@
-
 from v1.models import DocumentDetailPage
 from v1.util.migrations import get_stream_data, set_stream_data
 

--- a/cfgov/search/dotgov.py
+++ b/cfgov/search/dotgov.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.conf import settings

--- a/cfgov/search/wagtail_hooks.py
+++ b/cfgov/search/wagtail_hooks.py
@@ -1,4 +1,3 @@
-
 from django.conf.urls import url
 from django.core.urlresolvers import reverse
 

--- a/cfgov/v1/jinja2_environment.py
+++ b/cfgov/v1/jinja2_environment.py
@@ -1,4 +1,3 @@
-
 import os.path
 
 from django.contrib import messages

--- a/cfgov/v1/page_validation.py
+++ b/cfgov/v1/page_validation.py
@@ -1,4 +1,3 @@
-
 import re
 from difflib import ndiff
 from functools import partial

--- a/cfgov/v1/tests/atomic_elements/organisms/test_related_posts.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_related_posts.py
@@ -1,4 +1,3 @@
-
 import datetime as dt
 import re
 

--- a/cfgov/v1/tests/models/test_author_names.py
+++ b/cfgov/v1/tests/models/test_author_names.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 
 from mock import patch

--- a/cfgov/v1/tests/models/test_portal_topics.py
+++ b/cfgov/v1/tests/models/test_portal_topics.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 
 from v1.models.portal_topics import PortalCategory, PortalTopic

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 
 from django.test import TestCase

--- a/cfgov/wellbeing/forms.py
+++ b/cfgov/wellbeing/forms.py
@@ -1,4 +1,3 @@
-
 from django import forms
 
 


### PR DESCRIPTION
#5576 left behind some empty lines at the top of Python files (thanks to @higs4281 for the catch). This PR removes them, as well as any other leading newlines.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: