### PR TITLE
Improved desktop mega menu link highlighting

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -113,7 +113,7 @@
 
    ========================================================================== #}
 
-{% macro _nav_level( nav_depth, nav_item, nav_overview_url, nav_overview_text, language='en' ) %}
+{% macro _nav_level( nav_depth, nav_item, overview_link=none, language='en' ) %}
 <section class="{{- _content_classes( nav_depth ) -}}"
          aria-expanded="false"
          data-js-hook="behavior_flyout-menu_content">
@@ -129,13 +129,13 @@
 
     <div class="{{- _content_classes( nav_depth, '-wrapper' ) -}}">
 
-        {% if nav_depth > 1 and nav_overview_url and nav_overview_url != '#' %}
+        {% if overview_link and overview_link.url %}
         <h3 class="{{ _content_classes( nav_depth, '-overview' ) }}
                     {{ _content_classes( nav_depth, '-overview-heading' ) }}">
             <a class="{{ _content_classes( nav_depth, '-overview-link' ) }}
-                        {{ _content_classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
-                        {{ '' if nav_overview_url == request.path or nav_overview_url == '#' else 'href=' + nav_overview_url | e }}>
-                {{ nav_overview_text ~ ' Overview' }}
+                        {{ _content_classes( nav_depth, '-overview-link__current' ) if overview_link.selected else '' }}"
+               href="{{ overview_link.url }}">
+                {{ overview_link.text ~ ' Overview' }}
             </a>
         </h3>
         {% endif %}
@@ -147,8 +147,7 @@
 
         {% if nav_item.nav_groups %}
         <div class="{{ _content_classes( nav_depth, '-lists' ) }}">
-
-            {{ _nav_list( nav_depth, nav_item.nav_groups, nav_overview_text, language=language ) }}
+            {{ _nav_list( nav_depth, nav_item.nav_groups, overview_link.text, language=language ) }}
 
             {% if nav_item.featured_items or nav_item.other_items %}
 
@@ -184,7 +183,9 @@
                         {% for link in nav_item.other_items | default( [], true ) %}
                         <li class="{{ _content_classes( nav_depth, '-item' ) }}
                                     {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
-                            <a class="a-link {{ _content_classes( nav_depth, '-link' ) }}"
+                            <a class="a-link
+                                      {{ _content_classes( nav_depth, '-link' ) }}
+                                      {{ _content_classes( nav_depth, '-link__current' ) if link.selected else '' }}"
                             href="{{ link.url }}">
                                 {{ svg_icon( link.icon ) }}
                                 <span><span class="a-link_text">{{ link.text }}</span></span>
@@ -232,11 +233,9 @@
 <li class="{{ _content_classes( nav_depth, '-item' ) }}
            {{- _content_classes( nav_depth, '-item__has-icon' ) if link.icon_pre else '' -}}"
     {{ 'data-js-hook=behavior_flyout-menu' if has_children else '' }}>
-    {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
-    <a class="{{- 'u-link__disabled' if url == '' else '' -}}
-              {{- _content_classes( nav_depth, '-link' ) -}}
+    <a class="{{- _content_classes( nav_depth, '-link' ) -}}
               {{- _content_classes( nav_depth, '-link__has-children' ) if has_children else '' -}}
-              {{- _content_classes( nav_depth, '-link__current' ) if url == request.path else '' -}}"
+              {{- _content_classes( nav_depth, '-link__current' ) if nav_item.selected else '' -}}"
        href="{{ link.url | default( '#' ) }}"
        {{
          'data-js-hook=behavior_flyout-menu_trigger
@@ -256,7 +255,7 @@
           {% endif %}
     </a>
     {% if has_children %}
-        {{ _nav_level( nav_depth | int + 1, nav_item, link.url, link.text, language ) }}
+        {{ _nav_level( nav_depth + 1, nav_item, link, language ) }}
     {% endif %}
 </li>
 {% endmacro %}

--- a/cfgov/mega_menu/tests/test_frontend_conversion.py
+++ b/cfgov/mega_menu/tests/test_frontend_conversion.py
@@ -94,7 +94,7 @@ class FrontendConverterTests(TestCase):
         return page
 
     def do_conversion(self, menu):
-        request = RequestFactory().get('/')
+        request = RequestFactory().get('/consumer-tools/')
         converter = FrontendConverter(menu, request=request)
         return converter.get_menu_items()
 
@@ -117,12 +117,13 @@ class FrontendConverterTests(TestCase):
             self.do_conversion(self.menu)
 
     def test_conversion_output(self):
-        self.maxDiff = None
         self.assertEqual(self.do_conversion(self.menu), [
             {
+                'selected': True,
                 'overview': {
                     'url': '/consumer-tools/',
                     'text': 'Consumer Tools',
+                    'selected': True,
                 },
                 'nav_groups': [
                     {

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -186,6 +186,15 @@ body {
         &-link,
         &-overview-link {
             width: 100%;
+
+            &__current,
+            &:hover {
+                cursor: pointer;
+
+                .cf-icon-svg {
+                    fill: @black;
+                }
+            }
         }
 
         // Ensure desktop up/down arrow link icons don't appear at mobile.
@@ -418,15 +427,6 @@ body {
                         fill: @green;
                     }
                 }
-
-                &__current,
-                &:hover {
-                    cursor: pointer;
-
-                    .cf-icon-svg {
-                        fill: @black;
-                    }
-                }
             }
 
             &-overview-heading-text {
@@ -643,23 +643,28 @@ body {
                     border-bottom: none;
                 }
 
+                // This creates the hover/selection line.
+                // We can't use a border here as it will get a slant on
+                // the edges because there are transparent left/right
+                // borders.
+                &:after {
+                    position: absolute;
+                    left: 0;
+                    top: unit( 46px / @base-font-size-px, em );
+                    content: '';
+                    background: transparent;
+                    width: 100%;
+                    height: unit( 6px / @base-font-size-px, em );
+                }
+
                 &:hover {
                     padding-bottom: ( @grid_gutter-width / 2) - 6px;
                     border-bottom: 6px solid transparent;
                     cursor: pointer;
 
-                    // This creates the hover line.
-                    // We can't use a border here as it will get a slant on
-                    // the edges because there are transparent left/right
-                    // borders.
+                    // Change hover border color.
                     &:after {
-                        position: absolute;
-                        left: 0;
-                        top: unit( 46px / @base-font-size-px, em );
-                        content: '';
                         background: @gray-40;
-                        width: 100%;
-                        height: unit( 6px / @base-font-size-px, em );
                     }
                 }
 
@@ -729,6 +734,18 @@ body {
                 // Add padding to accommodate caret.
                 &__has-children {
                     padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
+                }
+
+                &__current {
+                    // Change the selection bar to black.
+                    &:after {
+                        background-color: @black;
+                    }
+                }
+
+                &__current[aria-expanded="true"]:after,
+                &__current:active:after {
+                    background-color: transparent;
                 }
             }
         }


### PR DESCRIPTION
This PR improves how mega menu link highlights work depending on the current page being visited. With this change, the top-level menu gets a highlight if you are on either any of its links or any of its links' children (deliberately excluding featured links, which may point to a different menu). Similarly, a specific menu link gets a highlight using the same logic.

These changes only apply to desktop, and do not affect the mobile design.

See below for some specific examples.

@contolini 

## Testing

First you'll need to rebuild using `gulp clean && gulp build`. The links below can be tested using a recent production dump.

## Screenshots

[Homepage](http://localhost:8000/) highlights nothing:

![image](https://user-images.githubusercontent.com/654645/77180508-66c94700-6aa0-11ea-8bc1-07666ee44795.png)

[Overview page](http://localhost:8000/consumer-tools/) highlights that menu, and the overview link:

![image](https://user-images.githubusercontent.com/654645/77180538-7779bd00-6aa0-11ea-883d-f9aac01f42ae.png)

![image](https://user-images.githubusercontent.com/654645/77180559-7d6f9e00-6aa0-11ea-9e01-643f20f13455.png)

[Menu link page](http://localhost:8000/consumer-tools/auto-loans/) highlights its menu and the link:

![image](https://user-images.githubusercontent.com/654645/77180643-9d9f5d00-6aa0-11ea-982b-2ce93e350c4a.png)
![image](https://user-images.githubusercontent.com/654645/77180661-a3953e00-6aa0-11ea-95ea-643b9fbfdbf1.png)

[Child of menu link page](http://localhost:8000/consumer-tools/auto-loans/answers/key-terms/) also highlights its menu and its parent menu link:

![image](https://user-images.githubusercontent.com/654645/77180726-b9a2fe80-6aa0-11ea-9560-58775ca16ec8.png)
![image](https://user-images.githubusercontent.com/654645/77180745-be67b280-6aa0-11ea-9930-0aa543ebc732.png)

Note that this same logic applies to Spanish, for example [a Spanish Ask page](http://localhost:8000/es/obtener-respuestas/como-puedo-conseguir-dinero-rapidamente-despues-de-depositar-un-cheque-en-mi-cuenta-de-cheques-que-es-un-deposito-en-retencion-es-1023/) highlights the Ask menu item:

![image](https://user-images.githubusercontent.com/654645/77181993-777abc80-6aa2-11ea-8628-563602020acf.png)

## Todos

It feels like the open menu should also get some kind of highlighting. It feels off that there's this strong black bar that then goes away when the menu opens. What do you think @huetingj @sonnakim @stephanieosan?

![ct](https://user-images.githubusercontent.com/654645/77180974-13a3c400-6aa1-11ea-984d-4ec3fcde3f0a.gif)

Also, this combination of selected/highlight state doesn't look great for the sidebar links:

![image](https://user-images.githubusercontent.com/654645/77181456-b9efc980-6aa1-11ea-8aee-ad3aa5375bfd.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: