### PR TITLE
Fix deprecated usage of is_authenticated as method

### DIFF
--- a/cfgov/v1/tests/views/test_login_views.py
+++ b/cfgov/v1/tests/views/test_login_views.py
@@ -1,0 +1,77 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class LoginViewsTestCase(TestCase):
+
+    def test_login_with_lockout_no_auth(self):
+        response = self.client.get('/login/?next=https://example.com')
+        self.assertTemplateUsed(response, 'wagtailadmin/login.html')
+        self.assertEqual(response.context['next'], '/login/welcome/')
+
+    def test_login_with_lockout_failed_login(self):
+        self.client.post(
+            '/login/',
+            {'username': 'admin', 'password': 'badadmin'}
+        )
+        self.assertIsNotNone(
+            User.objects.get(username='admin').failedloginattempt
+        )
+
+    def test_login_with_lockout_success_after_failed_login(self):
+        response = self.client.post(
+            '/login/',
+            {'username': 'admin', 'password': 'badadmin'}
+        )
+        response = self.client.post(
+            '/login/',
+            {'username': 'admin', 'password': 'admin'}
+        )
+        self.assertRedirects(
+            response,
+            '/login/check_permissions/?next=/login/welcome/',
+            target_status_code=302,
+            fetch_redirect_response=False,
+        )
+
+    def test_login_with_lockout_success(self):
+        response = self.client.post(
+            '/login/',
+            {'username': 'admin', 'password': 'admin'}
+        )
+        self.assertRedirects(
+            response,
+            '/login/check_permissions/?next=/login/welcome/',
+            target_status_code=302,
+            fetch_redirect_response=False,
+        )
+
+    def test_login_with_lockout_authenticated_redirects(self):
+        self.client.login(username='admin', password='admin')
+        response = self.client.get('/login/')
+        self.assertRedirects(
+            response,
+            '/login/check_permissions/?next=',
+            target_status_code=302,
+            fetch_redirect_response=False,
+        )
+
+    def test_check_permissions_no_auth(self):
+        response = self.client.get('/login/check_permissions/?next=/admin/')
+        self.assertRedirects(response, '/login/?next=/admin/')
+
+    def test_check_permissions_next_url_does_not_exist(self):
+        self.client.login(username='admin', password='admin')
+        response = self.client.get('/login/check_permissions/?next=/badurl/')
+        self.assertRedirects(response, '/login/welcome/')
+
+    def test_check_permissions_next_permissions_problem(self):
+        User.objects.create_user(
+            username='noperm', email='', password='noperm'
+        )
+        self.client.login(username='noperm', password='noperm')
+        response = self.client.get('/login/check_permissions/?next=/admin/')
+        self.assertIn(
+            b'You do not have permission to access this page.',
+            response.content
+        )

--- a/cfgov/v1/views/__init__.py
+++ b/cfgov/v1/views/__init__.py
@@ -103,7 +103,7 @@ def login_with_lockout(request, template_name='wagtailadmin/login.html'):
             return HttpResponseRedirect(
                 '/login/check_permissions/?next=' + redirect_to)
     else:
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             return HttpResponseRedirect(
                 '/login/check_permissions/?next=' + redirect_to)
         form = LoginForm(request)
@@ -128,7 +128,7 @@ def check_permissions(request):
     redirect_to = request.POST.get(REDIRECT_FIELD_NAME,
                                    request.GET.get(REDIRECT_FIELD_NAME, ''))
 
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         return HttpResponseRedirect(
             "%s?%s=%s" % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, redirect_to)
         )


### PR DESCRIPTION
Django 2.0 removes the ability to call `User.is_authenticated` as a method. It was deprecated in Django 1.10. It is not usable only as a property.

https://docs.djangoproject.com/en/3.0/releases/2.0/#features-removed-in-2-0

## Testing

1. Edit `requirements/django.txt` to pin 2.0.13
2. Rebuild your virtualenv or [Python Docker container](https://cfpb.github.io/cfgov-refresh/running-docker/#update-python-dependencies)
3. Run cfgov-refresh **from `master`**
4. Visit https://localhost:8000/admin and observe the following error:

   ![image](https://user-images.githubusercontent.com/10562538/79139081-a6bfd900-7d83-11ea-88a2-f065d08b9a50.png)

5. Run cfgov-refresh **from `fix-is-auth-method-dj2`** (this PR)
6. Visit https://localhost:8000/admin and observe the following error:

   ![image](https://user-images.githubusercontent.com/10562538/79138980-7b3cee80-7d83-11ea-9baa-6c194bbdeb26.png)

7. Note the above error *is not* a `TypeError` and does not happen with a check of `is_authenticated()`

## Notes

This PR only corrects the calls of `is_authenticated`. The `AttributeError` that still occurs on http://localhost:8000/login/?next=/admin/ will be addressed in another PR.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
