### PR TITLE
Enable `unittest-future` in GitHub Actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,7 +12,7 @@ jobs:
         toxenv:
           - lint-current
           - unittest-current
-          # - unittest-future
+          - unittest-future
 
     services:
       postgres:

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -49,4 +49,4 @@ https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.3.1/ccdb5_api-1.3.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.6.1/ccdb5_ui-1.6.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.14.0/comparisontool-1.14.0-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.2.4/teachers_digital_platform-1.2.4-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.3.0/teachers_digital_platform-1.3.0-py3-none-any.whl

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist=True
 # of django-treebeard and djangorestframework.
 # tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-{current}, unittest-{current}
+envlist=lint-{current}, unittest-{current,future}
 
 
 [testenv]


### PR DESCRIPTION
This change will enable unittest-future, which currently tests Python 3.6, Django 2.0, and Wagtail 2.3, in GitHub Actions, with Django 2.0 being the new thing. This means any changes that fail against Django 2.0 will fail the backend unit tests.

This PR also updated TDP to 1.3.0, which supports Django 2.0.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
