### PR TITLE
Remove `r` prefix to string that's not a regex

### DIFF
--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -117,7 +117,7 @@ def add_link_markup(tag, request_path):
         # anchor links.
         # TODO: Remove that functionality when we get to Wagtail>=2.7, which
         # adds the ability to create anchor links.
-        in_page_anchor_pattern = request_path + r'#'
+        in_page_anchor_pattern = request_path + '#'
         if tag['href'].startswith(in_page_anchor_pattern):
             # Strip current path from in-page anchor links
             tag['href'] = tag['href'].replace(request_path, '')


### PR DESCRIPTION
A prior change to address a production issue left an `r` prefix to the string matching anchor links. This change removes it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
