### PR TITLE
Give iRegs pages better titles and descriptions

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -5,17 +5,46 @@
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
-{% block body_classes %}
+{# HEAD items #}
+
+{% block title -%}
+    {% if section %}
+        {{section.title}}
+    {% elif versions %}
+        All versions of {{ page.regulation }}
+    {% else %}
+        {{ page.title }}
+    {% endif %}
+    | Consumer Financial Protection Bureau
+{%- endblock title %}
+
+{% block desc -%}
+    {% if section %}
+        {% if subpart_type_label == 'Appendix' %}
+            Appendix {{ section.label }}
+        {% elif subpart_type_label == 'Interpretation' %}
+            {# section.label[7:] strips out the "Interp-" part of the label #}
+            The comment for {{ regulation.part_number }}.{{ section.label[7:] }}
+        {% else %}
+            § {{ regulation.part_number }}.{{ section.label }}
+        {% endif %}
+        {% if requested_version.effective_date < current_version.effective_date %}
+            is part of a previous version of {{ page.regulation }} with
+            amendments that went into effect on
+            {{ ap_date(requested_version.effective_date) }}.
+        {% elif requested_version.effective_date > current_version.effective_date %}
+            is part of a future version of {{ page.regulation }} with
+            amendments that will go into effect on
+            {{ ap_date(requested_version.effective_date) }}.
+        {% else %}
+            is part of {{ page.regulation }}.
+        {% endif %}
+    {% elif versions %}
+        View the current, previous, and future versions of {{ page.regulation }}.
+    {% endif %}
+
     {{ super() }}
-{% endblock body_classes %}
-
-{% block content_modifiers -%}
-    {{ super() }} content__hide-horizontal-overflow
-{%- endblock %}
-
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom regulations3k
-{%- endblock %}
+{%- endblock desc %}
 
 {% block preload %}
     {{ super() }}
@@ -35,6 +64,20 @@
     {{ super() }}
     <link rel="stylesheet" href="{{ static('apps/regulations3k/css/main.css') }}">
 {%- endblock css %}
+
+{# BODY items #}
+
+{% block body_classes %}
+    {{ super() }}
+{% endblock body_classes %}
+
+{% block content_modifiers -%}
+    {{ super() }} content__hide-horizontal-overflow
+{%- endblock %}
+
+{% block content_main_modifiers -%}
+    {{ super() }} content__flush-bottom regulations3k
+{%- endblock %}
 
 {% block content_main %}
     {% if section %}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -46,6 +46,10 @@
     {{ super() }}
 {%- endblock desc %}
 
+{% block og_desc -%}
+    {{ self.desc() }}
+{%- endblock og_desc %}
+
 {% block preload %}
     {{ super() }}
     {% if next_section %}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -8,41 +8,39 @@
 {# HEAD items #}
 
 {% block title -%}
-    {% if section %}
+    {%- if section -%}
         {{section.title}}
-    {% elif versions %}
+    {%- elif versions -%}
         All versions of {{ page.regulation }}
-    {% else %}
+    {%- else -%}
         {{ page.title }}
-    {% endif %}
-    | Consumer Financial Protection Bureau
+    {%- endif %} | Consumer Financial Protection Bureau
 {%- endblock title %}
 
 {% block desc -%}
-    {% if section %}
-        {% if subpart_type_label == 'Appendix' %}
+    {% if section -%}
+        {% if subpart_type_label == 'Appendix' -%}
             Appendix {{ section.label }}
         {% elif subpart_type_label == 'Interpretation' %}
-            {# section.label[7:] strips out the "Interp-" part of the label #}
+            {#- section.label[7:] strips out the "Interp-" part of the label -#}
             The comment for {{ regulation.part_number }}.{{ section.label[7:] }}
-        {% else %}
+        {% else -%}
             § {{ regulation.part_number }}.{{ section.label }}
-        {% endif %}
-        {% if requested_version.effective_date < current_version.effective_date %}
+        {% endif -%}
+        {% if requested_version.effective_date < current_version.effective_date -%}
             is part of a previous version of {{ page.regulation }} with
             amendments that went into effect on
             {{ ap_date(requested_version.effective_date) }}.
-        {% elif requested_version.effective_date > current_version.effective_date %}
+        {% elif requested_version.effective_date > current_version.effective_date -%}
             is part of a future version of {{ page.regulation }} with
             amendments that will go into effect on
             {{ ap_date(requested_version.effective_date) }}.
-        {% else %}
+        {% else -%}
             is part of {{ page.regulation }}.
-        {% endif %}
-    {% elif versions %}
+        {% endif -%}
+    {% elif versions -%}
         View the current, previous, and future versions of {{ page.regulation }}.
-    {% endif %}
-
+    {% endif -%}
     {{ super() }}
 {%- endblock desc %}
 

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -18,10 +18,11 @@
 {%- endblock title %}
 
 {% block desc -%}
+    {#- 'section' pages are ones that show the actual text of the regulation -#}
     {% if section -%}
-        {% if subpart_type_label == 'Appendix' -%}
+        {% if section.subpart.type == 'Appendix' -%}
             Appendix {{ section.label }}
-        {% elif subpart_type_label == 'Interpretation' %}
+        {% elif section.subpart.type == 'Interpretation' %}
             {#- section.label[7:] strips out the "Interp-" part of the label -#}
             The comment for {{ regulation.part_number }}.{{ section.label[7:] }}
         {% else -%}
@@ -38,9 +39,12 @@
         {% else -%}
             is part of {{ page.regulation }}.
         {% endif -%}
+    {#- 'versions' is the page that lists all versions of a regulation -#}
     {% elif versions -%}
         View the current, previous, and future versions of {{ page.regulation }}.
     {% endif -%}
+    {#- super() tacks on the regulaation's description from Wagtail for more
+    context and also takes care of the regulation's landing page -#}
     {{ super() }}
 {%- endblock desc %}
 

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -173,6 +173,10 @@ class Subpart(models.Model):
         return self.title
 
     @property
+    def type(self):
+        return dict(Subpart.SUBPART_TYPE_CHOICES)[self.subpart_type]
+
+    @property
     def subpart_heading(self):
         """Keeping for now as possible hook into secondary nav"""
         return ''

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -27,7 +27,7 @@ from regdown import regdown
 
 from ask_cfpb.models.pages import SecondaryNavigationJSMixin
 from regulations3k.blocks import RegulationsListingFullWidthText
-from regulations3k.models import Part, Section, SectionParagraph
+from regulations3k.models import Part, Section, SectionParagraph, Subpart
 from regulations3k.resolver import get_contents_resolver, get_url_resolver
 from v1.atomic_elements import molecules, organisms
 from v1.models import CFGOVPage, CFGOVPageManager
@@ -474,6 +474,10 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         next_section = get_next_section(sections, current_index)
         previous_section = get_previous_section(sections, current_index)
 
+        # section.subpart.subpart_type can have a value of 0, 1000, or 2000
+        subpart_type_label = Subpart.SUBPART_TYPE_CHOICES[int(
+            section.subpart.subpart_type / 1000)][1]
+
         context.update({
             'requested_version': effective_version,
             'next_version': next_version,
@@ -487,6 +491,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             'previous_section': previous_section,
             'previous_url': get_section_url(self, previous_section,
                                             date_str=date_str),
+            'subpart_type_label': subpart_type_label,
         })
 
         return TemplateResponse(

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -27,7 +27,7 @@ from regdown import regdown
 
 from ask_cfpb.models.pages import SecondaryNavigationJSMixin
 from regulations3k.blocks import RegulationsListingFullWidthText
-from regulations3k.models import Part, Section, SectionParagraph, Subpart
+from regulations3k.models import Part, Section, SectionParagraph
 from regulations3k.resolver import get_contents_resolver, get_url_resolver
 from v1.atomic_elements import molecules, organisms
 from v1.models import CFGOVPage, CFGOVPageManager
@@ -474,10 +474,6 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         next_section = get_next_section(sections, current_index)
         previous_section = get_previous_section(sections, current_index)
 
-        # section.subpart.subpart_type can have a value of 0, 1000, or 2000
-        subpart_type_label = Subpart.SUBPART_TYPE_CHOICES[int(
-            section.subpart.subpart_type / 1000)][1]
-
         context.update({
             'requested_version': effective_version,
             'next_version': next_version,
@@ -491,7 +487,6 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             'previous_section': previous_section,
             'previous_url': get_section_url(self, previous_section,
                                             date_str=date_str),
-            'subpart_type_label': subpart_type_label,
         })
 
         return TemplateResponse(

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -238,6 +238,11 @@ class RegModelTests(DjangoTestCase):
         for each in Subpart.objects.all():
             self.assertEqual(each.subpart_heading, '')
 
+    def test_type(self):
+        self.assertEqual(self.section_num15.subpart.type, 'Regulation Body')
+        self.assertEqual(self.section_alpha.subpart.type, 'Appendix')
+        self.assertEqual(self.section_interps.subpart.type, 'Interpretation')
+
     def test_effective_version_string_method(self):
         self.assertEqual(
             self.effective_version.__str__(),


### PR DESCRIPTION
Right now, pretty much all iRegs pages have the default cf.gov meta and Open Graph description ("Our vision is a consumer finance marketplace that works for American consumers, responsible providers, and the economy as a whole.") and a title that is just the name of the regulation, even on section/appendix/interp pages. That's been causing alerts in our SEO audits (lots of pages with the same description is bad) and makes search results harder to read.

These changes give every regulation page a title that matches whatever the page's heading is and an informative description that's unique to that page.

See GHE/CFGOV/platform/issues/3723 for more details.

## Additions

- `{% block title %}`, `{% block desc %}`, and `{% block og_desc %}` to the template that renders regulation pages along with logic in each of those blocks to construct the right titles and descriptions for each page
- `Subpart.type` to make a human-readable name for each kind of subpart available in the page template
- Tests for `Subpart.type`

## Changes

- Reorganized the `browse-regulation.html` template a little to group the `head` and `body` blocks

## Testing

1. First, make sure `tox -e unittest regulations3k.tests.test_models` passes.
2. Fire up this branch locally, and choose a regulation or regulations to test with. For any regulations you want to test, edit the landing page in Wagtail to make the "Configuration -> Search Description" field have the same content as what's in "General content -> Intro." For example, if you test Regulation X, update the landing page (http://localhost:8000/admin/pages/11775/edit/#tab-configuration) so the search description is "Regulation X protects consumers when they apply for and have mortgage loans." (I'm going to do this in production for all the regs—see the todos section below).
3. Make sure every kind of page in that regulation has the right title, meta description, and Open Graph description. The page title should match the page's heading. The descriptions will have different formats depending on kind of page:
    - Regulation landing pages will have descriptions that match whatever you set in Wagtail for that page, like "Regulation X protects consumers when they apply for and have mortgage loans."
    - Regulation text pages will have descriptions like "§ 1024.5 is part of 12 CFR Part 1024 (Regulation X). Regulation X protects consumers when they apply for and have mortgage loans."
    - Appendix pages will have descriptions like "Appendix B is part of 12 CFR Part 1024 (Regulation X). Regulation X protects consumers when they apply for and have mortgage loans."
    - Interp pages will have descriptions like "The comment for 1024.17  is part of 12 CFR Part 1024 (Regulation X). Regulation X protects consumers when they apply for and have mortgage loans."
    - The page that lists all of the versions of a regulation will have a description like "View the current, previous, and future versions of 12 CFR Part 1024 (Regulation X). Regulation X protects consumers when they apply for and have mortgage loans."
    - Previous and future versions of regulation text, appendix, and interp pages will have descriptions similar to their current versions but with a phrase like "is part of a previous version of 12 CFR Part 1024 (Regulation X) with amendments that went into effect on Oct. 3, 2015" in it.

## Notes

- We talked about where all the logic for constructing the description for each page should live. It would have been cleaner to put all that logic in the page model, but because there's a lot of extra content needed to make the descriptions—and because all of the logic used in the description is already used elsewhere in the template—I decided to keep it in the template.
- I couldn't get all of the newlines out of the descriptions without a bunch of extra work to make sure all of the pieces had spaces between them. I *think* it's not a problem to have newlines in meta and Open Graph descriptions, though.
- I've never written a Python unit test before. The test I wrote for the new `type` property passes, but I'm not sure if that's the best way to test that it's working.

## Todos

- As this is being reviewed, I'm going to manually set all the regulation landing page search descriptions to be the descriptions from the landing page content.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing