### PR TITLE
Fix sublanding filterable page info units

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -84,7 +84,7 @@
                 {% endif %}
         {%- endif %}
 
-        {%- if value.heading %}
+        {%- if value.heading.text %}
             <div class="m-info-unit_heading-text">
                 {% include_block value.heading %}
             </div>

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -84,9 +84,13 @@
                 {% endif %}
         {%- endif %}
 
-        {%- if value.heading.text %}
+        {%- if value.heading %}
             <div class="m-info-unit_heading-text">
                 {% include_block value.heading %}
+            </div>
+        {%- elif value.heading %}
+            <div class="m-info-unit_heading-text">
+                {{ value.heading|safe }}
             </div>
         {%- endif %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -151,8 +151,8 @@
                                         content-l_col-1-2">
                                 {% set post_url = pageurl(post) %}
                                 {% set heading = '<h2 class="h3">' ~
-                                                post.preview_title ~
-                                                '</h2>'
+                                                 post.preview_title ~
+                                                 '</h2>'
                                 if post.preview_title else null %}
                                 {% if post.secondary_link_url and post.secondary_link_text %}
                                     {% set links = [
@@ -162,14 +162,16 @@
                                         }
                                     ] %}
                                 {% endif %}
-                                {{ info_unit( {
-                                    'image': {
+
+                                {{ info_unit( 
+                                    {
+                                        'image': {
                                         'upload': post.preview_image,
                                         'alt': post.preview_image.alt if post.preview_image.alt else '',
-                                    } if post.preview_image else {},
-                                    'heading': heading,
-                                    'body': post.preview_description,
-                                    'links': links or null,
+                                        } if post.preview_image else {},
+                                        'heading': heading,
+                                        'body': post.preview_description,
+                                        'links': links or null,
                                     },
                                     '50-50',
                                     value.link_image_and_heading

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -150,14 +150,10 @@
                             <div class="content-l_col
                                         content-l_col-1-2">
                                 {% set post_url = pageurl(post) %}
-                                {% set heading = '<a href="' ~ post_url ~ '"><h2 class="h3">' ~
+                                {% set heading = '<h2 class="h3">' ~
                                                 post.preview_title ~
-                                                '</h2></a>'
+                                                '</h2>'
                                 if post.preview_title else null %}
-                                {% set sub_heading = '<a href="' ~ post_url ~ '"><h2 class="h4">' ~
-                                                    post.preview_subheading ~
-                                                    '</h2></a>'
-                                if post.preview_subheading else null %}
                                 {% if post.secondary_link_url and post.secondary_link_text %}
                                     {% set links = [
                                         {
@@ -172,11 +168,12 @@
                                         'alt': post.preview_image.alt if post.preview_image.alt else '',
                                     } if post.preview_image else {},
                                     'heading': heading,
-                                    'sub_heading': sub_heading,
                                     'body': post.preview_description,
                                     'links': links or null,
-                                    'link_image_and_heading': value.link_image_and_heading
-                                } ) }}
+                                    },
+                                    '50-50',
+                                    value.link_image_and_heading
+                                 ) }}
                             </div>
                             {% endfor %}
                         </div>


### PR DESCRIPTION
This is an attempt to fix filterable info units on sublanding filterable pages like https://www.consumerfinance.gov/consumer-tools/everyone-has-a-story/. These info units are constructed rather than actual info unit blocks. 

It tries to work around a change in https://github.com/cfpb/cfgov-refresh/pull/5497 that expects `value.heading` to be a block.

This is a draft PR to get it up on UPC to test.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
