### PR TITLE
Update old-style middleware

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -113,44 +113,25 @@ OPTIONAL_APPS = [
 
 POSTGRES_APPS = []
 
-if django.VERSION < (2, 0):
-    MIDDLEWARE_CLASSES = (
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "django.middleware.locale.LocaleMiddleware",
-        "django.middleware.http.ConditionalGetMiddleware",
-        "django.middleware.common.CommonMiddleware",
-        "django.middleware.csrf.CsrfViewMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.messages.middleware.MessageMiddleware",
-        "core.middleware.ParseLinksMiddleware",
-        "core.middleware.DownstreamCacheControlMiddleware",
-        "flags.middleware.FlagConditionsMiddleware",
-        "wagtail.core.middleware.SiteMiddleware",
-        "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-    )
-else:
-    MIDDLEWARE = (
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "django.middleware.locale.LocaleMiddleware",
-        "django.middleware.http.ConditionalGetMiddleware",
-        "django.middleware.common.CommonMiddleware",
-        "django.middleware.csrf.CsrfViewMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.messages.middleware.MessageMiddleware",
-        "core.middleware.ParseLinksMiddleware",
-        "core.middleware.DownstreamCacheControlMiddleware",
-        "flags.middleware.FlagConditionsMiddleware",
-        "wagtail.core.middleware.SiteMiddleware",
-        "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-    )
+MIDDLEWARE = (
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
+    "django.middleware.http.ConditionalGetMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "core.middleware.ParseLinksMiddleware",
+    "core.middleware.DownstreamCacheControlMiddleware",
+    "flags.middleware.FlagConditionsMiddleware",
+    "wagtail.core.middleware.SiteMiddleware",
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+)
 
 CSP_MIDDLEWARE = ("csp.middleware.CSPMiddleware",)
 
 if "CSP_ENFORCE" in os.environ:
-    if django.VERSION < (2, 0):
-        MIDDLEWARE_CLASSES += CSP_MIDDLEWARE
-    else:
-        MIDDLEWARE += CSP_MIDDLEWARE
+    MIDDLEWARE += CSP_MIDDLEWARE
 
 ROOT_URLCONF = "cfgov.urls"
 
@@ -443,10 +424,7 @@ for app in OPTIONAL_APPS:
         for name in app.get("apps", ()):
             if name not in INSTALLED_APPS:
                 INSTALLED_APPS += (name,)
-        if django.VERSION < (2, 0):
-            MIDDLEWARE_CLASSES += app.get("middleware", ())
-        else:
-            MIDDLEWARE += app.get("middleware", ())
+        MIDDLEWARE += app.get("middleware", ())
     except ImportError:
         pass
 

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -52,12 +52,7 @@ if os.environ.get("ENABLE_SQL_LOGGING"):
 if os.environ.get("ENABLE_DEBUG_TOOLBAR"):
     INSTALLED_APPS += ("debug_toolbar",)
 
-    if django.VERSION < (2, 0):
-        MIDDLEWARE_CLASSES += (
-            "debug_toolbar.middleware.DebugToolbarMiddleware",
-        )
-    else:
-        MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)
+    MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)
 
     DEBUG_TOOLBAR_PANELS = [
         "debug_toolbar.panels.versions.VersionsPanel",
@@ -81,10 +76,7 @@ if os.environ.get("ENABLE_DEBUG_TOOLBAR"):
         "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG,
     }
 
-if django.VERSION < (2, 0):
-    MIDDLEWARE_CLASSES += CSP_MIDDLEWARE
-else:
-    MIDDLEWARE += CSP_MIDDLEWARE
+MIDDLEWARE += CSP_MIDDLEWARE
 
 # Disable caching when working locally
 CACHES = {

--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -9,7 +9,13 @@ from core.utils import add_link_markup, get_link_tags
 
 
 class DownstreamCacheControlMiddleware(object):
-    def process_response(self, request, response):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
         if 'CSRF_COOKIE_USED' in request.META:
             response['Edge-Control'] = 'no-store'
         return response
@@ -42,7 +48,12 @@ def parse_links(html, encoding=None):
 
 
 class ParseLinksMiddleware(object):
-    def process_response(self, request, response):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
         if self.should_parse_links(request.path, response['content-type']):
             response.content = parse_links(
                 response.content,

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -10,17 +10,28 @@ from v1.models import CFGOVPage
 from v1.tests.wagtail_pages.helpers import publish_page
 
 
+class TestDownstreamCacheControlMiddleware(TestCase):
+
+    def test_edge_control_header_in_response(self):
+        response = self.client.get('/', CSRF_COOKIE='', CSRF_COOKIE_USED=True)
+        self.assertIn('Edge-Control', response)
+
+    def test_edge_control_header_not_in_response(self):
+        response = self.client.get('/')
+        self.assertNotIn('Edge-Control', response)
+
+
 @mock.patch('core.middleware.parse_links')
 class TestParseLinksMiddleware(TestCase):
     def test_parse_links_gets_called(self, mock_parse_links):
         """Middleware correctly invokes parse links when rendering webpage"""
-        response = self.client.get('/foo/bar')
-        mock_parse_links.assert_called_with(response.content, encoding='utf-8')
+        self.client.get('/')
+        mock_parse_links.assert_called_once()
 
-    @override_settings(PARSE_LINKS_EXCLUSION_LIST=[r'^/foo/'])
+    @override_settings(PARSE_LINKS_EXCLUSION_LIST=[r'^/'])
     def test_parse_links_does_not_get_called_excluded(self, mock_parse_links):
         """Middleware does not invoke parse links when path is excluded"""
-        self.client.get('/foo/bar')
+        self.client.get('/')
         mock_parse_links.assert_not_called()
 
 


### PR DESCRIPTION
This change updates our middleware from the old pre-Django 1.10 style to the new post-Django 1.10 style. As part of this we'll be using `MIDDLEWARE` instead of `MIDDLEWARE_CLASSES` on Django 1.11 as well as 2.0.

This fixes middleware errors when running the tests with Django 2.0.

It also adds tests for `DownstreamCacheControlMiddleware`.

This is the result of pairing that @cwdavies and I did.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
