### PR TITLE
Fix wellbeing and diversity_inclusion so URLs are case-insensitive

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -385,11 +385,11 @@ urlpatterns = [
     re_path(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),
 
     re_path(
-        r'^consumer-tools/financial-well-being/',
+        r'^(?i)consumer-tools/financial-well-being/',
         include('wellbeing.urls')
     ),
     re_path(
-        r'^about-us/diversity-and-inclusion/',
+        r'^(?i)about-us/diversity-and-inclusion/',
         include((
             'diversity_inclusion.urls',
             'diversity_inclusion'),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -385,11 +385,11 @@ urlpatterns = [
     re_path(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),
 
     re_path(
-        r'^(?i)consumer-tools/financial-well-being/',
+        r'^consumer-tools/financial-well-being/',
         include('wellbeing.urls')
     ),
     re_path(
-        r'^(?i)about-us/diversity-and-inclusion/',
+        r'^about-us/diversity-and-inclusion/',
         include((
             'diversity_inclusion.urls',
             'diversity_inclusion'),

--- a/cfgov/diversity_inclusion/urls.py
+++ b/cfgov/diversity_inclusion/urls.py
@@ -11,19 +11,19 @@ except ImportError:
 
 urlpatterns = [
     re_path(
-        r'^voluntary-assessment-onboarding-form/$',
+        r'^voluntary-assessment-onboarding-form/$(?i)',
         GetAssessmentForm.as_view(),
         name='voluntary_assessment_form'
     ),
     re_path(
-        r'^voluntary-assessment-onboarding-form/form-submitted/$',
+        r'^voluntary-assessment-onboarding-form/form-submitted/$(?i)',
         TemplateView.as_view(
             template_name='diversity_inclusion/form-submitted.html'
         ),
         name='form_submitted'
     ),
     re_path(
-        r'^voluntary-assessment-onboarding-form/privacy-act-statement/$',
+        r'^voluntary-assessment-onboarding-form/privacy-act-statement/$(?i)',
         TemplateView.as_view(
             template_name='diversity_inclusion/privacy.html'
         ),

--- a/cfgov/wellbeing/urls.py
+++ b/cfgov/wellbeing/urls.py
@@ -11,15 +11,15 @@ except ImportError:
 
 urlpatterns = [
     re_path(
-        r'^$',
+        r'^$(?i)',
         TemplateView.as_view(template_name='wellbeing/home.html'),
         name='fwb_home'
     ),
     re_path(
-        r'^results/$', ResultsView.as_view(), name='fwb_results'
+        r'^results/$(?i)', ResultsView.as_view(), name='fwb_results'
     ),
     re_path(
-        r'^about/$',
+        r'^about/$(?i)',
         TemplateView.as_view(template_name='wellbeing/about.html'),
         name='fwb_about'
     ),


### PR DESCRIPTION
Add (?i) to wellbeing and diversity_inclusion so URLs are case-insensitive

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: