### PR TITLE
Simplify anchor link handling in parse links middleware

### DIFF
--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -117,8 +117,8 @@ def add_link_markup(tag, request_path):
         # anchor links.
         # TODO: Remove that functionality when we get to Wagtail>=2.7, which
         # adds the ability to create anchor links.
-        in_page_anchor_pattern = re.compile(request_path + r'#')
-        if in_page_anchor_pattern.match(tag['href']):
+        in_page_anchor_pattern = request_path + r'#'
+        if tag['href'].startswith(in_page_anchor_pattern):
             # Strip current path from in-page anchor links
             tag['href'] = tag['href'].replace(request_path, '')
             return str(tag)


### PR DESCRIPTION
Prior to this change we were using `request.path` as a part of a regular expression compilation. This depends on the request path being a valid regular expression. We encountered an issue where a request path in production was not.

This change, suggested by @wpears, does a straight string comparison between an link href and the request path looking for an anchor's `#`.

This causes the bad request path we saw in production (`/about-us/blog/worried-about-making-your-auto-loan-payments-your-lender-may-have-options-to-help/%20)`) to 404 instead of 500.

To test this requires the production-like Docker setup that uses Apache. You can [use the docs to get it up and running](https://cfpb.github.io/cfgov-refresh/running-docker/#docker-compose). Then visit http://localhost:8000/about-us/blog/worried-about-making-your-auto-loan-payments-your-lender-may-have-options-to-help/%20) and observe a 404.

I've also started an adhoc deploy of this.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
