### PR TITLE
Fix some additional print style issues

### DIFF
--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -34,17 +34,20 @@
     }
 
     a[href*="://"]:after {
-        // Output href in parentheses for links with a protocol already there
+        // Output href in parentheses for links with a protocol already there.
         content: " (" attr(href) ")";
     }
 
-    a[href^="/"]:after {
-        // Output root-relative hrefs in parentheses with our domain prepended
+    a[href^="/"]:not([href*="?authors"]):not([href="/"]):after {
+        // Output root-relative hrefs in parentheses with our domain prepended,
+        // as long as they are not author links or the logo homepage link.
         content: " (https://www.consumerfinance.gov" attr(href) ")";
     }
 
-    a[href^="#"] {
-        // Style in-page anchor links (like page TOCs) to not look like links
+    a[href^="#"],
+    a[href*="?authors"]{
+        // Style in-page anchor links (like page TOCs) and author links
+        // to not look like links.
         color: @dark-gray;
         border-bottom-width: 0;
     }
@@ -60,6 +63,7 @@
         content: "Watch the video at https://www.youtube.com/watch?v=" attr(data-id);
     }
 
+    .m-global-eyebrow,
     .join-the-conversation,
     .o-email-signup,
     .rss-subscribe {


### PR DESCRIPTION
Removals

- Remove the global eyebrow on print (wasn't printing in Chrome for reasons I don't understand, but was printing in Safari and it's pretty rough with the `href` output on)

## Changes

- Prevent `href` output for author links
- Prevent `href` output for the logo link

## Testing

1. Pull branch
1. `gulp styles`
1. Load up something like http://localhost:8000/about-us/blog/avoid-scams-find-help-during-quarantine/ in Safari and print it


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge 18
- [x] Internet Explorer 9 and 11