### PR TITLE
Mega Menu: Remove header scoping on legacy pages

### DIFF
--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -65,10 +65,7 @@
 
 @import (less) "../organisms/header.less";
 
-.o-header {
-  // menu needs to be scoped or the cascade pushes the other scoped styles up
-  @import (less) "../organisms/mega-menu.less";
-}
+@import (less) "../organisms/mega-menu.less";
 
 /* Template pieces
    ========================================================================== */

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -67,6 +67,20 @@
 
 @import (less) "../organisms/mega-menu.less";
 
+// Hacks to fix issues with styles spilling into menu on legacy pages.
+.o-mega-menu_trigger {
+   border-radius: 0;
+}
+.o-mega-menu_content-list__featured a:hover {
+   border: transparent;
+}
+.o-mega-menu_content-list__featured ul {
+   margin-bottom: 1.875em !important;
+}
+.o-mega-menu_content-list a:focus {
+   background-color: transparent !important;
+}
+
 /* Template pieces
    ========================================================================== */
 @import (less) "../skip-nav.less";


### PR DESCRIPTION
Removes scoping added in https://github.com/cfpb/cfgov-refresh/commit/0a57d03c9d409e7ac93f2ce7929b5f8f3460b6cb for legacy pages. Those page weren't showing the arrows in mobile, e.g. 

<img width="665" alt="Screen Shot 2020-03-25 at 5 51 47 PM" src="https://user-images.githubusercontent.com/704760/77589021-57dbfd80-6ec1-11ea-8fd3-81024be89b1a.png">

## Changes

- Removes mega menu scoping added in https://github.com/cfpb/cfgov-refresh/commit/0a57d03c9d409e7ac93f2ce7929b5f8f3460b6cb

## Testing

1. Pull branch and build.
2. Compare to http://localhost:8000/data-research/consumer-complaints/ to production in mobile.

## Screenshots

This makes the hover on the featured item pretty yuck. But possibly this is better than the missing arrows on mobile:

<img width="260" alt="Screen Shot 2020-03-25 at 4 51 53 PM" src="https://user-images.githubusercontent.com/704760/77589072-6de9be00-6ec1-11ea-851c-457213b64fc9.png">
