### PR TITLE
CCDB Landing page: IE11 remove node patch

### DIFF
--- a/cfgov/unprocessed/apps/ccdb-landing-map/js/TileMap.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/js/TileMap.js
@@ -204,6 +204,7 @@ export function tooltipFormatter() {
  * Draw a legend on a chart.
  * @param {Object} chart A highchart chart.
  */
+// eslint-disable-next-line max-lines-per-function, require-jsdoc
 export function _drawLegend( chart ) {
   const bins = chart.options.bins;
   const marginTop = chart.margin[0] || 0;

--- a/cfgov/unprocessed/apps/ccdb-landing-map/js/landing-map.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/js/landing-map.js
@@ -11,7 +11,7 @@ function start( isPerCapita ) {
   const elements = el.querySelectorAll( '*' );
   for ( let i = 0; i < elements.length; i++ ) {
     const node = elements[i];
-    node.parentNode.removeChild(node);
+    node.parentNode.removeChild( node );
   }
 
   const dataUrl = 'https://files.consumerfinance.gov/ccdb/hero-map-3y.json';

--- a/cfgov/unprocessed/apps/ccdb-landing-map/js/landing-map.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/js/landing-map.js
@@ -10,7 +10,8 @@ function start( isPerCapita ) {
   const el = document.getElementById( 'landing-map' );
   const elements = el.querySelectorAll( '*' );
   for ( let i = 0; i < elements.length; i++ ) {
-    elements[i].remove();
+    const node = elements[i];
+    node.parentNode.removeChild(node);
   }
 
   const dataUrl = 'https://files.consumerfinance.gov/ccdb/hero-map-3y.json';


### PR DESCRIPTION
Fixing an ie11 bug.  Object doesn't support .remove()