### PR TITLE
Mega Menu and Global Search: Adds hover states for mobile buttons

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -141,6 +141,14 @@
         .js & {
             display: block;
         }
+
+        // Hover state for (x) close button.
+        &:hover {
+            border-left: 1px solid @gray-40;
+
+            // Important needed to override background color in expanded state.
+            background: @gray-20 !important;
+        }
     }
 
     &_content {

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -323,6 +323,10 @@ body {
                 }
             }
 
+            // Hover state for (x) close button.
+            &:hover {
+                background: @gray-20;
+            }
         }
 
         // Menu flyout.
@@ -368,6 +372,11 @@ body {
 
                 .cf-icon-svg {
                     margin-right: 0.6em;
+                }
+
+                // Hover state for back button.
+                &:hover {
+                    background: @gray-20;
                 }
             }
 


### PR DESCRIPTION
## Changes

- Add gray-20 hover state to (x) close buttons and "back" button of the mobile menu and global search.

## Testing

1. Pull branch and build.
2. Visit localhost and resize to mobile view.
3. hover over (x) close buttons and "back" button.

## Screenshots

![hover](https://user-images.githubusercontent.com/704760/77182961-fd4b3780-6aa3-11ea-8c4a-af838d83aadf.gif)
@huetingj 