### PR TITLE
Use Postgres as the default test database

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -63,9 +63,10 @@ export ALLOW_ADMIN_URL=True
 # for local development this value is overridden at the end of the file
 export DATABASE_URL=postgres://cfpb@postgres/cfgov
 export PGPASSWORD=cfpb
-# We no longer support sqlite as a test database, so we need to specify postgres
-export TEST_DATABASE_URL=postgres://cfpb@localhost/cfgov
 
+# We don't support SQLite as a test database; tests run against postgres by default.
+# But if you want a custom test DB, TEST_DATABASE_URL is honored. It takes this form:
+# export TEST_DATABASE_URL=postgres://cfpb@localhost/cfgov
 
 #####################
 # Front end settings.

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -64,10 +64,6 @@ export ALLOW_ADMIN_URL=True
 export DATABASE_URL=postgres://cfpb@postgres/cfgov
 export PGPASSWORD=cfpb
 
-# We don't support SQLite as a test database; tests run against postgres by default.
-# But if you want a custom test DB, TEST_DATABASE_URL is honored. It takes this form:
-# export TEST_DATABASE_URL=postgres://cfpb@localhost/cfgov
-
 #####################
 # Front end settings.
 #####################

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -60,10 +60,12 @@ export ALLOW_ADMIN_URL=True
 # See https://github.com/kennethreitz/dj-database-url for URL formatting.
 #########################################################################
 
-# export DATABASE_URL=sqlite:///db.sqlite3
 # for local development this value is overridden at the end of the file
 export DATABASE_URL=postgres://cfpb@postgres/cfgov
 export PGPASSWORD=cfpb
+# We no longer support sqlite as a test database, so we need to specify postgres
+export TEST_DATABASE_URL=postgres://cfpb@localhost/cfgov
+
 
 #####################
 # Front end settings.

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,9 +20,9 @@ jobs:
         # https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml
         image: postgres
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
+          POSTGRES_USER: cfpb
+          POSTGRES_PASSWORD: cfpb
+          POSTGRES_DB: cfgov_test
         ports:
         - 5432:5432
         # needed because the postgres container does not provide a healthcheck
@@ -46,7 +46,6 @@ jobs:
           tox -e ${{ matrix.toxenv }}
         env: 
           TEST_RUNNER: cfgov.test.StdoutCapturingTestRunner 
-          TEST_DATABASE_URL: postgres://postgres:postgres@localhost/postgres
           CI_CHECK_MIGRATIONS: "./manage.py makemigrations --dry-run --check"
 
       - name: Prepare test coverage

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           POSTGRES_USER: cfpb
           POSTGRES_PASSWORD: cfpb
-          POSTGRES_DB: cfgov_test
+          POSTGRES_DB: cfgov
         ports:
         - 5432:5432
         # needed because the postgres container does not provide a healthcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 env:
   global:
     - COVERALLS_PARALLEL=true
-    - TEST_DATABASE_URL=postgres://travis:travis@localhost/travis
+    - DATABASE_URL=postgres://travis:travis@localhost/travis
     - CI_CHECK_MIGRATIONS="./manage.py makemigrations --dry-run --check"
   matrix:
     - RUNTEST='backend'

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,5 +1,6 @@
 from .local import *
 
+
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 TEST_RUNNER = os.environ.get('TEST_RUNNER', 'cfgov.test.TestRunner')

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,23 +1,5 @@
 from .local import *
 
-
-# A test database may be specified through use of the TEST_DATABASE_URL
-# environment variable. If not provided, unit tests will be run against an
-# in-memory SQLite database.
-TEST_DATABASE_URL = os.getenv('TEST_DATABASE_URL')
-if TEST_DATABASE_URL:
-    TEST_DATABASE = dj_database_url.parse(TEST_DATABASE_URL)
-else:
-    TEST_DATABASE = {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-        'TEST': {
-            'NAME': ':memory:',
-        },
-    }
-
-DATABASES = {'default': TEST_DATABASE}
-
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 TEST_RUNNER = os.environ.get('TEST_RUNNER', 'cfgov.test.TestRunner')
@@ -58,3 +40,9 @@ FLAG_SOURCES = (
 # other files don't write them to the local development media directory. The
 # test runner cleans up this directory after the tests run.
 MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'cfgov', 'tests', 'test-media')
+
+
+# A custom test database can be specified, but we don't support SQLite
+TEST_DATABASE_URL = os.getenv('TEST_DATABASE_URL')
+if TEST_DATABASE_URL:
+    DATABASES = {'default': dj_database_url.parse(TEST_DATABASE_URL)}

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -41,9 +41,3 @@ FLAG_SOURCES = (
 # other files don't write them to the local development media directory. The
 # test runner cleans up this directory after the tests run.
 MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'cfgov', 'tests', 'test-media')
-
-
-# A custom test database can be specified, but we don't support SQLite
-TEST_DATABASE_URL = os.getenv('TEST_DATABASE_URL')
-if TEST_DATABASE_URL:
-    DATABASES = {'default': dj_database_url.parse(TEST_DATABASE_URL)}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
             POSTGRES_USER: cfpb
             POSTGRES_PASSWORD: cfpb
             POSTGRES_DB: cfgov
+        ports:
+            - "5432:5432"
 
     python:
         build:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -155,22 +155,14 @@ Then create the database, associated user, and schema for that user:
 
 ```bash
 dropdb --if-exists cfgov && dropuser --if-exists cfpb
-createuser cfpb && createdb -O cfpb cfgov
+createuser --createdb cfpb && createdb -O cfpb cfgov
 psql postgres://cfpb@localhost/cfgov -c 'CREATE SCHEMA cfpb'
 ```
 
-If you absolutely need to use SQLite, you'll need to update your `.env` file
-to comment out the line that specifies Postgres as the db:
+We don't support using an SQLite database, because we use database fields 
+that are specific to Postgres. The `--createdb` flag above allows Django to 
+create temporary Postgres databases when running unit tests.
 
-```bash
-# export DATABASE_URL=postgres://cfpb@localhost/cfgov
-```
-
-And then uncomment the line that tells Django to use SQLite:
-
-```bash
-export DATABASE_URL=sqlite:///db.sqlite3
-```
 
 #### Run the setup script
 

--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -21,9 +21,8 @@ before running the tests:
 workon cfgov-refresh
 ```
 
-If have not set up the standalone installation of cfgov-refresh,
-it's not necessary to run the tests. 
-You can install Tox in your 
+If you have not set up the standalone installation of cfgov-refresh,
+you can still run the tests if you install Tox in your 
 [local installation of Python](https://github.com/cfpb/development/blob/master/guides/installing-python.md):
 
 ```
@@ -32,12 +31,11 @@ pip install tox
 
 If you have set up 
 [a Docker-based installation of cfgov-refresh](/installation/#docker-based-installation),
-you'll need to 
-[access the Python container's shell](http://localhost:8888/running-docker/#access-a-containers-shell) 
-before running the tests:
+you can run the tests there by  
+[accessing the Python container's shell](http://localhost:8888/running-docker/#access-a-containers-shell): 
 
 ```sh
-docker-compose exec python3 bash
+docker-compose exec python bash
 ```
 
 ## Running tests

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,7 @@ setenv=
     LC_ALL=en_US.UTF-8
     WAGTAIL_SHARING_HOSTNAME=content.localhost
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
+    TEST_DATABASE_URL={env:TEST_DATABASE_URL:postgres://cfpb:cfpb@localhost/cfgov_test}
 deps=
     -r{toxinidir}/requirements/libraries.txt
     -r{toxinidir}/requirements/test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ commands=
 changedir=
     {toxinidir}/cfgov
 passenv=
-    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TEST_DATABASE_URL TEST_RUNNER
+    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DATABASE_URL TEST_RUNNER
 setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_ADMIN_USERNAME=admin
@@ -104,7 +104,7 @@ setenv=
     LC_ALL=en_US.UTF-8
     WAGTAIL_SHARING_HOSTNAME=content.localhost
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
-    TEST_DATABASE_URL={env:TEST_DATABASE_URL:postgres://cfpb:cfpb@localhost/cfgov_test}
+    DATABASE_URL={env:DATABASE_URL:postgres://cfpb:cfpb@localhost/cfgov}
 deps=
     -r{toxinidir}/requirements/libraries.txt
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
We now use a Postgres-specific Django db field, JSONField, and to test this feature 
we can't use SQLite. So we need to specify our test database as Postgres, 
rather than providing that option.

This adds an uncommented line to our `.env_SAMPLE` file to specify Postgres
for local development and testing.

Documentation is updated to note that we're dropping support for SQLite and
to change setups so that Django ~~can create~~ creates test Postgres databases.

**UPDATE**
We don't need to "specify" Postgres; we can remove options for SQLite and let Django use Postgres by default. So we don't need a `TEST_DATABASE_URL`.
