### PR TITLE
Bump wagtail-sharing to version 2.1

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -41,7 +41,7 @@ urllib3==1.25.2
 wagtail-autocomplete==0.1.1
 wagtail-flags==4.1.1
 wagtail-inventory==1.0
-wagtail-sharing==1.0
+wagtail-sharing==2.1
 wagtail-treemodeladmin==1.1.1
 
 # These packages are installed from GitHub.


### PR DESCRIPTION
This change bumps the version of wagtail-sharing from 1.0 to [2.1](https://github.com/cfpb/wagtail-sharing/releases):

https://pypi.org/project/wagtail-sharing/2.1/

This new version adds support for Django 2.2, adds black formatting, and improves error messages when views raise an exception.