### PR TITLE
Ensure we have a copy of gh-pages in the docs GitHub Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --no-tags --prune --depth=1 origin gh-pages
 
       - name: Set up Python
         uses: actions/setup-python@v1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ nav:
     - Related Projects: related-projects.md
     - Development Tips: development-tips.md
     - How We Use Travis CI: travis.md
-    - How We Use GitHub Actions: github_actions.md
+    - How We Use GitHub Actions: github-actions.md
 - APIs and Data:
     - Ask CFPB: ask-cfpb.md
     - Consumer Complaints: consumer-complaint-database.md


### PR DESCRIPTION
In our docs action we did not have a copy of the gh-pages branch, so one was being created. When mkdocs tried to push it, it was rejected because there were changes on gh-pages upstream that we didn't have. This change will fetch the last commit on gh-pages to prevent that from happening.

See https://github.com/cfpb/cfgov-refresh/runs/567993361 for a successful run from this branch.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
