### PR TITLE
Ask CFPB: Handle questions with no answers in export

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -69,11 +69,17 @@ def assemble_output():
             # If no text block is found,
             # there is either a HowTo or FAQ schema block.
             # Both define a description field, so we'll use that here.
-            answer_schema = filter(
-                lambda item: item['type'] == 'how_to_schema' or
-                item['type'] == 'faq_schema', answer_streamfield)
+            answer_schema = list(
+                filter(
+                    lambda item: item['type'] == 'how_to_schema' or
+                    item['type'] == 'faq_schema', answer_streamfield
+                )
+            )
             if answer_schema:
-                answer = next(answer_schema).get('value').get('description')
+                answer = answer_schema[0].get('value').get('description')
+            else:
+                # This is a question with no answer, possibly a new draft.
+                answer = ''
 
         output['Answer'] = clean_and_strip(answer).replace('\x81', '')
         output['ShortAnswer'] = clean_and_strip(page['short_answer'])


### PR DESCRIPTION
Our Ask CFPB CSV export expected all questions to have an answer of some kind, be it a text block, or FAQ, or How To. If a question is created as a draft, but does not have any answer text yet, the export will fail.

This change fixes that issue.

An example page that was created and saved as a draft but without any answer text is 13831 (per the nightly database dump from 4/7/20).

## Testing

1. Using `master`, attempt to export Ask CFPB data from http://localhost:8000/admin/export-ask
2. Observe a `StopIteration` exception from the call to `next()` on the `filter` object without a next result.
3. Checkout `allow-ask-export-questions-no-answers`, and attempt to export Ask CFPB data from http://localhost:8000/admin/export-ask
4. Observe the export completes as expected and the data exists as expected

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
