### PR TITLE
Tests: Replace complex tox dependency factors with "current" and "future" factors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,12 @@ env:
     - TRAVIS_CHECK_MIGRATIONS="./manage.py makemigrations --dry-run --check"
   matrix:
     - RUNTEST='backend'
-    - RUNTEST='backend' TOXENV='unittest-py36-dj22-wag23'
+    - RUNTEST='backend' TOXENV='unittest-future'
     - RUNTEST='frontend'
 
 jobs:
   allow_failures:
-    - env: RUNTEST='backend' TOXENV='unittest-py36-dj22-wag23'
+    - env: RUNTEST='backend' TOXENV='unittest-future'
   include:
     # This stage will run after the default testing stage succeeds.
     - stage: Build docs and push them to GitHub Pages

--- a/cfgov/cfgov/settings/test_acceptance.py
+++ b/cfgov/cfgov/settings/test_acceptance.py
@@ -1,4 +1,4 @@
-from .test_nomigrations import *
+from .test import *
 
 
 TEST_RUNNER = 'cfgov.test.AcceptanceTestRunner'

--- a/cfgov/cfgov/settings/test_nomigrations.py
+++ b/cfgov/cfgov/settings/test_nomigrations.py
@@ -1,6 +1,0 @@
-from core.utils import NoMigrations
-
-from .test import *
-
-
-MIGRATION_MODULES = NoMigrations()

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import os
 import re
@@ -8,11 +7,8 @@ import sys
 from contextlib import redirect_stdout
 from io import StringIO
 
-from django.apps import apps
 from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.db import connection
-from django.db.migrations.loader import MigrationLoader
 from django.test import RequestFactory
 from django.test.runner import DiscoverRunner
 
@@ -68,41 +64,11 @@ class TestRunner(DiscoverRunner):
     def setup_databases(self, **kwargs):
         dbs = super(TestRunner, self).setup_databases(**kwargs)
 
-        # Ensure that certain key data migrations are always run, even if
-        # tests are being run without migrations, e.g. through use of
-        # settings.test_nomigrations.
-        self.run_required_data_migrations()
-
         # Set up additional required test data that isn't contained in data
         # migrations, for example an admin user.
         initial_data.run()
 
         return dbs
-
-    def run_required_data_migrations(self):
-        if settings.MIGRATION_MODULES:
-            migration_methods = (
-                (
-                    'wagtail.core.migrations.'
-                    '0002_initial_data',
-                    'initial_data'
-                ),
-                (
-                    'wagtail.core.migrations.'
-                    '0025_collection_initial_data',
-                    'initial_data'
-                ),
-            )
-        else:
-            migration_methods = ()
-
-        loader = MigrationLoader(connection)
-
-        for migration, method in migration_methods:
-            if not self.is_migration_applied(loader, migration):
-                print('applying migration {}'.format(migration))
-                module = importlib.import_module(migration)
-                getattr(module, method)(apps, None)
 
     @staticmethod
     def is_migration_applied(loader, migration):

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -2,9 +2,7 @@ import unittest
 
 from django.test import TestCase
 
-from core.utils import (
-    NoMigrations, extract_answers_from_request, format_file_size
-)
+from core.utils import extract_answers_from_request, format_file_size
 
 
 class FakeRequest(object):
@@ -27,17 +25,6 @@ class ExtractAnswersTest(TestCase):
         result = extract_answers_from_request(request)
         assert result == [('another', 'another_answer'),
                           ('first', 'some_answer')]
-
-
-class TestNoMigrations(TestCase):
-    def setUp(self):
-        self.nomigrations = NoMigrations()
-
-    def test_contains(self):
-        self.assertTrue('random-string' in self.nomigrations)
-
-    def test_getitem(self):
-        self.assertIsNone(self.nomigrations['random-string'])
 
 
 class FormatFileSizeTests(unittest.TestCase):

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -171,21 +171,6 @@ def add_link_markup(tag):
     return str(tag)
 
 
-class NoMigrations(object):
-    """Class to disable app migrations through settings.MIGRATION_MODULES.
-
-    The MIGRATION_MODULES setting can be used to tell Django where to look
-    for an app's migrations (by default this is the "migrations" subdirectory).
-    This class simulates a dictionary where a lookup for any app returns a
-    value that causes Django to think that no migrations exist.
-    """
-    def __contains__(self, item):
-        return True
-
-    def __getitem__(self, item):
-        return None
-
-
 def slugify_unique(context, value):
     """Generates a slug, making it unique for a context, if possible.
 

--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -60,33 +60,32 @@ You can select specific environments using `-e`.
 Running `tox` by itself is the same as running:
 
 ```sh
-tox -e lint -e unittest-py36-dj111-wag113-slow
+tox -e lint -e unittest
 ```
 
 These default environments are:
 
-- `lint`, which runs our [linting](#linting) tools
-- `unittest-py27-dj111-wag113-slow`, our "slow" (with migrations) environment 
-  for running unit tests on Python 2.7 with Django 1.11 and Wagtail 1.13.
-- `unittest-py36-dj111-wag113-slow`, our "slow" (with migrations) environment 
-  for running unit tests on Python 3.6 with Django 1.11 and Wagtail 1.13.
+- `lint`, which runs our [linting](#linting) tools. We require this 
+  environment to pass in CI.
+- `unittest`, which runs unit tests against the current production 
+  versions of Python, Django, and Wagtail. We require this environment to 
+  pass in CI.
+
+In addition, we also have this environment:
+
+- `unittest-future`, which runs unit tests against upcoming versions of 
+  Python, Django, and Wagtail. We do not require this environment to pass in 
+  CI.
  
 By default this uses a local SQLite database for tests. To override this, you
 can set the `TEST_DATABASE_URL` environment variable to a database connection
 string as supported by [dj-database-url](https://github.com/kennethreitz/dj-database-url).
 
-If you haven't changed any Python dependencies and you don't need to test 
-all migrations, you can run our "fast" environments that skip migrations:
-
-```sh
-tox -e unittest-py36-dj111-wag113-fast
-```
-
 If you would like to run only a specific test, or the tests for a specific app, 
 you can provide a dotted path to the test as the final argument to any of the above calls to `tox`:
 
 ```sh
-tox -e unittest-py36-dj111-wag113-fast regulations3k.tests.test_regdown
+tox -e unittest regulations3k.tests.test_regdown
 ```
 
 ### Linting
@@ -136,7 +135,7 @@ runner that fails if anything is written to stdout. This test runner is at
 environment variable:
 
 ```sh
-TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner tox -e fast
+TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner tox -e unittest
 ```
 
 This test runner is enabled when tests are run automatically on [Travis CI](https://travis-ci.org/),

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 -r base.txt
 django-debug-toolbar==1.11
 django-sslserver==0.20
-tox-pip-extensions==1.1.0
-tox==2.9.1
+tox-pip-extensions==1.6.0
+tox==3.14.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,5 @@ github3.py==0.9.6
 mock==2.0.0
 model_mommy==1.2.6
 moto==1.3.6
+pip==20.0.2
 responses==0.9.0

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,4 +1,3 @@
 coverage==4.5.1
-tox==2.9.1
-tox-pip-extensions==1.1.0
-tox-travis==0.12
+tox==3.14.5
+tox-pip-extensions==1.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,6 @@ changedir=
     {toxinidir}/cfgov
 passenv=
     TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TEST_DATABASE_URL TEST_RUNNER
-# Set DJANGO_SETTINGS_MODULE based on {with,no}-migrations
 setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_ADMIN_USERNAME=admin

--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,7 @@ deps=
 # To run unittests with the upcoming versions specified here.
 basepython=python3.6
 deps=
-    Django>=2.2,<2.3
+    Django>=2.0,<2.1
     wagtail>=2.3,<2.4
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist=True
 # of django-treebeard and djangorestframework.
 # tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{23}-slow
+envlist=lint-{current}, unittest-{current}
 
 
 [testenv]
@@ -13,77 +13,68 @@ envlist=lint-py{36}, unittest-py{36}-dj{111}-wag{23}-slow
 # and unittest is done in their respective configuration sections below.
 #
 # Factors:
-#   lint:               Lint Python files with flake8 and isort
-#   unittest:           Run Python unittests
-#   acceptance:         Run a Django server and acceptance tests
-#   py36:               Use Python 3.6
-#   py38:               Use Python 3.8
-#   dj111:              Use Django 1.11
-#   dj22:               Use Django 2.2
-#   wag23:              Use Wagtail 2.3
-#   wag28:              Use Wagtail 2.8
+#   lint:       Lint Python files with flake8 and isort
+#   unittest:   Run Python unittests
+#   acceptance: Run a Django server and acceptance tests
+#   current:    Use the current production Python, Django, Wagtail
+#   future:     Use the latest production Python, Django, Wagtail
 #
 # These factors are expected to combine into the follow generative environments:
 #
-#   lint-py{36}
-#   unittest-py{36}-dj{111}-wag{23}-{fast,slow}
-#   unittest-py{36}-dj{22}-wag{23,28}-{fast,slow}
-#   acceptance-py{36}-dj{111}-wag{23}-fast
+#   lint-current
+#   lint-future
+#   unittest-current
+#   unittest-future
+#   acceptance-current
+#   acceptance-future
 #
 # These factors are expected to combine to be invoked with:
 #
-#   tox -e lint-py36
-#   tox -e unittest-py36-dj111-wag23-fast
-#   tox -e unittest-py36-dj111-wag23-slow
-#   tox -e unittest-py36-dj22-wag23-fast
-#   tox -e unittest-py36-dj22-wag23-slow
-#   tox -e unittest-py36-dj22-wag28-fast
-#   tox -e unittest-py36-dj22-wag28-slow
+#   tox -e lint-current
+#   tox -e lint-future
+#   tox -e unittest-current
+#   tox -e unittest-future
+#   tox -e acceptance-current
+#   tox -e acceptance-future
 
 recreate=False
 
 whitelist_externals=echo
 
 changedir=
-    unittest:           {[unittest]changedir}
-    acceptance:         {[acceptance]changedir}
+    unittest:           {[unittest-config]changedir}
+    acceptance:         {[acceptance-config]changedir}
 
 basepython=
-    py36: python3.6
+    current: {[current-config]basepython}
+    future: {[future-config]basepython}
 
 deps=
-    dj111:              Django>=1.11,<1.12
-    dj22:               Django>=2.2,<2.3
-    wag23:              wagtail>=2.3,<2.4
-    wag28:              wagtail>=2.8,<2.9
-    lint:               {[lint]deps}
-    unittest:           {[unittest]deps}
-    acceptance:         {[acceptance]deps}
+    current:    {[current-config]deps}
+    future:     {[future-config]deps}
+    lint:       {[lint-config]deps}
+    unittest:   {[unittest-config]deps}
+    acceptance: {[acceptance-config]deps}
 
 passenv=
-    fast:       {[unittest]passenv}
-    slow:       {[unittest]passenv}
-    unittest:   {[unittest]passenv}
-    acceptance: {[acceptance]passenv}
+    unittest:   {[unittest-config]passenv}
+    acceptance: {[acceptance-config]passenv}
 
 setenv=
-    fast:               {[fast]setenv}
-    slow:               {[slow]setenv}
-    unittest:           {[unittest]setenv}
-    acceptance:         {[acceptance]setenv}
+    unittest:           {[unittest-config]setenv}
+    acceptance:         {[acceptance-config]setenv}
 
 commands=
-    lint:               {[lint]commands}
-    py36-slow:          {[missing-migrations]commands}
-    unittest:           {[unittest]commands}
-    acceptance:         {[acceptance]commands}
+    lint:               {[lint-config]commands}
+    unittest:           {[unittest-config]commands}
+    acceptance:         {[acceptance-config]commands}
 
 
-[lint]
-# Configuration values necessary to lint Python files.
-# Note: This is not an env will not run if invoked. Use an invocation of:
+[lint-config]
+# Configuration necessary to lint Python files.
+# Note: This is not an env and will not run if invoked. Use:
 #
-#   tox -e lint-py{36}
+#   tox -e lint-{current, future}
 #
 # To run Python linting.
 deps=
@@ -94,11 +85,11 @@ commands=
     isort --check-only --diff --recursive cfgov
 
 
-[unittest]
-# Configuration values necessary to run unittests.
-# Note: This is not an env will not run if invoked. Use an invocation of:
+[unittest-config]
+# Configuration necessary to run unittests.
+# Note: This is not an env and will not run if invoked. Use:
 #
-#   tox -e unittest-py{36}-dj{111,22}-wag{23}-{fast,slow}
+#   tox -e unittest-{current, future}
 #
 # To run unit tests.
 changedir=
@@ -113,6 +104,7 @@ setenv=
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
     WAGTAIL_SHARING_HOSTNAME=content.localhost
+    DJANGO_SETTINGS_MODULE=cfgov.settings.test
 deps=
     -r{toxinidir}/requirements/libraries.txt
     -r{toxinidir}/requirements/test.txt
@@ -121,53 +113,48 @@ commands=
     coverage run --source='.' manage.py test {posargs}
 
 
-[fast]
-# Configuration values necessary to run unittests without migrations.
-# Note: This is not an env will not run if invoked. Use an invocation of:
-#
-#   tox -e unittest-py{36}-dj{111}-wag{23}-fast
-#
-# To run unit tests.
-setenv=
-    DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
+[current-config]
+# Configuration necessary for the production versions Python, Django and 
+# Wagtail
+# Note: This is not an env and will not run if invoked. Use:
+# 
+#   tox -e unittest-current
+#   tox -e unittest
+# 
+# To run unittests with the current production versions.
+basepython=python3.6
+deps=
+    -r{toxinidir}/requirements/django.txt
+    -r{toxinidir}/requirements/wagtail.txt
+
+[future-config]
+# Configuration necessary for upcoming versions of Python, Django, and 
+# Wagtail. This is the place where the "future" dependencies will need to be 
+# modified when we're ready to track new versions of Python, Django, or 
+# Wagtail.
+# Note: This is not an env and will not run if invoked. Use:
+# 
+#   tox -e unittest-future
+# 
+# To run unittests with the upcoming versions specified here.
+basepython=python3.6
+deps=
+    Django>=2.2,<2.3
+    wagtail>=2.3,<2.4
 
 
-[slow]
-# Configuration values necessary to run unittests with migrations.
-# Note: This is not an env will not run if invoked. Use an invocation of:
-#
-#   tox -e unittest-py{36}-dj{111}-wag{23}-slow
-#
-# To run unit tests.
-setenv=
-    DJANGO_SETTINGS_MODULE=cfgov.settings.test
-
-
-[missing-migrations]
-# Extra configuration values used as part of slow environments.
-#
-# When running on Travis, we want to verify that Django migrations are
-# up-to-date. But we don't want to do that when running tox locally. We
-# accomplish this by having Travis set the TRAVIS_CHECK_MIGRATIONS
-# environment variable with the check migrations command.
-#
-# When not running on Travis, we want this to be a noop.
-commands=
-    {env:TRAVIS_CHECK_MIGRATIONS:echo "Skipping Travis-only step"}
-
-
-[acceptance]
-# Configuration values necessary to run acceptance tests using same
+[acceptance-config]
+# Configuration necessary to run acceptance tests using same
 # virtualenv as backend tests.
-# Note: This is not an env will not run if invoked. Use an invocation of:
+# Note: This is not an env and will not run if invoked. Use:
 #
-#   acceptance-py{36}-dj{111}-wag{23}-fast
+#   tox -e acceptance-{current, future}
 #
 # To run acceptance tests.
 changedir=
-    {[unittest]changedir}
+    {[unittest-config]changedir}
 deps=
-    {[unittest]deps}
+    {[unittest-config]deps}
 passenv=
     USER
     DISPLAY
@@ -183,51 +170,47 @@ commands=
     ./manage.py test {posargs}
 
 
-## Standalone and past-friendly envs
+## Standalone and user-friendly envs
+
+
+[testenv:unittest]
+# Invoke with: tox -e unittest
+# This should run identically to tox -e unittest-current
+recreate=False
+basepython={[current-config]basepython}
+envdir={toxworkdir}/unittest-current
+deps=
+    {[current-config]deps}
+    {[unittest-config]deps}
+commands={[unittest-config]commands}
 
 
 [testenv:lint]
 # Invoke with: tox -e lint
-# This should run identically to tox -e lint-py36
+# This should run identically to tox -e lint-current
 recreate=False
-basepython=python3.6
-envdir={toxworkdir}/lint-py36
-deps={[lint]deps}
-commands={[lint]commands}
-
-
-[testenv:fast]
-# Invoke with: tox -e fast
-# This should run identically to tox -e unittest-py36-dj111-wag23-fast
-recreate=False
-changedir={[unittest]changedir}
-basepython=python3.6
-envdir={toxworkdir}/unittest-py36-dj111-wag23-fast
-deps=
-    -r{toxinidir}/requirements/django.txt
-    -r{toxinidir}/requirements/wagtail.txt
-    {[unittest]deps}
-setenv=
-    {[fast]setenv}
-    {[unittest]setenv}
-commands={[unittest]commands}
+basepython={[current-config]basepython}
+envdir={toxworkdir}/lint-current
+deps={[lint-config]deps}
+commands={[lint-config]commands}
 
 
 [testenv:acceptance]
+# Invoke with: tox -e acceptance
+# Set up an environment against which acceptance tests can be run
 recreate=False
-changedir={[acceptance]changedir}
-basepython=python3.6
-envdir={toxworkdir}/acceptance-py36-dj111-wag23
+changedir={[acceptance-config]changedir}
+basepython={[current-config]basepython}
+envdir={toxworkdir}/acceptance-current
 deps=
-    -r{toxinidir}/requirements/django.txt
-    -r{toxinidir}/requirements/wagtail.txt
-    {[acceptance]deps}
-passenv={[acceptance]passenv}
+    {[current-config]deps}
+    {[acceptance-config]deps}
+passenv={[acceptance-config]passenv}
 setenv=
-    acceptance: {[acceptance]setenv}
+    acceptance: {[acceptance-config]setenv}
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
-commands={[acceptance]commands}
+commands={[acceptance-config]commands}
 
 
 [testenv:validate-assets]
@@ -235,7 +218,7 @@ commands={[acceptance]commands}
 # Ensure all assets are generated without error.
 recreate=False
 changedir={toxinidir}
-basepython=python3.6
+basepython={[current-config]basepython}
 deps=-r{toxinidir}/requirements/base.txt
 setenv=
     DJANGO_SETTINGS_MODULE=cfgov.settings.production


### PR DESCRIPTION
This is a proposal to replace our version-specific factors for tox environments with a simpler `current` and `future` nomenclature.

This means to run the unittests on the current production version of Python, Django, and Wagtail, one would use:

```
tox -e unittest-current
```

To run them against upcoming versions of Python, Django, and Wagtail:

```
tox -e unittest-future
```

I've also added a convenience `tox -e unittest` (🎩 @higs4281) that runs identically to `unittest-current`.

I've removed the `fast` and `slow` factors here and environments here; everything will run "slow," i.e. with migrations. As part of this, I've also removed the `NoMigrations` `MIGRATION_MODULE` and its dependencies. The acceptance test env will now run with full migrations (again, 🎩 @higs4281).

The intent here is to simplify the name of our test environments and make the naming version-independent.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
