### PR TITLE
Fix byte comparison mismatch in PFC disclosures model

### DIFF
--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -565,7 +565,7 @@ class Notification(DisclosureBase):
                             "response reason: {}\nstatus_code: {}\n"
                             "content: {}\n\n".format(
                                 now,
-                                endpoint,
+                                endpoint.decode('utf-8'),
                                 resp.reason,
                                 resp.status_code,
                                 resp.content)


### PR DESCRIPTION
The disclosures model tries to format a byte string in a message. This makes the message unicode on both sides.