### PR TITLE
Mega menu: Update mobile hover state

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-eyebrow.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-eyebrow.html
@@ -11,7 +11,7 @@
    is_horizontal: Whether the molecule appears horizontally or vertically.
                   defaults to false.
    language:      The page's language value (used to display different
-                  information on Spanish pages). Defaults to English. 
+                  information on Spanish pages). Defaults to English.
 
    ========================================================================== #}
 {% macro render( is_horizontal=false, language='en' ) %}

--- a/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
@@ -8,20 +8,16 @@
 
    Creates markup for Global Header Call to Action (CTA) molecule.
 
-   is_horizontal: Whether the molecule appears horizontally or vertically.
-                  defaults to false.
-
    language:      The page's language value (used to display different
                   information on Spanish pages). Defaults to English.
 
    ========================================================================== #}
 
 
-{% macro render( is_horizontal=false, language='en' ) %}
+{% macro render( language='en' ) %}
     {% set complaint_link = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
     {# TODO: Padding should be on link, not CTA itself #}
-    <div class="m-global-header-cta
-                m-global-header-cta__{{ 'horizontal' if is_horizontal else 'list' }}">
+    <div class="m-global-header-cta">
         <a href="{{ complaint_link }}">
             {{ svg_icon('complaint') }}
             {{ _('Submit a Complaint') }}

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -97,7 +97,7 @@
             {% endif %}
 
             {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-            {{ global_header_cta.render( true, language ) }}
+            {{ global_header_cta.render( language ) }}
 
             {% import 'molecules/global-search.html' as global_search with context %}
             {{ global_search.render() }}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -139,7 +139,7 @@
             </h3>
             {% endif %}
 
-            {# TODO: Make the follow menu markup use the _nav_item macro. #}
+            {# TODO: Make the following menu markup use the _nav_item macro. #}
             {% if nav_item.nav_items %}
                 {% set temp = nav_item.update({'nav_groups': [{'nav_items': nav_item.nav_items}]}) %}
             {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -281,19 +281,21 @@
             u-hidden"
      data-js-hook="behavior_flyout-menu"
      aria-label="main menu">
-    <button class="{{ base_class ~ '_trigger' }}"
-            data-js-hook="behavior_flyout-menu_trigger"
-            aria-haspopup="menu">
-        <span class="{{ base_class ~ '_trigger-open' }}">
-            {{ svg_icon('menu') }}
-        </span>
-        <span class="{{ base_class ~ '_trigger-close' }}">
-            {{ svg_icon('close') }}
-        </span>
-        <span class="u-visually-hidden">
-            Main menu
-        </span>
-    </button>
+    <h2 class="{{ base_class ~ '_heading' }}">
+        <button class="{{ base_class ~ '_trigger' }}"
+                data-js-hook="behavior_flyout-menu_trigger"
+                aria-haspopup="menu">
+            <span class="{{ base_class ~ '_trigger-open' }}">
+                {{ svg_icon('menu') }}
+            </span>
+            <span class="{{ base_class ~ '_trigger-close' }}">
+                {{ svg_icon('close') }}
+            </span>
+            <span class="u-visually-hidden">
+                Main menu
+            </span>
+        </button>
+    </h2>
    {# Create a root menu at depth one.
       This is the 1st level of a 3-level menu. #}
     {{ _nav_level( 1, {'nav_groups': [{'nav_items': menu_items}]}, language=language ) }}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -1,10 +1,10 @@
 {% set base_class = 'o-mega-menu' %}
 
-{# ==========================================================================
+{# =============================================================================
 
-   _classes()
+   _content_classes()
 
-   ==========================================================================
+   =============================================================================
 
    Description:
 
@@ -13,24 +13,24 @@
    nav_depth: Level of menu nesting. 1 equals the root menu.
 
    suffix:    Suffix to add to the classes.
-              Default is ''.
+              Default is an empty string.
 
    ========================================================================== #}
 
 {# TODO: Move to external macro so it can be shared with secondary nav. #}
-{%- macro _classes( nav_depth, suffix='' ) -%}
-{%- set general_class = base_class ~ '_content' ~ suffix -%}
-{%- set depth_class = base_class ~ '_content' ~ '-' ~ nav_depth ~ suffix -%}
+{%- macro _content_classes( nav_depth, suffix='' ) -%}
+    {%- set general_class = base_class ~ '_content' ~ suffix -%}
+    {%- set depth_class = base_class ~ '_content' ~ '-' ~ nav_depth ~ suffix -%}
 
-{{ general_class ~ ' ' ~ depth_class ~ ' ' }}
+    {{ general_class ~ ' ' ~ depth_class ~ ' ' }}
 {%- endmacro -%}
 
 
-{# ==========================================================================
+{# =============================================================================
 
    _nav_list()
 
-   ==========================================================================
+   =============================================================================
 
    Description:
 
@@ -48,46 +48,52 @@
 
 {% macro _nav_list( nav_depth, nav_groups, nav_title='', language='en' ) %}
     {% for group in nav_groups %}
-    <div class="{{ _classes( nav_depth, '-list' ) }}">
+    <div class="{{ _content_classes( nav_depth, '-list-group' ) }}">
+        <div class="{{ _content_classes( nav_depth, '-list' ) }}">
 
-        {% if group.title %}
-        {% set aria_group_title = group.title ~ ' continued' if group.title_hidden else group.title %}
-        <h4 class="h5
-                  {{ base_class ~ '_group-heading' }}
-                  {{ base_class ~ '_group-heading__hidden' if group.title_hidden else ''}}"
-            id="{{ aria_group_title | slugify ~ '-menu' }}"
-            aria-label="{{ aria_group_title }}">
-            {{ group.title }}
-        </h4>
-        {% endif %}
-        <ul
-            {% if aria_group_title %}
-            aria-labelledby="{{ aria_group_title | slugify ~ '-menu' }}"
-            {% elif nav_title %}
-            aria-label="{{ nav_title | safe }}"
-            {% endif %}>
-            {% if nav_depth == 1 -%}
-            <li class="{{ _classes( nav_depth, '-item' ) }}">
-                {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-                {{ global_header_cta.render( language=language ) }}
-            </li>
-            {%- endif %}
-            {%- for item in group.nav_items %}
-                {{ _nav_item( nav_depth, item, language ) }}
-            {%- endfor %}
-        </ul>
+            {% if group.title %}
+            {% set aria_group_title = group.title ~ ' continued' if group.title_hidden else group.title %}
+            <h4 class="h5
+                    {{ base_class ~ '_group-heading' }}
+                    {{ base_class ~ '_group-heading__hidden' if group.title_hidden else ''}}"
+                id="{{ aria_group_title | slugify ~ '-menu' }}"
+                aria-label="{{ aria_group_title }}">
+                {{ group.title }}
+            </h4>
+            {% endif %}
+            <ul
+                {% if aria_group_title %}
+                aria-labelledby="{{ aria_group_title | slugify ~ '-menu' }}"
+                {% elif nav_title %}
+                aria-label="{{ nav_title | safe }}"
+                {% endif %}>
+                {% if nav_depth == 1 -%}
+                    {% set complaint_url = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
+                    {% set complaint_item = {
+                        'text': 'Submit a Complaint',
+                        'url': complaint_url,
+                        'icon_pre': 'complaint'
+                    }
+                    %}
+                    {{ _nav_item( nav_depth, complaint_item, language ) }}
+                {%- endif %}
+                {%- for item in group.nav_items %}
+                    {{ _nav_item( nav_depth, item, language ) }}
+                {%- endfor %}
+            </ul>
+
+        </div>
     </div>
-
     {% endfor %}
 
 {% endmacro %}
 
 
-{# ==========================================================================
+{# =============================================================================
 
    _nav_level()
 
-   ==========================================================================
+   =============================================================================
 
    Description:
 
@@ -108,68 +114,86 @@
    ========================================================================== #}
 
 {% macro _nav_level( nav_depth, nav_item, nav_overview_url, nav_overview_text, language='en' ) %}
-<section class="{{- _classes( nav_depth ) -}}"
+<section class="{{- _content_classes( nav_depth ) -}}"
          aria-expanded="false"
          data-js-hook="behavior_flyout-menu_content">
-    <div class="{{- _classes( nav_depth, '-wrapper' ) -}}">
+    <div class="{{- _content_classes( nav_depth, '-wrapper' ) -}}">
         {# Open wrapper if needed #}
         {% if nav_depth > 1 %}
-        <button class="{{- _classes( nav_depth, '-alt-trigger' ) -}}"
+        <button class="{{- _content_classes( nav_depth, '-alt-trigger' ) -}}"
                 data-js-hook="behavior_flyout-menu_alt-trigger">
             {{ svg_icon('left') }}
             Back
         </button>
         {% endif %}
-        <div class="{{- _classes( nav_depth, '-grid' ) -}}">
+        <div class="{{- _content_classes( nav_depth, '-grid' ) -}}">
 
             {% if nav_depth > 1 and nav_overview_url and nav_overview_url != '#' %}
-            <h3 class="{{ _classes( nav_depth, '-overview' ) }}
-                       {{ _classes( nav_depth, '-overview-heading' ) }}">
-                <a class="{{ _classes( nav_depth, '-overview-link' ) }}
-                            {{ _classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
-                            {{ '' if nav_overview_url == request.path or nav_overview_url == '#' else 'href=' + nav_overview_url | e }}
-                   id="{{ nav_overview_text | slugify ~ '-menu' }}">
+            <h3 class="{{ _content_classes( nav_depth, '-overview' ) }}
+                       {{ _content_classes( nav_depth, '-overview-heading' ) }}">
+                <a class="{{ _content_classes( nav_depth, '-overview-link' ) }}
+                            {{ _content_classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
+                            {{ '' if nav_overview_url == request.path or nav_overview_url == '#' else 'href=' + nav_overview_url | e }}>
                     {{ nav_overview_text ~ ' Overview' }}
                 </a>
             </h3>
             {% endif %}
 
+            {# TODO: Make the follow menu markup use the _nav_item macro. #}
             {% if nav_item.nav_items %}
                 {% set temp = nav_item.update({'nav_groups': [{'nav_items': nav_item.nav_items}]}) %}
             {% endif %}
 
             {% if nav_item.nav_groups %}
-            <div class="{{ _classes( nav_depth, '-lists' ) }}">
+            <div class="{{ _content_classes( nav_depth, '-lists' ) }}">
+
                 {{ _nav_list( nav_depth, nav_item.nav_groups, nav_overview_text, language=language ) }}
 
                 {% if nav_item.featured_items or nav_item.other_items %}
-                <div class="{{ _classes( nav_depth, '-list' ) }}
-                            {{ _classes( nav_depth, '-list__featured' ) }} ">
+
+                <div class="{{ _content_classes( nav_depth, '-list-group' ) }}">
+
                     {% if nav_item.featured_items %}
-                    <ul class="{{ _classes( nav_depth, '-list__featured-item' ) }}" aria-label="Featured">
-                        {% for link in nav_item.featured_items | default( [], true ) %}
-                        <li class="{{ _classes( nav_depth, '-item' ) }}">
-                            <a class="{{ _classes( nav_depth, '-link' ) }}"
-                               href="{{ link.url }}">
-                                {{ svg_icon( 'favorite' ) }}
-                                <span><span class="a-link_text">{{ link.text }}</span></span>
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
+                    <div class="{{ _content_classes( nav_depth, '-list' ) }}
+                                {{ _content_classes( nav_depth, '-list__featured' ) }}">
+                        <h4 class="h5 {{ base_class ~ '_group-heading' }}">
+                            Featured
+                        </h4>
+                        <ul aria-label="Featured">
+                            {% for link in nav_item.featured_items | default( [], true ) %}
+                            <li class="{{ _content_classes( nav_depth, '-item' ) }}
+                                       {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
+                                <a class="{{ _content_classes( nav_depth, '-link' ) }}"
+                                   href="{{ link.url }}">
+                                    {{ svg_icon( 'favorite' ) }}
+                                    <span><span class="a-link_text">{{ link.text }}</span></span>
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
                     {% endif %}
 
-                    <ul>
-                        {% for link in nav_item.other_items | default( [], true ) %}
-                        <li class="{{ _classes( nav_depth, '-item' ) }}">
-                            <a class="a-link {{ _classes( nav_depth, '-link' ) }}"
-                               href="{{ link.url }}">
-                                {{ svg_icon( link.icon ) }}
-                                <span><span class="a-link_text">{{ link.text }}</span></span>
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
+                    {% if nav_item.other_items %}
+                    <div class="{{ _content_classes( nav_depth, '-list' ) }}">
+                        <h4 class="h5 {{ base_class ~ '_group-heading' }}">
+                            Additional Resources
+                        </h4>
+                        <ul aria-label="Additional Resources">
+                            {% for link in nav_item.other_items | default( [], true ) %}
+                            <li class="{{ _content_classes( nav_depth, '-item' ) }}
+                                       {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
+                                <a class="a-link {{ _content_classes( nav_depth, '-link' ) }}"
+                                href="{{ link.url }}">
+                                    {{ svg_icon( link.icon ) }}
+                                    <span><span class="a-link_text">{{ link.text }}</span></span>
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+
                 </div>
                 {% endif %}
             </div>
@@ -185,11 +209,11 @@
 </section>
 {% endmacro %}
 
-{# ==========================================================================
+{# =============================================================================
 
    _nav_item()
 
-   ==========================================================================
+   =============================================================================
 
    Description:
 
@@ -206,24 +230,30 @@
 {% macro _nav_item( nav_depth, nav_item, language='en' ) %}
 {% set has_children = nav_item.nav_groups or nav_item.nav_items %}
 {% set link = nav_item.overview if nav_item.overview else nav_item %}
-<li class="{{ _classes( nav_depth, '-item' ) }}"
+<li class="{{ _content_classes( nav_depth, '-item' ) }}
+           {{- _content_classes( nav_depth, '-item__has-icon' ) if link.icon_pre else '' -}}"
     {{ 'data-js-hook=behavior_flyout-menu' if has_children else '' }}>
     {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
     <a class="{{- 'u-link__disabled' if url == '' else '' -}}
-              {{- _classes( nav_depth, '-link' ) -}}
-              {{- _classes( nav_depth, '-link__has-children' ) if has_children else '' -}}
-              {{- _classes( nav_depth, '-link__current' ) if url == request.path else '' -}}"
+              {{- _content_classes( nav_depth, '-link' ) -}}
+              {{- _content_classes( nav_depth, '-link__has-children' ) if has_children else '' -}}
+              {{- _content_classes( nav_depth, '-link__current' ) if url == request.path else '' -}}"
        href="{{ link.url | default( '#' ) }}"
        {{
          'data-js-hook=behavior_flyout-menu_trigger
           aria-haspopup=menu'
          if has_children else ''
        }}>
+          {% if link.icon_pre %}
+          <span class="{{- _content_classes( nav_depth, '-link-icon-pre' ) -}}">{{ svg_icon( link.icon_pre ) }}</span>
+          {% endif %}
+
           {{ link.text }}
-          {{ svg_icon('right') }}
+
           {% if has_children %}
-          <span class="{{- _classes( nav_depth, '-link-icon-closed' ) -}}">{{ svg_icon( 'down' ) }}</span>
-          <span class="{{- _classes( nav_depth, '-link-icon-open' ) -}}">{{ svg_icon( 'up' ) }}</span>
+          <span class="{{- _content_classes( nav_depth, '-link-icon-post' ) -}}">{{ svg_icon('right') }}</span>
+          <span class="{{- _content_classes( nav_depth, '-link-icon-closed' ) -}}">{{ svg_icon( 'down' ) }}</span>
+          <span class="{{- _content_classes( nav_depth, '-link-icon-open' ) -}}">{{ svg_icon( 'up' ) }}</span>
           {% endif %}
     </a>
     {% if has_children %}
@@ -233,11 +263,11 @@
 {% endmacro %}
 
 
-{# ==========================================================================
+{# =============================================================================
 
    Mega Menu
 
-   ==========================================================================
+   =============================================================================
 
    Description:
 
@@ -251,21 +281,19 @@
             u-hidden"
      data-js-hook="behavior_flyout-menu"
      aria-label="main menu">
-    <h2 class="{{ base_class ~ '_heading' }}">
-        <button class="{{ base_class ~ '_trigger' }}"
-                data-js-hook="behavior_flyout-menu_trigger"
-                aria-haspopup="menu">
-            <span class="{{ base_class ~ '_trigger-open' }}">
-                {{ svg_icon('menu') }}
-            </span>
-            <span class="{{ base_class ~ '_trigger-close' }}">
-                {{ svg_icon('close') }}
-            </span>
-            <span class="u-visually-hidden">
-                Main menu
-            </span>
-        </button>
-    </h2>
+    <button class="{{ base_class ~ '_trigger' }}"
+            data-js-hook="behavior_flyout-menu_trigger"
+            aria-haspopup="menu">
+        <span class="{{ base_class ~ '_trigger-open' }}">
+            {{ svg_icon('menu') }}
+        </span>
+        <span class="{{ base_class ~ '_trigger-close' }}">
+            {{ svg_icon('close') }}
+        </span>
+        <span class="u-visually-hidden">
+            Main menu
+        </span>
+    </button>
    {# Create a root menu at depth one.
       This is the 1st level of a 3-level menu. #}
     {{ _nav_level( 1, {'nav_groups': [{'nav_items': menu_items}]}, language=language ) }}

--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -92,15 +92,19 @@
     }
 
     &__list {
-        padding: unit( @grid_gutter-width / 2 / 12px, em )
-                 unit( @grid_gutter-width / 2 / 12px, em )
-                 unit( @grid_gutter-width / 12px, em );
-        border-top: 1px solid @gray-40;
+        padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, rem );
+        padding-left: unit( @grid_gutter-width / @base-font-size-px, rem );
+        padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, rem );
+        padding-bottom: unit( @grid_gutter-width / @base-font-size-px, rem );
+
+        .a-tagline {
+            line-height: unit( 18px / @base-font-size-px, rem );
+        }
 
         .m-global-eyebrow_actions {
-            padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+            padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, rem );
             border-top: 1px solid @gray-40;
-            margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+            margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, rem );
 
             text-align: left;
         }
@@ -108,7 +112,7 @@
         .m-global-eyebrow_phone,
         .m-global-eyebrow_languages {
             display: block;
-            padding-left: 32px; //22px flag + 15px spacing
+            padding-left: 0;
         }
     }
 }

--- a/cfgov/unprocessed/css/molecules/global-header-cta.less
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.less
@@ -4,51 +4,29 @@
   patterns:
     - name: Horizontal layout example
       markup: |
-        <div class="m-global-header-cta
-                    m-global-header-cta__horizontal">
+        <div class="m-global-header-cta">
             <a href="#">Submit a Complaint</a>
         </div>
       codenotes:
         - |
           Structural cheat sheet:
           -----------------------
-          .m-global-header-cta.m-global-header-cta__horizontal
-            a
-    - name: List item example
-      markup: |
-        <div class="m-global-header-cta
-                    m-global-header-cta__list">
-            <a href="#">Submit a Complaint</a>
-        </div>
-      codenotes:
-        - |
-          Structural cheat sheet:
-          -----------------------
-          .m-global-header-cta.m-global-header-cta__list
+          .m-global-header-cta
             a
   tags:
     - cfgov-molecules
 */
 
 .m-global-header-cta {
+    border-left: 1px solid @gray-40;
+    padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+    padding-top: 13px;
+    padding-bottom: 11px;
 
     a {
         // Colors for :link, :visited, :hover, :focus, :active.
         .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
         font-weight: 500;
-    }
-
-    &__horizontal {
-        border-left: 1px solid @gray-40;
-        padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-        padding-top: 13px;
-        padding-bottom: 11px;
-    }
-
-    &__list a {
-        display: block;
-        padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-        padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
     }
 }
 

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -119,7 +119,8 @@ body {
           Structural cheat sheet:
           -----------------------
           nav.o-mega-menu
-            .o-mega-menu_trigger
+            .o-mega-menu_heading
+                .o-mega-menu_trigger
             .o-mega-menu_content
                 .o-mega-menu_content-wrapper
                     .wrapper
@@ -162,6 +163,12 @@ body {
 @menu_max_width_px: 1200px;
 
 .o-mega-menu {
+
+    &_heading {
+        // Override h2 element styles.
+        margin: 0;
+        font-size: 1em;
+    }
 
     // Reset default unordered list padding and margin.
     ul {

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -398,7 +398,6 @@ body {
                 .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
 
                 padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-                //padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
 
                 // Hide ">" icon when we don't have children.

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -67,32 +67,37 @@ body {
                                                         </h3>
                                                     </span>
                                                     <div class="o-mega-menu_content-lists">
-                                                        <ul class="m-list
-                                                                    m-list__unstyled
-                                                                    o-mega-menu_content-list">
-                                                            <li class="m-list_item
-                                                                        o-mega-menu_content-item">
-                                                                <a class="o-mega-menu_content-link"
-                                                                    href="/the-bureau/">
-                                                                    The Bureau
-                                                                    </a>
-                                                            </li>
+                                                        <div class="o-mega-menu_content-list-group">
+                                                            <div class="o-mega-menu_content-list">
+
+                                                                <ul class="m-list
+                                                                            m-list__unstyled
+                                                                            o-mega-menu_content-list">
+                                                                    <li class="m-list_item
+                                                                                o-mega-menu_content-item">
+                                                                        <a class="o-mega-menu_content-link"
+                                                                            href="/the-bureau/">
+                                                                            The Bureau
+                                                                            </a>
+                                                                    </li>
+                                                                    …
+                                                                </ul>
+                                                                <ul class="m-list
+                                                                            m-list__unstyled
+                                                                            o-mega-menu_content-list">
+                                                                        <li class="m-list_item
+                                                                                    o-mega-menu_content-item">
+                                                                            <a class="o-mega-menu_content-link__current
+                                                                                        o-mega-menu_content-link"
+                                                                                href="/about-us/careers/">
+                                                                                Careers
+                                                                                </a>
+                                                                        </li>
+                                                                        …
+                                                                </ul>
+                                                            </div>
                                                             …
-                                                        </ul>
-                                                        <ul class="m-list
-                                                                    m-list__unstyled
-                                                                    o-mega-menu_content-list">
-                                                                <li class="m-list_item
-                                                                            o-mega-menu_content-item">
-                                                                    <a class="o-mega-menu_content-link__current
-                                                                                o-mega-menu_content-link"
-                                                                        href="/about-us/careers/">
-                                                                        Careers
-                                                                        </a>
-                                                                </li>
-                                                                …
-                                                        </ul>
-                                                        …
+                                                        </div>
                                                     </div>
                                                 </div>
                                                 <aside class="sub-nav_media">
@@ -114,8 +119,7 @@ body {
           Structural cheat sheet:
           -----------------------
           nav.o-mega-menu
-            .o-mega-menu_heading
-                .o-mega-menu_trigger
+            .o-mega-menu_trigger
             .o-mega-menu_content
                 .o-mega-menu_content-wrapper
                     .wrapper
@@ -126,26 +130,28 @@ body {
                             .o-mega-menu_content-title
                                 a.o-mega-menu_content-link
                             .o-mega-menu_content-lists
-                                ul.o-mega-menu_content-list
-                                    li.o-mega-menu_content-item
-                                        .m-global-header-cta.m-global-header-cta__list
-                                    li.o-mega-menu_content-item
-                                        a.o-mega-menu_content-link
-                                    li.o-mega-menu_content-item
-                                        a.o-mega-menu_content-link
-                                        .o-mega-menu_content
-                                            .o-mega-menu_content-wrapper
-                                                .wrapper
-                                                    button.o-mega-menu_content-alt-trigger
-                                                    .o-mega-menu_content-grid
-                                                        .o-mega-menu_content-title
-                                                            a.o-mega-menu_content-link
-                                                        .o-mega-menu_content-lists
-                                                            ul.o-mega-menu_content-list
-                                                                li.o-mega-menu_content-item
-                                                            ul.o-mega-menu_content-list
-                                                                li.o-mega-menu_content-item
-                                                    aside.sub-nav_media
+                                .o-mega-menu_content-list-group
+                                    .o-mega-menu_content-list
+                                        ul
+                                            li.o-mega-menu_content-item
+                                                .m-global-header-cta.m-global-header-cta__list
+                                            li.o-mega-menu_content-item
+                                                a.o-mega-menu_content-link
+                                            li.o-mega-menu_content-item
+                                                a.o-mega-menu_content-link
+                                                .o-mega-menu_content
+                                                    .o-mega-menu_content-wrapper
+                                                        .wrapper
+                                                            button.o-mega-menu_content-alt-trigger
+                                                            .o-mega-menu_content-grid
+                                                                .o-mega-menu_content-title
+                                                                    a.o-mega-menu_content-link
+                                                                .o-mega-menu_content-lists
+                                                                    ul.o-mega-menu_content-list
+                                                                        li.o-mega-menu_content-item
+                                                                    ul.o-mega-menu_content-list
+                                                                        li.o-mega-menu_content-item
+                                                            aside.sub-nav_media
       notes:
         - "Not shown, but each content level adds a depth-specific class,
            such as o-mega-menu_content-1, o-mega-menu_content-2, etc."
@@ -157,12 +163,6 @@ body {
 
 .o-mega-menu {
 
-    &_heading {
-        // Override h2 element styles.
-        margin: 0;
-        font-size: 1em;
-    }
-
     // Reset default unordered list padding and margin.
     ul {
         padding-left: 0;
@@ -170,44 +170,53 @@ body {
     }
 
     &_content {
+
         &-overview-heading {
             margin-bottom: 0;
-            font-size: unit( @base-font-size-px / @base-font-size-px, em );
+            font-size: unit( 18px / @base-font-size-px, rem );
             font-weight: normal;
         }
 
-        // Hide the ">" icon next to menu items on desktop…
-        &-link {
-            .cf-icon-svg {
-                display: none;
-            }
-        }
-
         // …however, show the icons in featured links.
-        &_content-list__featured {
+        &-item__has-icon {
             .cf-icon-svg {
                 display: inline-block;
             }
         }
 
+        &-link,
+        &-overview-link {
+            width: 100%;
+        }
+
+        // Ensure desktop up/down arrow link icons don't appear at mobile.
+        &-link {
+            &-icon-closed .cf-icon-svg,
+            &-icon-open .cf-icon-svg {
+                display: none;
+            }
+        }
+
         // Featured menu content is link items with icons.
-        &-list__featured {
+        &-item__has-icon {
+            // Align the icon and text.
+            display: flex;
+            align-items: baseline;
+
+            & a {
+                display: flex;
+            }
+
+            // Hide link bottom line from Design System link styles.
+            & .a-link_text {
+                border-bottom-width: 0;
+            }
 
             & .cf-icon-svg {
                 display: inline;
                 color: @pacific;
                 margin-right: 10px;
-            }
-        }
-
-        &-list__featured li {
-            // Align the icon and text.
-            display: flex;
-            align-items: baseline;
-
-            // Hide link bottom line from Design System link styles.
-            & .a-link_text {
-                border-bottom-width: 0;
+                width: 100%;
             }
         }
     }
@@ -360,23 +369,19 @@ body {
                 border-bottom: 1px solid @gray-40;
             }
 
+            &-grid {
+                padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, rem );
+                padding-left: unit( @grid_gutter-width / @base-font-size-px, rem );
+            }
+
             // Adjust padding and margin on unordered list menu items
             // above the global eyebrow.
-            &-list {
-                padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+            &-list-group {
                 margin-bottom: 0;
             }
 
             &-item {
                 border-bottom: 1px solid @gray-40;
-            }
-
-            // Ensure desktop link icons don't appear at mobile.
-            &-link {
-                &-icon-closed .cf-icon-svg,
-                &-icon-open .cf-icon-svg {
-                    display: none !important;
-                }
             }
 
             &-link,
@@ -386,18 +391,23 @@ body {
                 .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
 
                 padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-                padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+                //padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
 
-                .js & {
-                    &__has-children .cf-icon-svg {
-                        display: block;
+                // Hide ">" icon when we don't have children.
+                &-icon-post {
+                    display: none;
+                }
 
-                        position: absolute;
-                        right: 0;
-                        top: 50%;
-                        transform: translateY( -50% );
+                &__has-children &-icon-post {
+                    display: block;
 
+                    position: absolute;
+                    right: 0;
+                    top: 50%;
+                    transform: translateY( -50% );
+
+                    .cf-icon-svg {
                         fill: @green;
                     }
                 }
@@ -405,6 +415,10 @@ body {
                 &__current,
                 &:hover {
                     cursor: pointer;
+
+                    .cf-icon-svg {
+                        fill: @black;
+                    }
                 }
             }
 
@@ -414,25 +428,48 @@ body {
                 padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             }
 
+            &-link,
+            &-overview-link {
+                position: relative;
+                left: unit( -15px / 18px, em );
+                padding-top: unit( 15px / 18px, em );
+                padding-bottom: unit( 15px / 18px, em );
+                padding-left: unit( 10px / 18px, em );
+
+                border-left: 5px solid transparent;
+
+                &:hover {
+                    color: @black;
+                    border-left-color: @green;
+                }
+
+                &:focus {
+                    border-color: @black;
+                    outline: 1px dotted @black;
+                }
+
+                // This is styling for the currently selected content-2 links.
+                &__current:hover,
+                &__current,
+                &__current:visited {
+                    color: @black;
+                    border-left-color: @black;
+                    cursor: default;
+                }
+            }
         }
 
         // 1st-level menu - Tablet/Mobile.
         &_content-1 {
+            display: block;
+
             .js & {
                 // Offset for height of trigger button.
                 top: @mobile_trigger_ht__px;
             }
-            display: block;
 
-            &-list {
+            &-list-group {
                 padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-            }
-
-            // Remove final border line of last list item.
-            &-list:last-child {
-                .o-mega-menu_content-1-item:last-child {
-                    border-bottom: none;
-                }
             }
 
             // TODO: Remove when Consumer Tools and Ed Resources links are in.
@@ -450,8 +487,9 @@ body {
         // 2nd-level menu - Tablet/Mobile.
         &_content-2 {
 
-            &-list__featured-item {
-                display: none;
+            // Remove final border line of last list item.
+            &-lists &-list-group:last-child &-list:last-child &-item:last-child {
+                border-bottom: none;
             }
 
             // TODO: Enable or delete when non-clickable
@@ -468,13 +506,6 @@ body {
             //        cursor: default;
             //    }
             // }
-
-            // Remove final border line of last list item.
-            &-list:last-child {
-                .o-mega-menu_content-2-item:last-child {
-                    border-bottom: none;
-                }
-            }
         }
 
         // 3rd-level menu - Tablet/Mobile.
@@ -482,7 +513,7 @@ body {
             // TODO: There is similar code set on all three menus.
             //       Investigate if it can be combined.
             // Remove final border line of last list item.
-            &-list:last-child {
+            &-list-group:last-child {
                 .o-mega-menu_content-3-item:last-child {
                     border-bottom: none;
                 }
@@ -499,14 +530,15 @@ body {
             z-index: 10;
 
             &-grid {
-                padding-left: unit( @grid_gutter-width / 2 / 18px, em );
                 padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+                padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             }
         }
 
         // Group heading - Tablet/Mobile
         &_group-heading {
-            margin-top: @grid_gutter-width;
+            // !important is used to override a highly specific ul+.h5 rule in base.less
+            margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, rem ) !important;
 
             &__hidden {
                 .u-visually-hidden;
@@ -544,6 +576,11 @@ body {
             display: none;
         }
 
+        // Hide the ">" icon next to menu items on desktop…
+        &_content-link-icon-post {
+            display: none;
+        }
+
         // 1st-level menu - Desktop.
         &_content-1 {
             &[aria-expanded="true"] {
@@ -553,7 +590,7 @@ body {
                 }
             }
 
-            &-list {
+            &-list-group {
                 margin-bottom: 0;
                 // Truncate the expanded menu to this element.
                 position: relative;
@@ -581,7 +618,10 @@ body {
                 border-top: 1px solid transparent;
                 border-right: 1px solid transparent;
                 border-left: 1px solid transparent;
-                font-size: unit( 16px / @base-font-size-px, em );
+                font-size: unit( 16px / @base-font-size-px, rem );
+
+                // Revert 100% width set globally within menu.
+                width: auto !important;
 
                 &:first-child {
                     margin-left: 0;
@@ -686,6 +726,11 @@ body {
             }
         }
 
+        // Hide last columns headings at desktop sizes.
+        &_content-2-lists &_content-2-list-group:last-child &_group-heading {
+            display: none;
+        }
+
         // 2nd-level menu - Desktop.
         &_content-2 {
             overflow: hidden;
@@ -694,15 +739,17 @@ body {
             z-index: 10;
 
             // Featured item has a highlight box around it.
-            &-list__featured-item {
+            &-list__featured {
 
-                // Style the featured item box.
-                padding-right: unit( 13px / @base-font-size-px, em );
-                padding-top: unit( 30px / @base-font-size-px, em );
-                padding-bottom: unit( 30px / @base-font-size-px, em );
-                margin-bottom: unit( 30px / @base-font-size-px, em );
-                border: 1px solid @gray-40;
-                border-top: 6px solid @gold;
+                & ul {
+                    // Style the featured item box.
+                    padding-right: unit( 13px / @base-font-size-px, em );
+                    padding-top: unit( 30px / @base-font-size-px, em );
+                    padding-bottom: unit( 30px / @base-font-size-px, em );
+                    margin-bottom: unit( 30px / @base-font-size-px, em );
+                    border: 1px solid @gray-40;
+                    border-top: 6px solid @gold;
+                }
 
                 & a {
                     display: flex;
@@ -727,29 +774,10 @@ body {
                 }
             }
 
-            &-list__featured li {
+            &-item__has-icon {
                 // Pad in featured items from their icons.
                 padding-left: unit( 13px / @base-font-size-px, em );
 
-                & a {
-                    display: flex;
-                }
-
-                & .cf-icon-svg {
-                    width: 100%;
-                }
-            }
-
-            // Adding padding between featured items.
-            &-list__featured-item li {
-                margin-bottom: unit( 20px / @base-font-size-px, em );
-            }
-
-            &-list__featured-item li:last-child {
-                margin-bottom: 0;
-            }
-
-            &-list__featured li {
                 & a:hover .cf-icon-svg {
                     color: @black;
                 }
@@ -785,7 +813,7 @@ body {
             &-overview {
                 padding-bottom: @grid_gutter-width / 2;
                 margin-bottom: @grid_gutter-width;
-                font-size: unit( 18px / @base-font-size-px, em );
+                font-size: unit( 18px / @base-font-size-px, rem );
 
                 &-heading {
                     padding-top: 0;
@@ -801,14 +829,14 @@ body {
                 margin-top: unit( 10px / @base-font-size-px, em );
             }
 
-            &-list {
+            &-list-group {
                 display: table-cell;
                 width: 25%;
                 vertical-align: top;
                 padding-right: 10px;
             }
 
-            &-list:last-child {
+            &-list-group:last-child {
                 padding-right: 0;
             }
 
@@ -900,6 +928,11 @@ body {
     // JS isn't available to remove u-hidden class, so override it.
     &.u-hidden {
       display: block;
+    }
+
+    // Hide the ">" arrow icon (used on mobile view).
+    .o-mega-menu_content-link-icon-post {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Changes

- Left align all items in the mobile menu, including global CTA.
- Add green hover to mobile menu items.
- Convert global CTA link to a native link in the menu.
- Rename menu `_classes` helper to `_content_classes` as works on `o-mega-menu_content`
- Add `o-mega-menu_content-list-group` container.

## Testing

1. Pull branch and build.
2. Visit http://localhost:8000/policy-compliance/ and resize to mobile.
3. Note currently selected item and hover state.
4. Desktop should be unchanged from production.

## Screenshots

<img width="758" alt="Screen Shot 2020-03-13 at 5 26 07 PM" src="https://user-images.githubusercontent.com/704760/76661398-b87a4a80-6551-11ea-824a-45e04d1b535e.png">

<img width="828" alt="Screen Shot 2020-03-13 at 5 42 43 PM" src="https://user-images.githubusercontent.com/704760/76661648-5d952300-6552-11ea-9fb8-6153d1040c28.png">
