### PR TITLE
Fix test that called 'str' on a bytes object

### DIFF
--- a/cfgov/agreements/tests/test_legacy.py
+++ b/cfgov/agreements/tests/test_legacy.py
@@ -50,7 +50,7 @@ class Views(TestCase):
 
     def test_index_renders(self):
         response = self.client.get(reverse('agreements_home'))
-        str(response.content)
+        str(response.content.decode('utf-8'))
 
     @patch('agreements.views.render', return_value=HttpResponse())
     def test_index_with_agreements(self, render):


### PR DESCRIPTION
Fix test that called `str` on a bytes object

The remaining warnings come from our elasticsearch library, which is ancient.  
Unfortunately, upgrading elasticsearch to the latest doesn't fix it.