### PR TITLE
Mega Menu: Remove `o-mega-menu_content-grid` container

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -117,89 +117,88 @@
 <section class="{{- _content_classes( nav_depth ) -}}"
          aria-expanded="false"
          data-js-hook="behavior_flyout-menu_content">
+
+    {# Create "back" button in mobile menu. #}
+    {% if nav_depth > 1 %}
+    <button class="{{- _content_classes( nav_depth, '-alt-trigger' ) -}}"
+            data-js-hook="behavior_flyout-menu_alt-trigger">
+        {{ svg_icon('left') }}
+        Back
+    </button>
+    {% endif %}
+
     <div class="{{- _content_classes( nav_depth, '-wrapper' ) -}}">
-        {# Open wrapper if needed #}
-        {% if nav_depth > 1 %}
-        <button class="{{- _content_classes( nav_depth, '-alt-trigger' ) -}}"
-                data-js-hook="behavior_flyout-menu_alt-trigger">
-            {{ svg_icon('left') }}
-            Back
-        </button>
+
+        {% if nav_depth > 1 and nav_overview_url and nav_overview_url != '#' %}
+        <h3 class="{{ _content_classes( nav_depth, '-overview' ) }}
+                    {{ _content_classes( nav_depth, '-overview-heading' ) }}">
+            <a class="{{ _content_classes( nav_depth, '-overview-link' ) }}
+                        {{ _content_classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
+                        {{ '' if nav_overview_url == request.path or nav_overview_url == '#' else 'href=' + nav_overview_url | e }}>
+                {{ nav_overview_text ~ ' Overview' }}
+            </a>
+        </h3>
         {% endif %}
-        <div class="{{- _content_classes( nav_depth, '-grid' ) -}}">
 
-            {% if nav_depth > 1 and nav_overview_url and nav_overview_url != '#' %}
-            <h3 class="{{ _content_classes( nav_depth, '-overview' ) }}
-                       {{ _content_classes( nav_depth, '-overview-heading' ) }}">
-                <a class="{{ _content_classes( nav_depth, '-overview-link' ) }}
-                            {{ _content_classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
-                            {{ '' if nav_overview_url == request.path or nav_overview_url == '#' else 'href=' + nav_overview_url | e }}>
-                    {{ nav_overview_text ~ ' Overview' }}
-                </a>
-            </h3>
-            {% endif %}
+        {# TODO: Make the following menu markup use the _nav_item macro. #}
+        {% if nav_item.nav_items %}
+            {% set temp = nav_item.update({'nav_groups': [{'nav_items': nav_item.nav_items}]}) %}
+        {% endif %}
 
-            {# TODO: Make the following menu markup use the _nav_item macro. #}
-            {% if nav_item.nav_items %}
-                {% set temp = nav_item.update({'nav_groups': [{'nav_items': nav_item.nav_items}]}) %}
-            {% endif %}
+        {% if nav_item.nav_groups %}
+        <div class="{{ _content_classes( nav_depth, '-lists' ) }}">
 
-            {% if nav_item.nav_groups %}
-            <div class="{{ _content_classes( nav_depth, '-lists' ) }}">
+            {{ _nav_list( nav_depth, nav_item.nav_groups, nav_overview_text, language=language ) }}
 
-                {{ _nav_list( nav_depth, nav_item.nav_groups, nav_overview_text, language=language ) }}
+            {% if nav_item.featured_items or nav_item.other_items %}
 
-                {% if nav_item.featured_items or nav_item.other_items %}
+            <div class="{{ _content_classes( nav_depth, '-list-group' ) }}">
 
-                <div class="{{ _content_classes( nav_depth, '-list-group' ) }}">
-
-                    {% if nav_item.featured_items %}
-                    <div class="{{ _content_classes( nav_depth, '-list' ) }}
-                                {{ _content_classes( nav_depth, '-list__featured' ) }}">
-                        <h4 class="h5 {{ base_class ~ '_group-heading' }}">
-                            Featured
-                        </h4>
-                        <ul aria-label="Featured">
-                            {% for link in nav_item.featured_items | default( [], true ) %}
-                            <li class="{{ _content_classes( nav_depth, '-item' ) }}
-                                       {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
-                                <a class="{{ _content_classes( nav_depth, '-link' ) }}"
-                                   href="{{ link.url }}">
-                                    {{ svg_icon( 'favorite' ) }}
-                                    <span><span class="a-link_text">{{ link.text }}</span></span>
-                                </a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                    {% endif %}
-
-                    {% if nav_item.other_items %}
-                    <div class="{{ _content_classes( nav_depth, '-list' ) }}">
-                        <h4 class="h5 {{ base_class ~ '_group-heading' }}">
-                            Additional Resources
-                        </h4>
-                        <ul aria-label="Additional Resources">
-                            {% for link in nav_item.other_items | default( [], true ) %}
-                            <li class="{{ _content_classes( nav_depth, '-item' ) }}
-                                       {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
-                                <a class="a-link {{ _content_classes( nav_depth, '-link' ) }}"
+                {% if nav_item.featured_items %}
+                <div class="{{ _content_classes( nav_depth, '-list' ) }}
+                            {{ _content_classes( nav_depth, '-list__featured' ) }}">
+                    <h4 class="h5 {{ base_class ~ '_group-heading' }}">
+                        Featured
+                    </h4>
+                    <ul aria-label="Featured">
+                        {% for link in nav_item.featured_items | default( [], true ) %}
+                        <li class="{{ _content_classes( nav_depth, '-item' ) }}
+                                    {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
+                            <a class="{{ _content_classes( nav_depth, '-link' ) }}"
                                 href="{{ link.url }}">
-                                    {{ svg_icon( link.icon ) }}
-                                    <span><span class="a-link_text">{{ link.text }}</span></span>
-                                </a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                    {% endif %}
-
+                                {{ svg_icon( 'favorite' ) }}
+                                <span><span class="a-link_text">{{ link.text }}</span></span>
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
                 </div>
                 {% endif %}
+
+                {% if nav_item.other_items %}
+                <div class="{{ _content_classes( nav_depth, '-list' ) }}">
+                    <h4 class="h5 {{ base_class ~ '_group-heading' }}">
+                        Additional Resources
+                    </h4>
+                    <ul aria-label="Additional Resources">
+                        {% for link in nav_item.other_items | default( [], true ) %}
+                        <li class="{{ _content_classes( nav_depth, '-item' ) }}
+                                    {{ _content_classes( nav_depth, '-item__has-icon' ) }}">
+                            <a class="a-link {{ _content_classes( nav_depth, '-link' ) }}"
+                            href="{{ link.url }}">
+                                {{ svg_icon( link.icon ) }}
+                                <span><span class="a-link_text">{{ link.text }}</span></span>
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endif %}
+
             </div>
             {% endif %}
-
         </div>
+        {% endif %}
     </div>
 
     {% if nav_depth == 1 %}

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -38,78 +38,74 @@ body {
             <div class="o-mega-menu_content"
                  aria-expanded="false">
                 <div class="o-mega-menu_content-wrapper">
-                    <div class="o-mega-menu_content-grid">
-                        <div class="o-mega-menu-lists">
-                            <ul class="o-mega-menu_content-list">
-                                <li class="o-mega-menu_content-item">
-                                    [Global Header CTA]
-                                </li>
-                                <li class="o-mega-menu_content-item">
-                                    <a class="o-mega-menu_content-link"
-                                        href="/about-us/"
+                    <div class="o-mega-menu-lists">
+                        <ul class="o-mega-menu_content-list">
+                            <li class="o-mega-menu_content-item">
+                                [Global Header CTA]
+                            </li>
+                            <li class="o-mega-menu_content-item">
+                                <a class="o-mega-menu_content-link"
+                                    href="/about-us/"
+                                    aria-expanded="false">
+                                    About Us
+                                </a>
+                                <div class="o-mega-menu_content"
                                         aria-expanded="false">
-                                        About Us
-                                    </a>
-                                    <div class="o-mega-menu_content"
-                                            aria-expanded="false">
-                                        <div class="o-mega-menu_content-wrapper">
-                                            <div class="wrapper">
-                                                <button class="o-mega-menu_content-alt-trigger">
-                                                    Back
-                                                </button>
-                                                <div class="o-mega-menu_content-grid">
-                                                    <span class="o-mega-menu_content-overview">
-                                                        <h3 class="o-mega-menu_content-overview-heading">
-                                                            <a class="o-mega-menu_content-overview-link"
-                                                                href="/about-us/">
-                                                                About Us Overview
-                                                            </a>
-                                                        </h3>
-                                                    </span>
-                                                    <div class="o-mega-menu_content-lists">
-                                                        <div class="o-mega-menu_content-list-group">
-                                                            <div class="o-mega-menu_content-list">
+                                    <div class="o-mega-menu_content-wrapper">
+                                        <div class="wrapper">
+                                            <button class="o-mega-menu_content-alt-trigger">
+                                                Back
+                                            </button>
+                                            <span class="o-mega-menu_content-overview">
+                                                <h3 class="o-mega-menu_content-overview-heading">
+                                                    <a class="o-mega-menu_content-overview-link"
+                                                        href="/about-us/">
+                                                        About Us Overview
+                                                    </a>
+                                                </h3>
+                                            </span>
+                                            <div class="o-mega-menu_content-lists">
+                                                <div class="o-mega-menu_content-list-group">
+                                                    <div class="o-mega-menu_content-list">
 
-                                                                <ul class="m-list
-                                                                            m-list__unstyled
-                                                                            o-mega-menu_content-list">
-                                                                    <li class="m-list_item
-                                                                                o-mega-menu_content-item">
-                                                                        <a class="o-mega-menu_content-link"
-                                                                            href="/the-bureau/">
-                                                                            The Bureau
-                                                                            </a>
-                                                                    </li>
-                                                                    …
-                                                                </ul>
-                                                                <ul class="m-list
-                                                                            m-list__unstyled
-                                                                            o-mega-menu_content-list">
-                                                                        <li class="m-list_item
-                                                                                    o-mega-menu_content-item">
-                                                                            <a class="o-mega-menu_content-link__current
-                                                                                        o-mega-menu_content-link"
-                                                                                href="/about-us/careers/">
-                                                                                Careers
-                                                                                </a>
-                                                                        </li>
-                                                                        …
-                                                                </ul>
-                                                            </div>
+                                                        <ul class="m-list
+                                                                    m-list__unstyled
+                                                                    o-mega-menu_content-list">
+                                                            <li class="m-list_item
+                                                                        o-mega-menu_content-item">
+                                                                <a class="o-mega-menu_content-link"
+                                                                    href="/the-bureau/">
+                                                                    The Bureau
+                                                                    </a>
+                                                            </li>
                                                             …
-                                                        </div>
+                                                        </ul>
+                                                        <ul class="m-list
+                                                                    m-list__unstyled
+                                                                    o-mega-menu_content-list">
+                                                                <li class="m-list_item
+                                                                            o-mega-menu_content-item">
+                                                                    <a class="o-mega-menu_content-link__current
+                                                                                o-mega-menu_content-link"
+                                                                        href="/about-us/careers/">
+                                                                        Careers
+                                                                        </a>
+                                                                </li>
+                                                                …
+                                                        </ul>
                                                     </div>
+                                                    …
                                                 </div>
-                                                <aside class="sub-nav_media">
-                                                    [Featured Menu Content]
-                                                </aside>
                                             </div>
+                                            <aside class="sub-nav_media">
+                                                [Featured Menu Content]
+                                            </aside>
                                         </div>
                                     </div>
-                                </li>
-                            </ul>
-                            [Global Eyebrow]
-                        </div>
+                                </div>
+                            </li>
+                        </ul>
+                        [Global Eyebrow]
                     </div>
                 </div>
             </div>
@@ -123,36 +119,32 @@ body {
                 .o-mega-menu_trigger
             .o-mega-menu_content
                 .o-mega-menu_content-wrapper
-                    .wrapper
-                        .o-mega-menu-content-grid
-                            .o-mega-menu_content-overview
-                                .o-mega-menu_content-overview-heading
-                                    .o-mega-menu_content-overview-link
-                            .o-mega-menu_content-title
-                                a.o-mega-menu_content-link
-                            .o-mega-menu_content-lists
-                                .o-mega-menu_content-list-group
-                                    .o-mega-menu_content-list
-                                        ul
-                                            li.o-mega-menu_content-item
-                                                .m-global-header-cta.m-global-header-cta__list
-                                            li.o-mega-menu_content-item
-                                                a.o-mega-menu_content-link
-                                            li.o-mega-menu_content-item
-                                                a.o-mega-menu_content-link
-                                                .o-mega-menu_content
-                                                    .o-mega-menu_content-wrapper
-                                                        .wrapper
-                                                            button.o-mega-menu_content-alt-trigger
-                                                            .o-mega-menu_content-grid
-                                                                .o-mega-menu_content-title
-                                                                    a.o-mega-menu_content-link
-                                                                .o-mega-menu_content-lists
-                                                                    ul.o-mega-menu_content-list
-                                                                        li.o-mega-menu_content-item
-                                                                    ul.o-mega-menu_content-list
-                                                                        li.o-mega-menu_content-item
-                                                            aside.sub-nav_media
+                    .o-mega-menu_content-overview
+                        .o-mega-menu_content-overview-heading
+                            .o-mega-menu_content-overview-link
+                    .o-mega-menu_content-title
+                        a.o-mega-menu_content-link
+                    .o-mega-menu_content-lists
+                        .o-mega-menu_content-list-group
+                            .o-mega-menu_content-list
+                                ul
+                                    li.o-mega-menu_content-item
+                                        .m-global-header-cta.m-global-header-cta__list
+                                    li.o-mega-menu_content-item
+                                        a.o-mega-menu_content-link
+                                    li.o-mega-menu_content-item
+                                        a.o-mega-menu_content-link
+                                        .o-mega-menu_content
+                                            .o-mega-menu_content-wrapper
+                                                button.o-mega-menu_content-alt-trigger
+                                                .o-mega-menu_content-title
+                                                    a.o-mega-menu_content-link
+                                                .o-mega-menu_content-lists
+                                                    ul.o-mega-menu_content-list
+                                                        li.o-mega-menu_content-item
+                                                    ul.o-mega-menu_content-list
+                                                        li.o-mega-menu_content-item
+                                            aside.sub-nav_media
       notes:
         - "Not shown, but each content level adds a depth-specific class,
            such as o-mega-menu_content-1, o-mega-menu_content-2, etc."
@@ -376,7 +368,7 @@ body {
                 border-bottom: 1px solid @gray-40;
             }
 
-            &-grid {
+            &-wrapper {
                 padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, rem );
                 padding-left: unit( @grid_gutter-width / @base-font-size-px, rem );
             }
@@ -535,7 +527,7 @@ body {
             top: -1px;
             z-index: 10;
 
-            &-grid {
+            &-wrapper {
                 padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             }
@@ -808,7 +800,7 @@ body {
 
                 padding: unit( @grid_gutter-width / @base-font-size-px, em );
                 padding-top: unit( 20px / @base-font-size-px, em );
-                padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+                padding-left: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em );
                 padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
             }
 
@@ -844,10 +836,6 @@ body {
 
             &-list-group:last-child {
                 padding-right: 0;
-            }
-
-            &-grid {
-                padding-left: @grid_gutter-width;
             }
 
             &-link,


### PR DESCRIPTION
We had the structure:
```
.o-mega-menu_content-wrapper
  .o-mega-menu_content-grid
```
Which just adds padding. So these containers can be combined. One markup change is that the "back" button was a child of the `-wrapper` container and has been moved to be a sibling.

## Removals

- Removes `o-mega-menu_content-grid` container.

## Testing

1. Pull branch and build.
2. Mega menu layout should be unchanged from production at all screen sizes.
