### PR TITLE
Mega Menu: Remove unused classes and add missing ones

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -55,7 +55,7 @@
         {% set aria_group_title = group.title ~ ' continued' if group.title_hidden else group.title %}
         <h4 class="h5
                   {{ base_class ~ '_group-heading' }}
-                  {{ base_class ~ '_group-heading' ~ '__hidden' if group.title_hidden else ''}}"
+                  {{ base_class ~ '_group-heading__hidden' if group.title_hidden else ''}}"
             id="{{ aria_group_title | slugify ~ '-menu' }}"
             aria-label="{{ aria_group_title }}">
             {{ group.title }}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -70,7 +70,7 @@
             aria-label="{{ nav_title | safe }}"
             {% endif %}>
             {% if nav_depth == 1 -%}
-            <li class="m-list_item {{ _classes( nav_depth, '-item' ) }}">
+            <li class="{{ _classes( nav_depth, '-item' ) }}">
                 {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
                 {{ global_header_cta.render( language=language ) }}
             </li>
@@ -123,7 +123,7 @@
             Back
         </button>
         {% endif %}
-        <div class="{{- _classes( nav_depth, '-grid', 'three-col' if nav_item.nav_groups | count < 4 else '' ) -}}">
+        <div class="{{- _classes( nav_depth, '-grid' ) -}}">
 
             {% if nav_depth > 1 and nav_overview_url and nav_overview_url != '#' %}
             <h3 class="{{ _classes( nav_depth, '-overview' ) }}
@@ -150,7 +150,7 @@
                     {% if nav_item.featured_items %}
                     <ul class="{{ _classes( nav_depth, '-list__featured-item' ) }}" aria-label="Featured">
                         {% for link in nav_item.featured_items | default( [], true ) %}
-                        <li>
+                        <li class="{{ _classes( nav_depth, '-item' ) }}">
                             <a class="{{ _classes( nav_depth, '-link' ) }}"
                                href="{{ link.url }}">
                                 {{ svg_icon( 'favorite' ) }}
@@ -161,9 +161,9 @@
                     </ul>
                     {% endif %}
 
-                    <ul class="m-list m-list__unstyled">
+                    <ul>
                         {% for link in nav_item.other_items | default( [], true ) %}
-                        <li>
+                        <li class="{{ _classes( nav_depth, '-item' ) }}">
                             <a class="a-link {{ _classes( nav_depth, '-link' ) }}"
                                href="{{ link.url }}">
                                 {{ svg_icon( link.icon ) }}
@@ -208,7 +208,7 @@
 {% macro _nav_item( nav_depth, nav_item, language='en' ) %}
 {% set has_children = nav_item.nav_groups or nav_item.nav_items %}
 {% set link = nav_item.overview if nav_item.overview else nav_item %}
-<li class="m-list_item {{ _classes( nav_depth, '-item' ) }}"
+<li class="{{ _classes( nav_depth, '-item' ) }}"
     {{ 'data-js-hook=behavior_flyout-menu' if has_children else '' }}>
     {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
     <a class="{{- 'u-link__disabled' if url == '' else '' -}}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -21,9 +21,8 @@
 {%- macro _classes( nav_depth, suffix='' ) -%}
 {%- set general_class = base_class ~ '_content' -%}
 {%- set depth_class = general_class ~ '-' ~ nav_depth -%}
-{%- set additional_class = depth_class ~ suffix -%}
 
-{{ general_class ~ suffix ~ ' ' ~ depth_class ~ suffix ~ ' ' ~ additional_class }}
+{{ general_class ~ suffix ~ ' ' ~ depth_class ~ suffix ~ ' ' }}
 {%- endmacro -%}
 
 

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -19,10 +19,10 @@
 
 {# TODO: Move to external macro so it can be shared with secondary nav. #}
 {%- macro _classes( nav_depth, suffix='' ) -%}
-{%- set general_class = base_class ~ '_content' -%}
-{%- set depth_class = general_class ~ '-' ~ nav_depth -%}
+{%- set general_class = base_class ~ '_content' ~ suffix -%}
+{%- set depth_class = base_class ~ '_content' ~ '-' ~ nav_depth ~ suffix -%}
 
-{{ general_class ~ suffix ~ ' ' ~ depth_class ~ suffix ~ ' ' }}
+{{ general_class ~ ' ' ~ depth_class ~ ' ' }}
 {%- endmacro -%}
 
 

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -15,15 +15,13 @@
    suffix:    Suffix to add to the classes.
               Default is ''.
 
-   additional_suffix: Optional additional class suffix.
-
    ========================================================================== #}
 
 {# TODO: Move to external macro so it can be shared with secondary nav. #}
-{%- macro _classes( nav_depth, suffix='', additional_suffix='' ) -%}
+{%- macro _classes( nav_depth, suffix='' ) -%}
 {%- set general_class = base_class ~ '_content' -%}
 {%- set depth_class = general_class ~ '-' ~ nav_depth -%}
-{%- set additional_class = depth_class ~ suffix ~ '__' ~  additional_suffix if additional_suffix else '' -%}
+{%- set additional_class = depth_class ~ suffix -%}
 
 {{ general_class ~ suffix ~ ' ' ~ depth_class ~ suffix ~ ' ' ~ additional_class }}
 {%- endmacro -%}
@@ -146,7 +144,8 @@
                 {{ _nav_list( nav_depth, nav_item.nav_groups, nav_overview_text, language=language ) }}
 
                 {% if nav_item.featured_items or nav_item.other_items %}
-                <div class="{{ _classes( nav_depth, '-list' ) }} {{ _classes( nav_depth, '-list__featured' ) }} ">
+                <div class="{{ _classes( nav_depth, '-list' ) }}
+                            {{ _classes( nav_depth, '-list__featured' ) }} ">
                     {% if nav_item.featured_items %}
                     <ul class="{{ _classes( nav_depth, '-list__featured-item' ) }}" aria-label="Featured">
                         {% for link in nav_item.featured_items | default( [], true ) %}

--- a/test/unit_tests/js/organisms/MegaMenu-spec.js
+++ b/test/unit_tests/js/organisms/MegaMenu-spec.js
@@ -17,7 +17,7 @@ const HTML_SNIPPET = `
     <div class="o-mega-menu_content o-mega-menu_content-1 u-hidden-overflow u-move-transition u-move-to-origin" aria-expanded="false" data-js-hook="behavior_flyout-menu_content">
         <div class="o-mega-menu_content-wrapper o-mega-menu_content-1-wrapper ">
 
-            <div class="o-mega-menu_content-grid o-mega-menu_content-1-grid o-mega-menu_content-1-grid__three-col">
+            <div class="o-mega-menu_content-grid o-mega-menu_content-1-grid">
 
                 <div class="o-mega-menu_content-lists o-mega-menu_content-1-lists ">
 
@@ -50,7 +50,7 @@ const HTML_SNIPPET = `
                                                 Back
                                             </button>
 
-                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid o-mega-menu_content-2-grid__three-col">
+                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
                                                 <h3 class="o-mega-menu_content-overview o-mega-menu_content-2-overview o-mega-menu_content-overview-heading o-mega-menu_content-2-overview-heading">
                                                     <span class="o-mega-menu_content-overview-heading-text o-mega-menu_content-2-overview-heading-text ">Consumer Tools</span>
                                                 </h3>
@@ -167,7 +167,7 @@ const HTML_SNIPPET = `
                                                 Back
                                             </button>
 
-                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid o-mega-menu_content-2-grid__three-col">
+                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
 
                                                 <h3 class="o-mega-menu_content-overview o-mega-menu_content-2-overview o-mega-menu_content-overview-heading o-mega-menu_content-2-overview-heading">
                                                     <a class="o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link" href="https://content.consumerfinance.gov/data-research/">Data &amp; Research Overview</a>

--- a/test/unit_tests/js/organisms/MegaMenuMobile-spec.js
+++ b/test/unit_tests/js/organisms/MegaMenuMobile-spec.js
@@ -17,7 +17,7 @@ const HTML_SNIPPET = `
     <div class="o-mega-menu_content o-mega-menu_content-1 u-hidden-overflow u-move-transition u-move-to-origin" aria-expanded="false" data-js-hook="behavior_flyout-menu_content">
         <div class="o-mega-menu_content-wrapper o-mega-menu_content-1-wrapper ">
 
-            <div class="o-mega-menu_content-grid o-mega-menu_content-1-grid o-mega-menu_content-1-grid__three-col">
+            <div class="o-mega-menu_content-grid o-mega-menu_content-1-grid">
 
                 <div class="o-mega-menu_content-lists o-mega-menu_content-1-lists ">
 
@@ -49,7 +49,7 @@ const HTML_SNIPPET = `
                                                 Back
                                             </button>
 
-                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid o-mega-menu_content-2-grid__three-col">
+                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
                                                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview ">
                                                     <a class="u-link__disabled
                                                               o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
@@ -169,7 +169,7 @@ const HTML_SNIPPET = `
                                                 Back
                                             </button>
 
-                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid o-mega-menu_content-2-grid__three-col">
+                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
 
                                                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview ">
                                                     <a class="o-mega-menu_content-overview-link
@@ -244,7 +244,7 @@ const HTML_SNIPPET = `
                                                 Back
                                             </button>
 
-                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid o-mega-menu_content-2-grid__three-col">
+                                            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
 
                                                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview ">
                                                     <a class="o-mega-menu_content-overview-link
@@ -337,7 +337,7 @@ const HTML_SNIPPET = `
                                                                                 Back
                                                                             </button>
 
-                                                                            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid o-mega-menu_content-3-grid__three-col">
+                                                                            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
 
                                                                                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview ">
                                                                                     <a class="o-mega-menu_content-overview-link


### PR DESCRIPTION
Unused `o-mega-menu_content-grid__three-col` class, which is no longer needed as there will always be four columns.

## Removals

- Unused `o-mega-menu_content-grid__three-col` class.
- Unneeded `m-list` classes.
- Remove `additional_suffix` argument from `_classes` helper.

## Changes

- Adds missing `o-mega-menu_content-item` class to menu `li` items.

## Testing

1. Pull branch and build
2. Compare to production. The only difference should be that the featured items at mobile get separator lines:

## Screenshots

Before:
<img width="376" alt="Screen Shot 2020-03-16 at 3 52 30 PM" src="https://user-images.githubusercontent.com/704760/76794792-32067880-679e-11ea-984a-e469de8a2dc6.png">

After:
<img width="379" alt="Screen Shot 2020-03-16 at 3 52 25 PM" src="https://user-images.githubusercontent.com/704760/76794796-3468d280-679e-11ea-8331-5ee83a2cd54e.png">
