### PR TITLE
Tests: warn on byte comparison to strings

### DIFF
--- a/cfgov/agreements/tests/test_legacy.py
+++ b/cfgov/agreements/tests/test_legacy.py
@@ -50,7 +50,7 @@ class Views(TestCase):
 
     def test_index_renders(self):
         response = self.client.get(reverse('agreements_home'))
-        str(response.content)
+        str(response.content.decode('utf-8'))
 
     @patch('agreements.views.render', return_value=HttpResponse())
     def test_index_with_agreements(self, render):

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -565,7 +565,7 @@ class Notification(DisclosureBase):
                             "response reason: {}\nstatus_code: {}\n"
                             "content: {}\n\n".format(
                                 now,
-                                endpoint,
+                                endpoint.decode('utf-8'),
                                 resp.reason,
                                 resp.status_code,
                                 resp.content)

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ deps=
     -r{toxinidir}/requirements/test.txt
 commands=
     coverage erase
-    coverage run --source='.' manage.py test {posargs}
+    python -b -m coverage run --source='.' manage.py test {posargs}
 
 
 [current-config]


### PR DESCRIPTION
Because Django 2.0 [removes support for bytestrings in some places](https://docs.djangoproject.com/en/2.0/releases/2.0/#removed-support-for-bytestrings-in-some-places), this change uses [Python's `-b` switch](https://docs.python.org/3/using/cmdline.html#cmdoption-b) to warn on these comparisons during test runs.

## Testing

Run `tox`. You'll see warnings like:

```
/Users/bartonw/repos/cfgov-refresh/.tox/unittest-py36-dj111-wag23-fast/lib/python3.6/site-packages/elasticsearch/client/utils.py:47: BytesWarning: Comparison between bytes and string
  quote_plus(_escape(p), b',*') for p in parts if p not in SKIP_IN_PATH)
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: