### PR TITLE
Remove django-overextends

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -65,7 +65,6 @@ INSTALLED_APPS = (
     "haystack",
     "ask_cfpb",
     "agreements",
-    "overextends",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -153,7 +152,7 @@ TEMPLATES = [
         # Look for Django templates in each app under a templates subdirectory
         "APP_DIRS": True,
         "OPTIONS": {
-            "builtins": ["overextends.templatetags.overextends_tags"],
+            "builtins": [],
             "context_processors": [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",

--- a/cfgov/templates/modeladmin/create.html
+++ b/cfgov/templates/modeladmin/create.html
@@ -1,4 +1,4 @@
-{% overextends "modeladmin/create.html" %}
+{% extends "modeladmin/create.html" %}
 
 {% block header %}
 {{ block.super }}

--- a/cfgov/templates/registration/logged_out.html
+++ b/cfgov/templates/registration/logged_out.html
@@ -1,4 +1,4 @@
-{% overextends "wagtailadmin/login.html" %}
+{% extends "wagtailadmin/login.html" %}
 {% load i18n admin_static %}
 
 {% block furniture %}

--- a/cfgov/templates/wagtailadmin/access_denied.html
+++ b/cfgov/templates/wagtailadmin/access_denied.html
@@ -1,4 +1,4 @@
-{% overextends "wagtailadmin/login.html" %}
+{% extends "wagtailadmin/login.html" %}
 {% load i18n admin_static %}
 
 

--- a/cfgov/templates/wagtailadmin/login.html
+++ b/cfgov/templates/wagtailadmin/login.html
@@ -1,4 +1,4 @@
-{% overextends "wagtailadmin/login.html" %}
+{% extends "wagtailadmin/login.html" %}
 {% load staticfiles i18n %}
 
 {% block furniture %}

--- a/cfgov/templates/wagtailadmin/pages/edit.html
+++ b/cfgov/templates/wagtailadmin/pages/edit.html
@@ -1,4 +1,4 @@
-{% overextends "wagtailadmin/pages/edit.html" %}
+{% extends "wagtailadmin/pages/edit.html" %}
 {% block content %}
 {{ block.super }}
 {% if page.answer_base %}

--- a/cfgov/templates/welcome.html
+++ b/cfgov/templates/welcome.html
@@ -1,4 +1,4 @@
-{% overextends "wagtailadmin/login.html" %}
+{% extends "wagtailadmin/login.html" %}
 {% load i18n admin_static %}
 
 {% block furniture %}

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -14,7 +14,6 @@ django-js-asset==1.1.0
 django-localflavor==2.2
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
-django-overextends==0.4.3
 django-storages==1.7.1
 django-treebeard==3.0
 django-watchman==0.15.0


### PR DESCRIPTION
Since 1.9, Django's built-in `extends` template tag does everything that the django-overextends library's `overextends` template tag did, and django-overextends no longer appears to be maintained.

This change removes django-overextends and uses `extends` in place of `overextends`. The practical effect of this is to fix errors caused by API incompatibilities in django-overextends with Django 2.0.

## Testing

1. Edit `requirements/django.txt` to pin 2.0.13
2. Rebuild your virtualenv or [Python Docker container](https://cfpb.github.io/cfgov-refresh/running-docker/#update-python-dependencies)
3. Run cfgov-refresh **from `master`**
4. Visit https://localhost:8000/admin and observe the following error:

   ![image](https://user-images.githubusercontent.com/10562538/79138980-7b3cee80-7d83-11ea-9baa-6c194bbdeb26.png)

5. Run cfgov-refresh **from `remove-django-overextends`** (this PR)
6. Visit https://localhost:8000/admin and login successfully without the above error.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
