### PR TITLE
Fix an assertRedirects that's failing in Django 2.0

### DIFF
--- a/cfgov/v1/tests/test_admin_views.py
+++ b/cfgov/v1/tests/test_admin_views.py
@@ -81,7 +81,7 @@ class TestCDNManagementView(TestCase):
 
     def test_requires_authentication(self):
         response = self.client.get(reverse("manage-cdn"))
-        expected_url = "http://testserver/admin/login/?next=/admin/cdn/"
+        expected_url = "/admin/login/?next=/admin/cdn/"
         self.assertRedirects(
             response, expected_url, fetch_redirect_response=False
         )


### PR DESCRIPTION
Since Django 1.8, [redirects are not forced to be absolute URLs](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.SimpleTestCase.assertRedirects). `assertRedirects` fails in 2.0 with the absolute URL in this test.

This change fixes that by removing the host component of the URL.

## Testing

1. Comment out TDP in `requirements/libraries.txt`
2. `tox -e unittest-future` will show that `v1.tests.test_admin_views.TestCDNManagementView. test_requires_authentication` no longer fails.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
