### PR TITLE
Mega menu: Improve link group spacing

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -972,6 +972,13 @@ body {
                 padding-right: 0;
             }
 
+            // Move the first link in each mega menu list group up a bit so that it aligns
+            // with the featured links box. We do this instead of removing the top padding
+            // to preserve the links' hover state.
+            &-item:first-child &-link {
+                margin-top: unit( -12px / @base-font-size-px, em );
+            }
+
             &-overview-link,
             &-link {
                 padding: unit( 10px / 18px, em );
@@ -1046,8 +1053,12 @@ body {
             display: none;
         }
 
-        &_group-heading__hidden {
-            visibility: hidden;
+        &_group-heading {
+            margin-bottom: unit( 30px / @base-font-size-px, em );
+
+            &__hidden {
+                visibility: hidden;
+            }
         }
 
         // Hide global header CTA container and eyebrow at desktop size.


### PR DESCRIPTION
Bring the top of the mega menu link groups closer to the horizontal rule
under MM overview headings. A negative top margin is used instead of removing
the top padding so that the side border on hover keeps the proper padding.

https://GHE/CFPB/el-camino/issues/153

@anselmbradford 

## Changes

- MM link margin.
- The bottom margin of the optional group headings like "Money tools" is enlarged to compensate when they're present.

## Testing

1. Pull down and build.
2. Open the mm and check out the spacing. See screenshots below.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1050" alt="Screen Shot 2020-03-13 at 12 53 19 PM" src="https://user-images.githubusercontent.com/1060248/76642620-f2cff180-6529-11ea-9f72-5d63a46aa33b.png">   | <img width="1050" alt="Screen Shot 2020-03-13 at 12 52 19 PM" src="https://user-images.githubusercontent.com/1060248/76642619-f19ec480-6529-11ea-9577-b5a343d1b88a.png">  |

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android
