### PR TITLE
Replace use of model-mommy with model-bakery

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -16,7 +16,7 @@ from haystack.query import SearchQuerySet
 from wagtail.core.blocks import StreamValue
 from wagtail.tests.utils import WagtailTestUtils
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from ask_cfpb.models.django import (
     ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG, Answer, Category, NextStep
@@ -599,20 +599,20 @@ class AnswerPageTestCase(TestCase):
         kwargs.setdefault('depth', self.english_parent_page.depth + 1)
         kwargs.setdefault('slug', 'mock-answer-page-en-1234')
         kwargs.setdefault('title', 'Mock answer page title')
-        page = mommy.prepare(AnswerPage, **kwargs)
+        page = baker.prepare(AnswerPage, **kwargs)
         page.save()
         return page
 
     def setUp(self):
         self.test_user = User.objects.get(pk=1)
         ROOT_PAGE = HomePage.objects.get(slug='cfgov')
-        self.category = mommy.make(
+        self.category = baker.make(
             Category, name='stub_cat', name_es='que', slug='stub-cat')
         self.category.save()
-        self.test_image = mommy.make(CFGOVImage)
-        self.test_image2 = mommy.make(CFGOVImage)
-        self.next_step = mommy.make(NextStep, title='stub_step')
-        self.portal_topic = mommy.make(
+        self.test_image = baker.make(CFGOVImage)
+        self.test_image2 = baker.make(CFGOVImage)
+        self.next_step = baker.make(NextStep, title='stub_step')
+        self.portal_topic = baker.make(
             PortalTopic,
             heading='test topic',
             heading_es='prueba tema')
@@ -1070,7 +1070,7 @@ class AnswerPageTestCase(TestCase):
 
     def test_answer_meta_image_uses_category_image_if_no_social_image(self):
         """ Answer page's meta image is its category's image """
-        category = mommy.make(Category, category_image=self.test_image)
+        category = baker.make(Category, category_image=self.test_image)
         page = self.page1
         page.category.add(category)
         page.save_revision()

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -11,7 +11,7 @@ from wagtail.core.models import Site
 from wagtailsharing.models import SharingSite
 
 import mock
-from model_mommy import mommy
+from model_bakery import baker
 
 from ask_cfpb.models import (
     ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG, AnswerPage
@@ -59,8 +59,8 @@ class AnswerPagePreviewCase(TestCase):
             self.ROOT_PAGE,
             language='es',
             live=True)
-        self.test_answer = mommy.make(Answer)
-        self.test_answer2 = mommy.make(Answer)
+        self.test_answer = baker.make(Answer)
+        self.test_answer2 = baker.make(Answer)
         self.english_answer_page = AnswerPage(
             answer_base=self.test_answer,
             language='en',
@@ -79,13 +79,13 @@ class AnswerPagePreviewCase(TestCase):
             question='Test question2.')
         self.english_parent_page.add_child(instance=self.english_answer_page2)
         self.english_answer_page2.save_revision().publish()
-        self.site = mommy.make(
+        self.site = baker.make(
             Site,
             root_page=self.ROOT_PAGE,
             hostname='localhost',
             port=8000,
             is_default_site=True)
-        self.sharing_site = mommy.make(
+        self.sharing_site = baker.make(
             SharingSite,
             site=self.site,
             hostname='preview.localhost',

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -4,7 +4,7 @@ import unittest
 import django
 from django.http import HttpRequest
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from data_research.models import (
     County, CountyMortgageData, MetroArea, MortgageBase, MortgageDataConstant,
@@ -24,7 +24,7 @@ class GeoValidationTests(django.test.TestCase):
 
     def setUp(self):
 
-        mommy.make(
+        baker.make(
             State,
             fips='12',
             name='Florida',
@@ -34,7 +34,7 @@ class GeoValidationTests(django.test.TestCase):
             non_msa_counties=["12013"],
             msas=["45300", "35840", "45220"])
 
-        mommy.make(
+        baker.make(
             State,
             fips='34',
             name='New Jersey',
@@ -44,7 +44,7 @@ class GeoValidationTests(django.test.TestCase):
             non_msa_counties=[],
             msas=[])
 
-        mommy.make(
+        baker.make(
             MetroArea,
             fips='45220',
             name='Tallahassee, FL',
@@ -52,7 +52,7 @@ class GeoValidationTests(django.test.TestCase):
             states=['12'],
             valid=False)
 
-        mommy.make(
+        baker.make(
             MetroArea,
             fips='35840',
             name='North Port-Sarasota-Bradenton, FL',
@@ -60,28 +60,28 @@ class GeoValidationTests(django.test.TestCase):
             states=['12'],
             valid=True)
 
-        mommy.make(
+        baker.make(
             County,
             fips='12081',
             name='Manatee County',
             state=State.objects.get(fips='12'),
             valid=False)
 
-        mommy.make(
+        baker.make(
             County,
             fips='12039',
             name='Gadsden County',
             state=State.objects.get(fips='12'),
             valid=False)
 
-        mommy.make(
+        baker.make(
             County,
             fips='12013',
             name='Calhoun County',
             state=State.objects.get(fips='12'),
             valid=True)
 
-        mommy.make(
+        baker.make(
             MSAMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='45220',
@@ -93,7 +93,7 @@ class GeoValidationTests(django.test.TestCase):
             other='0',
             msa=MetroArea.objects.get(fips='45220'))
 
-        mommy.make(
+        baker.make(
             MSAMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='35840',
@@ -105,7 +105,7 @@ class GeoValidationTests(django.test.TestCase):
             other='0',
             msa=MetroArea.objects.get(fips='35840'))
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='12039',
@@ -117,7 +117,7 @@ class GeoValidationTests(django.test.TestCase):
             other='0',
             county=County.objects.get(fips='12039'))
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='12081',
@@ -129,7 +129,7 @@ class GeoValidationTests(django.test.TestCase):
             other='26',
             county=County.objects.get(fips='12081'))
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='12013',
@@ -141,7 +141,7 @@ class GeoValidationTests(django.test.TestCase):
             other='26',
             county=County.objects.get(fips='12013'))
 
-        mommy.make(
+        baker.make(
             NonMSAMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='12-non',
@@ -153,7 +153,7 @@ class GeoValidationTests(django.test.TestCase):
             other='0',
             state=State.objects.get(fips='12'))
 
-        mommy.make(
+        baker.make(
             NonMSAMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='34-non',
@@ -165,7 +165,7 @@ class GeoValidationTests(django.test.TestCase):
             other=None,
             state=State.objects.get(fips='34'))
 
-        mommy.make(
+        baker.make(
             StateMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='12',
@@ -176,7 +176,7 @@ class GeoValidationTests(django.test.TestCase):
             ninety='0',
             other='0')
 
-        mommy.make(
+        baker.make(
             NationalMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='-----',
@@ -325,7 +325,7 @@ class MortgageModelTests(django.test.TestCase):
 
     def setUp(self):
 
-        self.base_data = mommy.make(
+        self.base_data = baker.make(
             CountyMortgageData,
             fips='12081',
             date=datetime.date(2016, 9, 1),
@@ -336,19 +336,19 @@ class MortgageModelTests(django.test.TestCase):
             ninety=0,
             other=3)
 
-        self.msa_data = mommy.make(
+        self.msa_data = baker.make(
             MSAMortgageData,
             total=0,
             fips='45300',
             date=datetime.date(2016, 9, 1))
 
-        self.state_obj = mommy.make(
+        self.state_obj = baker.make(
             StateMortgageData,
             total=0,
             fips='12',
             date=datetime.date(2016, 9, 1))
 
-        self.nation_obj = mommy.make(
+        self.nation_obj = baker.make(
             NationalMortgageData,
             current=2500819,
             date=datetime.date(2016, 9, 1),

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -8,7 +8,7 @@ import django
 import mock
 import unicodecsv
 from dateutil import parser
-from model_mommy import mommy
+from model_bakery import baker
 
 from data_research.models import (
     County, CountyMortgageData, MetroArea, MortgageDataConstant,
@@ -51,13 +51,13 @@ class SourceToTableTest(django.test.TestCase):
                 '1443', '10', '5', '4', '2', '2891']
 
     def setUp(self):
-        AL = mommy.make(
+        AL = baker.make(
             State,
             fips='01',
             abbr='AL',
             name='Alabama')
 
-        Autauga = mommy.make(
+        Autauga = baker.make(
             County,
             id=2891,
             fips='01001',
@@ -65,7 +65,7 @@ class SourceToTableTest(django.test.TestCase):
             state=AL,
             valid=True)
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             fips='01001',
             date=self.start_date,
@@ -161,7 +161,7 @@ class DataLoadIntegrityTest(django.test.TestCase):
 
     def setUp(self):
 
-        FL = mommy.make(
+        FL = baker.make(
             State,
             fips='12',
             abbr='FL',
@@ -173,7 +173,7 @@ class DataLoadIntegrityTest(django.test.TestCase):
             non_msa_valid=True)
         FL.save()
 
-        mommy.make(
+        baker.make(
             County,
             fips='12081',
             name='Manatee County',
@@ -251,7 +251,7 @@ class MergeTheDadesTest(django.test.TestCase):
         self.old_dade_fips = '12025'
         self.new_dade_fips = '12086'
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             current=100,
             date=datetime.date(2008, 1, 1),
@@ -262,7 +262,7 @@ class MergeTheDadesTest(django.test.TestCase):
             thirty=100,
             total=500)
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             current=100,
             date=datetime.date(2008, 1, 1),
@@ -303,7 +303,7 @@ class DataExportTest(django.test.TestCase):
 
     def setUp(self):
 
-        mommy.make(
+        baker.make(
             State,
             fips='12',
             abbr='FL',
@@ -314,14 +314,14 @@ class DataExportTest(django.test.TestCase):
             non_msa_counties=["12001"],
             non_msa_valid=True)
 
-        mommy.make(
+        baker.make(
             County,
             fips='12081',
             name='Manatee County',
             state=State.objects.get(fips='12'),
             valid=True)
 
-        mommy.make(
+        baker.make(
             MetroArea,
             fips='35840',
             name='North Port-Sarasota-Bradenton, FL',
@@ -329,7 +329,7 @@ class DataExportTest(django.test.TestCase):
             counties=["12081", "12115"],
             valid=True)
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             current=1250,
             date=datetime.date(2008, 1, 1),
@@ -341,7 +341,7 @@ class DataExportTest(django.test.TestCase):
             thirty=100,
             total=1650)
 
-        mommy.make(
+        baker.make(
             MSAMortgageData,
             current=5250,
             date=datetime.date(2008, 1, 1),
@@ -353,7 +353,7 @@ class DataExportTest(django.test.TestCase):
             thirty=3676,
             total=22674)
 
-        mommy.make(
+        baker.make(
             NonMSAMortgageData,
             current=5250,
             date=datetime.date(2008, 1, 1),
@@ -365,7 +365,7 @@ class DataExportTest(django.test.TestCase):
             thirty=3676,
             total=22674)
 
-        mommy.make(
+        baker.make(
             StateMortgageData,
             current=250081,
             date=datetime.date(2008, 1, 1),
@@ -377,7 +377,7 @@ class DataExportTest(django.test.TestCase):
             thirty=6766,
             total=26748)
 
-        mommy.make(
+        baker.make(
             NationalMortgageData,
             current=2500000,
             date=datetime.date(2008, 1, 1),
@@ -470,7 +470,7 @@ class DataLoadTest(django.test.TestCase):
 
     def setUp(self):
 
-        FL = mommy.make(
+        FL = baker.make(
             State,
             fips='12',
             abbr='FL',
@@ -482,7 +482,7 @@ class DataLoadTest(django.test.TestCase):
             non_msa_valid=True)
         FL.save()
 
-        manatee = mommy.make(
+        manatee = baker.make(
             County,
             fips='12081',
             name='Manatee County',
@@ -490,7 +490,7 @@ class DataLoadTest(django.test.TestCase):
             valid=True)
         manatee.save()
 
-        mommy.make(
+        baker.make(
             MetroArea,
             fips='35840',
             name='North Port-Sarasota-Bradenton, FL',
@@ -498,13 +498,13 @@ class DataLoadTest(django.test.TestCase):
             states='["12"]',
             valid=True)
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             date=datetime.date(2016, 1, 1),
             fips='12081',
             county=manatee)
 
-        mommy.make(
+        baker.make(
             MSAMortgageData,
             current=5250,
             date=datetime.date(2016, 1, 1),
@@ -516,7 +516,7 @@ class DataLoadTest(django.test.TestCase):
             thirty=3676,
             total=22674)
 
-        mommy.make(
+        baker.make(
             NonMSAMortgageData,
             current=250081,
             date=datetime.date(2016, 1, 1),
@@ -528,7 +528,7 @@ class DataLoadTest(django.test.TestCase):
             thirty=6766,
             total=26748)
 
-        mommy.make(
+        baker.make(
             StateMortgageData,
             current=250081,
             date=datetime.date(2016, 1, 1),
@@ -614,7 +614,7 @@ class UpdateSamplingDatesTest(django.test.TestCase):
 
     def setUp(self):
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             current=1250,
             date=datetime.date(2008, 1, 1),

--- a/cfgov/data_research/tests/test_views.py
+++ b/cfgov/data_research/tests/test_views.py
@@ -5,7 +5,7 @@ import unittest
 import django
 from django.core.urlresolvers import NoReverseMatch, reverse
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from data_research.models import (
     County, CountyMortgageData, MetroArea, MSAMortgageData,
@@ -47,7 +47,7 @@ class TimeseriesViewTests(django.test.TestCase):
     fixtures = ['mortgage_constants.json', 'mortgage_metadata.json']
 
     def setUp(self):
-        mommy.make(
+        baker.make(
             State,
             fips='12',
             abbr='FL',
@@ -58,14 +58,14 @@ class TimeseriesViewTests(django.test.TestCase):
             non_msa_counties=["12001"],
             non_msa_valid=True)
 
-        mommy.make(
+        baker.make(
             County,
             fips='12081',
             name='Manatee County',
             state=State.objects.get(fips='12'),
             valid=True)
 
-        mommy.make(
+        baker.make(
             MetroArea,
             fips='35840',
             name='North Port-Sarasota-Bradenton, FL',
@@ -73,7 +73,7 @@ class TimeseriesViewTests(django.test.TestCase):
             counties=["12081", "12115"],
             valid=True)
 
-        mommy.make(
+        baker.make(
             MetroArea,
             fips='16220',
             name='Casper, WY',
@@ -81,7 +81,7 @@ class TimeseriesViewTests(django.test.TestCase):
             counties=["12081", "12115"],
             valid=True)
 
-        mommy.make(
+        baker.make(
             NationalMortgageData,
             current=2500819,
             date=datetime.date(2008, 1, 1),
@@ -93,7 +93,7 @@ class TimeseriesViewTests(django.test.TestCase):
             thirty=67668,
             total=2674899)
 
-        mommy.make(
+        baker.make(
             StateMortgageData,
             current=250081,
             date=datetime.date(2008, 1, 1),
@@ -106,7 +106,7 @@ class TimeseriesViewTests(django.test.TestCase):
             thirty=6766,
             total=26748)
 
-        mommy.make(
+        baker.make(
             MSAMortgageData,
             current=5250,
             date=datetime.date(2008, 1, 1),
@@ -119,7 +119,7 @@ class TimeseriesViewTests(django.test.TestCase):
             thirty=3676,
             total=22674)
 
-        mommy.make(
+        baker.make(
             NonMSAMortgageData,
             current=5250,
             date=datetime.date(2008, 1, 1),
@@ -132,7 +132,7 @@ class TimeseriesViewTests(django.test.TestCase):
             thirty=3676,
             total=22674)
 
-        mommy.make(
+        baker.make(
             CountyMortgageData,
             current=250,
             date=datetime.date(2008, 1, 1),

--- a/cfgov/hmda/tests/test_pages.py
+++ b/cfgov/hmda/tests/test_pages.py
@@ -1,6 +1,6 @@
 from django.test import RequestFactory, TestCase
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from hmda.models.pages import HmdaHistoricDataPage
 
@@ -13,7 +13,7 @@ class TestHmdaHistoricDataPage(TestCase):
         self.factory = RequestFactory()
 
     def test_hmda_explorer_page_no_params(self):
-        page = mommy.prepare(HmdaHistoricDataPage)
+        page = baker.prepare(HmdaHistoricDataPage)
         test_context = page.get_context(self.factory.get('/'))
 
         self.assertEqual(test_context['title'], 'Showing nationwide records')
@@ -24,7 +24,7 @@ class TestHmdaHistoricDataPage(TestCase):
         self.assertEqual(years, self.expected_years)
 
     def test_hmda_explorer_page_with_params(self):
-        page = mommy.prepare(HmdaHistoricDataPage)
+        page = baker.prepare(HmdaHistoricDataPage)
         request = '/?geo=ny&records=all-records&field_descriptions=codes'
         test_context = page.get_context(self.factory.get(request))
 

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from wagtail.core.models import Site
 
 from mock import patch
-from model_mommy import mommy
+from model_bakery import baker
 
 from jobmanager.models.django import (
     ApplicantType, City, Grade, JobCategory, Office, Region, State
@@ -71,8 +71,8 @@ class JobListingPageQuerySetTests(TestCase):
 
 class JobListingPageTestCase(TestCase):
     def setUp(self):
-        self.division = mommy.make(JobCategory)
-        self.location = mommy.make(Region)
+        self.division = baker.make(JobCategory)
+        self.location = baker.make(Region)
 
         page_clean = patch('jobmanager.models.pages.CFGOVPage.clean')
         page_clean.start()
@@ -82,7 +82,7 @@ class JobListingPageTestCase(TestCase):
         kwargs.setdefault('description', 'default')
         kwargs.setdefault('division', self.division)
         kwargs.setdefault('location', self.location)
-        return mommy.prepare(JobListingPage, **kwargs)
+        return baker.prepare(JobListingPage, **kwargs)
 
     def test_clean_with_all_fields_passes_validation(self):
         page = self.prepare_job_listing_page()
@@ -127,7 +127,7 @@ class JobListingPageTestCase(TestCase):
 
         for grade in grades:
             panel = GradePanel.objects.create(
-                grade=mommy.make(Grade, grade=str(grade)),
+                grade=baker.make(Grade, grade=str(grade)),
                 job_listing=page
             )
             page.grades.add(panel)
@@ -156,12 +156,12 @@ class JobListingPageTestCase(TestCase):
             self.assertIsInstance(grade, str)
 
     def test_context_for_page_with_region_location(self):
-        region = mommy.make(
+        region = baker.make(
             Region,
             name="Tri-State Area",
             abbreviation="TA",
         )
-        state = mommy.make(
+        state = baker.make(
             State,
             name="Unknown",
             abbreviation='UN',
@@ -180,15 +180,15 @@ class JobListingPageTestCase(TestCase):
         self.assertIn(test_context['cities'][0].name, cities)
 
     def test_context_for_page_with_office_location(self):
-        region = mommy.make(
+        region = baker.make(
             Region,
             name="Mideastern",
             abbreviation="ME")
-        office = mommy.make(
+        office = baker.make(
             Office,
             name="Zenith Office",
             abbreviation="ZE")
-        state = mommy.make(
+        state = baker.make(
             State,
             name="Winnemac",
             abbreviation='WM',
@@ -226,11 +226,11 @@ class JobListingPageTestCase(TestCase):
         page.usajobs_application_links = [
             USAJobsApplicationLink(
                 announcement_number='1',
-                applicant_type=mommy.make(ApplicantType, applicant_type='1'),
+                applicant_type=baker.make(ApplicantType, applicant_type='1'),
             ),
             USAJobsApplicationLink(
                 announcement_number='2',
-                applicant_type=mommy.make(ApplicantType, applicant_type='2'),
+                applicant_type=baker.make(ApplicantType, applicant_type='2'),
             ),
         ]
 

--- a/cfgov/jobmanager/tests/models/test_panels.py
+++ b/cfgov/jobmanager/tests/models/test_panels.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from wagtail.core.models import Page
 
 from mock import Mock
-from model_mommy import mommy
+from model_bakery import baker
 
 from jobmanager.models.django import ApplicantType, JobLocation
 from jobmanager.models.pages import JobListingPage
@@ -23,7 +23,7 @@ class ApplicationLinkTestCaseMixin(object):
 
     def setUp(self):
         location = JobLocation.objects.create(abbreviation='US', name='USA')
-        self.job_listing = mommy.prepare(
+        self.job_listing = baker.prepare(
             JobListingPage,
             description='foo',
             location=location
@@ -45,7 +45,7 @@ class USAJobsApplicationLinkTestCase(ApplicationLinkTestCaseMixin, TestCase):
 
     def setUp(self):
         super(USAJobsApplicationLinkTestCase, self).setUp()
-        self.applicant_type = mommy.make(ApplicantType)
+        self.applicant_type = baker.make(ApplicantType)
 
     def test_all_fields_passes_validation(self):
         self.check_clean(
@@ -88,7 +88,7 @@ class EmailApplicationLinkTestCase(ApplicationLinkTestCaseMixin, TestCase):
         )
 
     def test_mailto_link(self):
-        job = mommy.prepare(
+        job = baker.prepare(
             JobListingPage,
             title='This is a page title!',
             description='This is a page description'

--- a/cfgov/jobmanager/tests/test_blocks.py
+++ b/cfgov/jobmanager/tests/test_blocks.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_text
 
 from wagtail.core.models import Page
 
-from model_mommy import mommy
+from model_bakery import baker
 from scripts._atomic_helpers import job_listing_list
 
 from jobmanager.blocks import JobListingList, JobListingTable
@@ -19,13 +19,13 @@ from v1.util.migrations import set_stream_data
 
 
 def make_job_listing_page(title, close_date=None, grades=[], **kwargs):
-    page = mommy.prepare(
+    page = baker.prepare(
         JobListingPage,
         title=title,
         close_date=close_date or timezone.now().date(),
         description='description',
-        division=mommy.make(JobCategory),
-        location=mommy.make(JobLocation, name='Silicon Valley'),
+        division=baker.make(JobCategory),
+        location=baker.make(JobLocation, name='Silicon Valley'),
         **kwargs
     )
 
@@ -33,7 +33,7 @@ def make_job_listing_page(title, close_date=None, grades=[], **kwargs):
     home.add_child(instance=page)
 
     for grade in grades:
-        grade_model = mommy.make(Grade, grade=grade)
+        grade_model = baker.make(Grade, grade=grade)
         GradePanel.objects.create(grade=grade_model, job_listing=page)
 
     return page

--- a/cfgov/regulations3k/tests/test_blocks.py
+++ b/cfgov/regulations3k/tests/test_blocks.py
@@ -5,7 +5,7 @@ from django.test import TestCase, override_settings
 from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Page
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from regulations3k.blocks import RegulationsList
 from regulations3k.models.django import EffectiveVersion, Part
@@ -26,26 +26,26 @@ class RegulationsListTestCase(TestCase):
         )
         self.ROOT_PAGE.add_child(instance=self.landing_page)
 
-        self.part_1002 = mommy.make(
+        self.part_1002 = baker.make(
             Part,
             part_number='1002',
             title='Equal Credit Opportunity Act',
             short_name='Regulation B',
             chapter='X'
         )
-        self.part_1003 = mommy.make(
+        self.part_1003 = baker.make(
             Part,
             part_number='1003',
             title='Home Mortgage Disclosure',
             short_name='Regulation C',
             chapter='X'
         )
-        self.effective_version = mommy.make(
+        self.effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2014, 1, 18),
             part=self.part_1002
         )
-        self.future_effective_version = mommy.make(
+        self.future_effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2022, 1, 1),
             part=self.part_1002

--- a/cfgov/regulations3k/tests/test_copyable_modeladmin.py
+++ b/cfgov/regulations3k/tests/test_copyable_modeladmin.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from wagtail.tests.utils import WagtailTestUtils
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from regulations3k.models.django import (
     EffectiveVersion, Part, Section, Subpart
@@ -14,26 +14,26 @@ from regulations3k.models.django import (
 class TestCopyableModelAdmin(TestCase, WagtailTestUtils):
 
     def setUp(self):
-        self.part_1002 = mommy.make(
+        self.part_1002 = baker.make(
             Part,
             part_number='1002',
             title='Equal Credit Opportunity Act',
             short_name='Regulation B',
             chapter='X'
         )
-        self.effective_version = mommy.make(
+        self.effective_version = baker.make(
             EffectiveVersion,
             effective_date=date(2014, 1, 18),
             part=self.part_1002
         )
-        self.subpart = mommy.make(
+        self.subpart = baker.make(
             Subpart,
             label='Subpart General',
             title='General',
             subpart_type=Subpart.BODY,
             version=self.effective_version
         )
-        self.section_num4 = mommy.make(
+        self.section_num4 = baker.make(
             Section,
             label='4',
             title='\xa7\xa01002.4 General rules.',

--- a/cfgov/regulations3k/tests/test_hooks.py
+++ b/cfgov/regulations3k/tests/test_hooks.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from wagtail.tests.utils import WagtailTestUtils
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from regulations3k.models.django import (
     EffectiveVersion, Part, Section, Subpart
@@ -21,26 +21,26 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
             title='Reg Landing', slug='reg-landing')
         self.ROOT_PAGE.add_child(instance=self.landing_page)
 
-        self.part_1002 = mommy.make(
+        self.part_1002 = baker.make(
             Part,
             part_number='1002',
             title='Equal Credit Opportunity Act',
             short_name='Regulation B',
             chapter='X'
         )
-        self.effective_version = mommy.make(
+        self.effective_version = baker.make(
             EffectiveVersion,
             effective_date=date(2014, 1, 18),
             part=self.part_1002
         )
-        self.subpart = mommy.make(
+        self.subpart = baker.make(
             Subpart,
             label='Subpart General',
             title='General',
             subpart_type=Subpart.BODY,
             version=self.effective_version
         )
-        self.section_num4 = mommy.make(
+        self.section_num4 = baker.make(
             Section,
             label='4',
             title='\xa7\xa01002.4 General rules.',
@@ -48,20 +48,20 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
             subpart=self.subpart,
         )
 
-        self.draft_effective_version = mommy.make(
+        self.draft_effective_version = baker.make(
             EffectiveVersion,
             effective_date=date(2020, 1, 18),
             part=self.part_1002,
             draft=True,
         )
-        self.draft_subpart = mommy.make(
+        self.draft_subpart = baker.make(
             Subpart,
             label='Subpart General',
             title='General',
             subpart_type=Subpart.BODY,
             version=self.draft_effective_version
         )
-        self.draft_section_num4 = mommy.make(
+        self.draft_section_num4 = baker.make(
             Section,
             label='4',
             title='\xa7\xa01002.4 General rules.',

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -13,7 +13,7 @@ from django.test import (
 from wagtail.core.models import Site
 
 import mock
-from model_mommy import mommy
+from model_bakery import baker
 
 from core.testutils.mock_cache_backend import CACHE_PURGED_URLS
 from regulations3k.models.django import (
@@ -43,7 +43,7 @@ class RegModelTests(DjangoTestCase):
             title='Reg Landing', slug='reg-landing')
         self.ROOT_PAGE.add_child(instance=self.landing_page)
 
-        self.part_1002 = mommy.make(
+        self.part_1002 = baker.make(
             Part,
             cfr_title_number=12,
             part_number='1002',
@@ -51,7 +51,7 @@ class RegModelTests(DjangoTestCase):
             short_name='Regulation B',
             chapter='X'
         )
-        self.part_1030 = mommy.make(
+        self.part_1030 = baker.make(
             Part,
             cfr_title_number=12,
             part_number='1030',
@@ -60,58 +60,58 @@ class RegModelTests(DjangoTestCase):
             chapter='X'
         )
 
-        self.effective_version = mommy.make(
+        self.effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2014, 1, 18),
             part=self.part_1002
         )
-        self.old_effective_version = mommy.make(
+        self.old_effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2011, 1, 1),
             part=self.part_1002,
         )
-        self.draft_effective_version = mommy.make(
+        self.draft_effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2020, 1, 1),
             part=self.part_1002,
             draft=True,
         )
 
-        self.subpart = mommy.make(
+        self.subpart = baker.make(
             Subpart,
             label='Subpart General',
             title='Subpart A - General',
             subpart_type=Subpart.BODY,
             version=self.effective_version
         )
-        self.subpart_appendices = mommy.make(
+        self.subpart_appendices = baker.make(
             Subpart,
             label='Appendices',
             title='Appendices',
             subpart_type=Subpart.APPENDIX,
             version=self.effective_version
         )
-        self.subpart_interps = mommy.make(
+        self.subpart_interps = baker.make(
             Subpart,
             label='Official Interpretations',
             title='Supplement I to Part 1002',
             subpart_type=Subpart.INTERPRETATION,
             version=self.effective_version
         )
-        self.subpart_orphan = mommy.make(
+        self.subpart_orphan = baker.make(
             Subpart,
             label='General Mistake',
             title='An orphan subpart with no sections for testing',
             version=self.effective_version
         )
-        self.old_subpart = mommy.make(
+        self.old_subpart = baker.make(
             Subpart,
             label='Subpart General',
             title='General',
             subpart_type=Subpart.BODY,
             version=self.old_effective_version
         )
-        self.section_num4 = mommy.make(
+        self.section_num4 = baker.make(
             Section,
             label='4',
             title='\xa7\xa01002.4 General rules.',
@@ -125,27 +125,27 @@ class RegModelTests(DjangoTestCase):
             ),
             subpart=self.subpart,
         )
-        self.graph_to_keep = mommy.make(
+        self.graph_to_keep = baker.make(
             SectionParagraph,
             section=self.section_num4,
             paragraph_id='d',
             paragraph=(
                 '(1) General rule. A creditor that provides in writing.')
         )
-        self.graph_to_delete = mommy.make(
+        self.graph_to_delete = baker.make(
             SectionParagraph,
             section=self.section_num4,
             paragraph_id='x',
             paragraph='(x) Non-existent graph that should get deleted.'
         )
-        self.section_num15 = mommy.make(
+        self.section_num15 = baker.make(
             Section,
             label='15',
             title='\xa7\xa01002.15 Rules concerning requests for information.',
             contents='regdown content.',
             subpart=self.subpart,
         )
-        self.section_alpha = mommy.make(
+        self.section_alpha = baker.make(
             Section,
             label='A',
             title=('Appendix A to Part 1002-Federal Agencies '
@@ -153,21 +153,21 @@ class RegModelTests(DjangoTestCase):
             contents='regdown content.',
             subpart=self.subpart_appendices,
         )
-        self.section_beta = mommy.make(
+        self.section_beta = baker.make(
             Section,
             label='B',
             title=('Appendix B to Part 1002-Errata'),
             contents='regdown content.',
             subpart=self.subpart_appendices,
         )
-        self.section_interps = mommy.make(
+        self.section_interps = baker.make(
             Section,
             label='Interp-A',
             title=('Official interpretations for Appendix A to Part 1002'),
             contents='interp content.',
             subpart=self.subpart_interps,
         )
-        self.old_section_num4 = mommy.make(
+        self.old_section_num4 = baker.make(
             Section,
             label='4',
             title='\xa7\xa01002.4 General rules.',
@@ -580,7 +580,7 @@ class RegModelTests(DjangoTestCase):
         )
 
     def test_effective_version_date_unique(self):
-        new_effective_version = mommy.make(
+        new_effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2020, 1, 1),
             part=self.part_1002,

--- a/cfgov/regulations3k/tests/test_resolver.py
+++ b/cfgov/regulations3k/tests/test_resolver.py
@@ -4,7 +4,7 @@ import datetime
 
 from django.test import TestCase, override_settings
 
-from model_mommy import mommy
+from model_bakery import baker
 from regdown import DEFAULT_RENDER_BLOCK_REFERENCE, regdown
 
 from regulations3k.models import (
@@ -37,45 +37,45 @@ class ReferenceResolutionTestCase(TestCase):
             title='Reg Landing', slug='reg-landing')
         self.ROOT_PAGE.add_child(instance=self.landing_page)
 
-        self.part_1002 = mommy.make(
+        self.part_1002 = baker.make(
             Part,
             part_number='1002',
             title='Equal Credit Opportunity Act',
             short_name='Regulation B',
             chapter='X'
         )
-        self.effective_version = mommy.make(
+        self.effective_version = baker.make(
             EffectiveVersion,
             effective_date=datetime.date(2014, 1, 18),
             part=self.part_1002
         )
-        self.subpart = mommy.make(
+        self.subpart = baker.make(
             Subpart,
             label='1002',
             title='',
             version=self.effective_version
         )
-        self.subpart_interps = mommy.make(
+        self.subpart_interps = baker.make(
             Subpart,
             label='Interp',
             title='Suppliment I to Part 1002',
             version=self.effective_version
         )
-        self.section_2 = mommy.make(
+        self.section_2 = baker.make(
             Section,
             label='2',
             title='\xa7 1002.2 Definitions.',
             contents='{c}\nAdverse action.\n\nsee(2-c-Interp)\n',
             subpart=self.subpart,
         )
-        self.section_3 = mommy.make(
+        self.section_3 = baker.make(
             Section,
             label='3',
             title='\xa7 1002.3 Limited exceptions.',
             contents='{b}\nSecurities credit.\n\nsee(3-b-Interp)\n',
             subpart=self.subpart,
         )
-        self.section_interp2 = mommy.make(
+        self.section_interp2 = baker.make(
             Section,
             label='Interp-2',
             title='Section 1002.2—Definitions',

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.test import RequestFactory, TestCase, override_settings
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from regulations3k.models import EffectiveVersion, Part
 from regulations3k.views import get_version_date, redirect_eregs
@@ -14,33 +14,33 @@ class RedirectRegulations3kTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-        self.test_reg_1002 = mommy.make(
+        self.test_reg_1002 = baker.make(
             Part,
             part_number='1002')
 
-        self.test_reg_1005 = mommy.make(
+        self.test_reg_1005 = baker.make(
             Part,
             part_number='1005')
 
-        self.test_version_1002 = mommy.make(
+        self.test_version_1002 = baker.make(
             EffectiveVersion,
             part=self.test_reg_1002,
             effective_date=datetime.date(2016, 7, 11),
             draft=False)
 
-        self.test_version_1002_2011 = mommy.make(
+        self.test_version_1002_2011 = baker.make(
             EffectiveVersion,
             part=self.test_reg_1002,
             effective_date=datetime.date(2011, 12, 30),
             draft=False)
 
-        self.test_version_1002_not_live = mommy.make(
+        self.test_version_1002_not_live = baker.make(
             EffectiveVersion,
             part=self.test_reg_1002,
             effective_date=datetime.date(2014, 1, 10),
             draft=True)
 
-        self.test_version_1005 = mommy.make(
+        self.test_version_1005 = baker.make(
             EffectiveVersion,
             part=self.test_reg_1005,
             effective_date=datetime.date(2013, 3, 26),

--- a/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
+++ b/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
@@ -3,7 +3,7 @@ from datetime import date
 from django.template import engines
 from django.test import RequestFactory, TestCase, override_settings
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from v1.atomic_elements.atoms import ImageBasic
 from v1.jinja2tags import complaint_issue_banner, email_popup, image_alt_value
@@ -28,26 +28,26 @@ class TestImageAltValue(TestCase):
         self.assertEqual(image_alt_value(value), '')
 
     def test_block_no_alt_text_set(self):
-        image_no_alt_text = mommy.make(CFGOVImage, alt='')
+        image_no_alt_text = baker.make(CFGOVImage, alt='')
         block = ImageBasic()
         value = block.to_python({'upload': image_no_alt_text.pk, 'alt': ''})
         self.assertEqual(image_alt_value(value), '')
 
     def test_block_alt_text_on_upload(self):
-        image_with_alt_text = mommy.make(CFGOVImage, alt='Alt text on upload')
+        image_with_alt_text = baker.make(CFGOVImage, alt='Alt text on upload')
         block = ImageBasic()
         value = block.to_python({'upload': image_with_alt_text.pk, 'alt': ''})
         self.assertEqual(image_alt_value(value), 'Alt text on upload')
 
     def test_block_alt_text_on_block(self):
-        image_no_alt_text = mommy.make(CFGOVImage, alt='')
+        image_no_alt_text = baker.make(CFGOVImage, alt='')
         block = ImageBasic()
         value = block.to_python({'upload': image_no_alt_text.pk,
                                  'alt': 'Alt text on block'})
         self.assertEqual(image_alt_value(value), 'Alt text on block')
 
     def test_block_alt_text_on_both(self):
-        image_with_alt_text = mommy.make(CFGOVImage, alt='Alt text on upload')
+        image_with_alt_text = baker.make(CFGOVImage, alt='Alt text on upload')
         block = ImageBasic()
         value = block.to_python({'upload': image_with_alt_text.pk,
                                  'alt': 'Alt text on block'})

--- a/cfgov/v1/tests/test_email.py
+++ b/cfgov/v1/tests/test_email.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from wagtail.core.models import Site
 
 from mock import patch
-from model_mommy import mommy
+from model_bakery import baker
 
 from v1.email import create_request_for_email, send_password_reset_email
 
@@ -27,13 +27,13 @@ class CreateEmailRequestTestCase(TestCase):
         )
 
     def test_http_site(self):
-        site = mommy.prepare(Site, is_default_site=True, port=80)
+        site = baker.prepare(Site, is_default_site=True, port=80)
         with patch('v1.email.Site.objects.get', return_value=site):
             request = create_request_for_email()
         self.assertRequestMatches(request, site.hostname, site.port, False)
 
     def test_https_site(self):
-        site = mommy.prepare(Site, is_default_site=True, port=443)
+        site = baker.prepare(Site, is_default_site=True, port=443)
         with patch('v1.email.Site.objects.get', return_value=site):
             request = create_request_for_email()
         self.assertRequestMatches(request, site.hostname, site.port, True)

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -4,19 +4,19 @@ from wagtail.images.tests.utils import get_test_image_file
 
 import boto3
 import moto
-from model_mommy import mommy
+from model_bakery import baker
 
 from v1.models import AbstractFilterPage, CFGOVImage, CFGOVPage, LearnPage
 
 
 class TestMetaImage(TestCase):
     def setUp(self):
-        self.preview_image = mommy.prepare(CFGOVImage)
-        self.social_sharing_image = mommy.prepare(CFGOVImage)
+        self.preview_image = baker.prepare(CFGOVImage)
+        self.social_sharing_image = baker.prepare(CFGOVImage)
 
     def test_meta_image_no_images(self):
         """ Meta image should be undefined if no image provided """
-        page = mommy.prepare(
+        page = baker.prepare(
             CFGOVPage,
             social_sharing_image=None
         )
@@ -24,7 +24,7 @@ class TestMetaImage(TestCase):
 
     def test_meta_image_only_social_sharing(self):
         """ Meta image uses social sharing image if provided """
-        page = mommy.prepare(
+        page = baker.prepare(
             CFGOVPage,
             social_sharing_image=self.social_sharing_image
         )
@@ -34,7 +34,7 @@ class TestMetaImage(TestCase):
         """ AbstractFilterPages use preview image for meta image
         if a social image is not provided
         """
-        page = mommy.prepare(
+        page = baker.prepare(
             AbstractFilterPage,
             social_sharing_image=None,
             preview_image=self.preview_image
@@ -45,7 +45,7 @@ class TestMetaImage(TestCase):
         """ AbstractFilterPages use social image for meta image
         if both preview image and social image are provided
         """
-        page = mommy.prepare(
+        page = baker.prepare(
             AbstractFilterPage,
             social_sharing_image=self.social_sharing_image,
             preview_image=self.preview_image
@@ -79,7 +79,7 @@ class TestMetaImage(TestCase):
     def check_template_meta_image_url(self, expected_root):
         """Template meta tags should use an absolute image URL."""
         image_file = get_test_image_file(filename='foo.png')
-        image = mommy.make(CFGOVImage, file=image_file)
+        image = baker.make(CFGOVImage, file=image_file)
         page = LearnPage(social_sharing_image=image)
         response = page.serve(page.dummy_request())
         response.render()

--- a/cfgov/v1/tests/test_signals.py
+++ b/cfgov/v1/tests/test_signals.py
@@ -3,12 +3,12 @@ from unittest import TestCase
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from model_mommy import mommy
+from model_bakery import baker
 
 
 class UserSaveTestCase(TestCase):
     def make_user(self, password, is_superuser=False):
-        user = mommy.prepare(User, is_superuser=is_superuser)
+        user = baker.prepare(User, is_superuser=is_superuser)
         user.set_password(password)
         user.save()
         return user

--- a/cfgov/v1/tests/test_social_sharing_image_validation.py
+++ b/cfgov/v1/tests/test_social_sharing_image_validation.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from model_mommy import mommy
+from model_bakery import baker
 
 from v1.models.browse_filterable_page import BrowseFilterablePage
 from v1.models.images import CFGOVImage
@@ -17,7 +17,7 @@ class TestSocialSharingImage(TestCase):
         save_new_page(self.page)
 
     def test_validation_error_thrown_if_width_height_too_large(self):
-        self.page.social_sharing_image = mommy.prepare(CFGOVImage, width=5000, height=5000)
+        self.page.social_sharing_image = baker.prepare(CFGOVImage, width=5000, height=5000)
         with self.assertRaisesRegexp(
             ValidationError,
             'Social sharing image must be less than 4096w x 4096h'
@@ -25,7 +25,7 @@ class TestSocialSharingImage(TestCase):
             self.page.save()
 
     def test_validation_error_thrown_if_width_too_large(self):
-        self.page.social_sharing_image = mommy.prepare(CFGOVImage, width=4097, height=1500)
+        self.page.social_sharing_image = baker.prepare(CFGOVImage, width=4097, height=1500)
         with self.assertRaisesRegexp(
             ValidationError,
             'Social sharing image must be less than 4096w x 4096h'
@@ -33,7 +33,7 @@ class TestSocialSharingImage(TestCase):
             self.page.save()
 
     def test_validation_error_thrown_if_height_too_large(self):
-        self.page.social_sharing_image = mommy.prepare(CFGOVImage, width=1500, height=4097)
+        self.page.social_sharing_image = baker.prepare(CFGOVImage, width=1500, height=4097)
         with self.assertRaisesRegexp(
             ValidationError,
             'Social sharing image must be less than 4096w x 4096h'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@ django-sslserver==0.20
 freezegun==0.3.12
 github3.py==0.9.6
 mock==2.0.0
-model_mommy==1.2.6
+model-bakery==1.1.0
 moto==1.3.6
 pip==20.0.2
 responses==0.9.0


### PR DESCRIPTION
The model-mommy project was recently [renamed to model-bakery](https://model-bakery.readthedocs.io/en/latest/index.html#model-bakery-smart-fixtures-for-better-tests). Our version was also a little bit out of date. This change uses the new package name and brings it up to date.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: