### PR TITLE
Fix 500 errors due to invalid form_id on POSTs

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -270,10 +270,11 @@ class CFGOVPage(Page):
                     except ValueError:
                         streamfield_index = None
 
-                    try:
-                        form_module = streamfield[streamfield_index]
-                    except IndexError:
-                        form_module = None
+                    if streamfield_index is not None:
+                        try:
+                            form_module = streamfield[streamfield_index]
+                        except IndexError:
+                            form_module = None
 
         if form_module is None:
             return self._return_bad_post_response(request)

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -101,6 +101,12 @@ class TestCFGOVPage(TestCase):
         response = page.serve_post(request)
         self.assertIsInstance(response, HttpResponseBadRequest)
 
+    def test_serve_post_returns_400_for_invalid_form_id_non_number_index(self):
+        page = BrowsePage(title='test', slug='test')
+        request = self.factory.post('/', {'form_id': 'form-content-abc'})
+        response = page.serve_post(request)
+        self.assertIsInstance(response, HttpResponseBadRequest)
+
     def test_serve_post_valid_calls_feedback_block_handler(self):
         """A valid post should call the feedback block handler.
 


### PR DESCRIPTION
The CFGOVPage.serve_post method expects a certain format for the `form_id` parameter. Certain form_ids could trigger a 500, when they should be handled and instead return 400.

This change is similar to the one in #3143, which in turn related to internal platform#665.

## Testing

This error can currently be reproduced in production with a URL like this, which requires a valid CSRF token:

> curl -v -X POST -H 'REFERER: https://www.consumerfinance.gov' -H 'X-Requested-With: XMLHttpRequest' --cookie 'csrftoken=CSRFTOKENHERE' -d "form_id=form-content-EVIL&csrfmiddlewaretoken=CSRFTOKENHERE" "https://www.consumerfinance.gov/owning-a-home/process/close/close-deal/"

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: