### PR TITLE
Update satellite apps with Django 2.2 support

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -46,7 +46,7 @@ wagtail-treemodeladmin==1.1.1
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.14.0/owning_a_home_api-0.14.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.3.0/ccdb5_api-1.3.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/1.6.0/ccdb5_ui-1.6.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.3.1/ccdb5_api-1.3.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/1.6.1/ccdb5_ui-1.6.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.14.0/comparisontool-1.14.0-py3-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.4/teachers_digital_platform-1.2.4-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -46,7 +46,7 @@ wagtail-treemodeladmin==1.1.1
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.14.0/owning_a_home_api-0.14.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.3.0/ccdb5_api-1.3.0-py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/1.6.0/ccdb5_ui-1.6.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.3.0/ccdb5_api-1.3.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/1.6.0/ccdb5_ui-1.6.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.14.0/comparisontool-1.14.0-py3-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.4/teachers_digital_platform-1.2.4-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -44,9 +44,9 @@ wagtail-sharing==1.0
 wagtail-treemodeladmin==1.1.1
 
 # These packages are installed from GitHub.
-https://github.com/cfpb/owning-a-home-api/releases/download/0.13.1/owning_a_home_api-0.13.1-py3-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.11.0/retirement-0.11.0-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.2.2/ccdb5_api-1.2.2-py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/1.4.0/ccdb5_ui-1.4.0-py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.13.1/comparisontool-1.13.1-py3-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.14.0/owning_a_home_api-0.14.0-py3-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.3.0/ccdb5_api-1.3.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/1.6.0/ccdb5_ui-1.6.0-py3-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.14.0/comparisontool-1.14.0-py3-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.4/teachers_digital_platform-1.2.4-py3-none-any.whl


### PR DESCRIPTION
This change updates our satellite apps in bulk to versions that have been made Django 1.11 through 2.2-compatible.

This is intended to make #5582 easier to work with.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
