### PR TITLE
Appops 834 - Only Deploy PSQL and Elasticsearch to non manager nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,11 @@ pipeline {
                     env.CFGOV_SITE_SCHEME = 'https'
                     env.CFGOV_SITE_DOMAIN = "appops-${STACK_NAME}.${BASE_HOSTNAME}"
                     env.CFGOV_SITE_URL = "${CFGOV_SITE_SCHEME}://${CFGOV_SITE_DOMAIN}"
+
+                    // Docker tag names
+                    env.IMAGE_TAG="${stackBaseName}-${BUILD_NUMBER}"
+                    env.CFGOV_WEB_REPO="${DOCKER_REGISTRY}/${DOCKER_REGISTRY_ORG}/cf-gov"
+                    env.CFGOV_WEB_IMAGE="${CFGOV_WEB_REPO}:${IMAGE_TAG}"
                 }
                 sh 'env | sort'
             }
@@ -94,6 +99,32 @@ pipeline {
                         env.CFGOV_PYTHON_IMAGE = image.imageName()
                     }
                 }
+            }
+        }
+        stage ('"master" Override') {
+            when {
+                branch 'master'
+            }
+            environment {
+                AUTH_OIDC_CLIENT_CREDS = credentials('collab-monolith-oidc-client-master')
+            }
+            steps {
+                script {
+                    env.AUTH_MODE = 'oidc'
+                    env.AUTH_OIDC_CLIENT_ID = env.AUTH_OIDC_CLIENT_CREDS_USR
+                    
+                    env.COLLAB_SITE_DOMAIN = "cfgov.${BASE_HOSTNAME}"
+                    env.COLLAB_SITE_URL = "${CFGOV_SITE_SCHEME}://${CFGOV_SITE_DOMAIN}"
+                }
+                sh 'env | sort'
+                // FIXME: If we ever go to production with this, we'll need a better
+                //        way of setting mod_auth_openidc's crypto passphrase.  For now,
+                //        it's just the stack name to make Swarm happy since it won't let
+                //        you change secrets on deploys. 
+                sh """
+                echo '${AUTH_OIDC_CLIENT_CREDS_PSW}' > ${WORKSPACE}/auth_oidc_client_secret
+                echo '${STACK_NAME}' > ${WORKSPACE}/auth_oidc_crypto_passphrase
+                """
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,14 @@ pipeline {
     }
 
     environment {
+        APP_NAME = "cf-gov"
+        BASE_HOSTNAME = 'demo.cfpb.gov'
         IMAGE_REPO="cfpb/cfgov-python"
         IMAGE_TAG="${JOB_BASE_NAME}-${BUILD_NUMBER}"
         STACK_PREFIX = 'cfgov'
+        DOCKER_REGISTRY = 'dtr.cfpb.gov'
+        DOCKER_REGISTRY_URL = 'https://dtr.cfpb.gov/'
+        DOCKER_REGISTRY_ORG = 'development'
     }
 
     parameters {
@@ -38,6 +43,11 @@ pipeline {
                     env.STACK_NAME = dockerStack.sanitizeStackName("${env.STACK_PREFIX}-${JOB_BASE_NAME}")
                     env.CFGOV_HOSTNAME = dockerStack.getHostingDomain(env.STACK_NAME)
                     env.IMAGE_NAME_LOCAL = "${env.IMAGE_REPO}:${env.IMAGE_TAG}"
+
+                    // Site name
+                    env.CFGOV_SITE_SCHEME = 'https'
+                    env.CFGOV_SITE_DOMAIN = "appops-${STACK_NAME}.${BASE_HOSTNAME}"
+                    env.CFGOV_SITE_URL = "${CFGOV_SITE_SCHEME}://${CFGOV_SITE_DOMAIN}"
                 }
                 sh 'env | sort'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         BASE_HOSTNAME = 'demo.cfpb.gov'
         IMAGE_REPO="cfpb/cfgov-python"
         IMAGE_TAG="${JOB_BASE_NAME}-${BUILD_NUMBER}"
-        STACK_PREFIX = 'cfgov'
+        STACK_PREFIX = 'josh'
         DOCKER_REGISTRY = 'dtr.cfpb.gov'
         DOCKER_REGISTRY_URL = 'https://dtr.cfpb.gov/'
         DOCKER_REGISTRY_ORG = 'development'
@@ -46,7 +46,7 @@ pipeline {
 
                     // Site name
                     env.CFGOV_SITE_SCHEME = 'https'
-                    env.CFGOV_SITE_DOMAIN = "appops-${STACK_NAME}.${BASE_HOSTNAME}"
+                    env.CFGOV_SITE_DOMAIN = "josh-test-${STACK_NAME}.${BASE_HOSTNAME}"
                     env.CFGOV_SITE_URL = "${CFGOV_SITE_SCHEME}://${CFGOV_SITE_DOMAIN}"
 
                     // Docker tag names

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,14 +11,9 @@ pipeline {
     }
 
     environment {
-        APP_NAME = "cf-gov"
-        BASE_HOSTNAME = 'demo.cfpb.gov'
         IMAGE_REPO="cfpb/cfgov-python"
         IMAGE_TAG="${JOB_BASE_NAME}-${BUILD_NUMBER}"
-        STACK_PREFIX = 'josh'
-        DOCKER_REGISTRY = 'dtr.cfpb.gov'
-        DOCKER_REGISTRY_URL = 'https://dtr.cfpb.gov/'
-        DOCKER_REGISTRY_ORG = 'development'
+        STACK_PREFIX = 'test-cfgov'
     }
 
     parameters {
@@ -43,16 +38,6 @@ pipeline {
                     env.STACK_NAME = dockerStack.sanitizeStackName("${env.STACK_PREFIX}-${JOB_BASE_NAME}")
                     env.CFGOV_HOSTNAME = dockerStack.getHostingDomain(env.STACK_NAME)
                     env.IMAGE_NAME_LOCAL = "${env.IMAGE_REPO}:${env.IMAGE_TAG}"
-
-                    // Site name
-                    env.CFGOV_SITE_SCHEME = 'https'
-                    env.CFGOV_SITE_DOMAIN = "josh-test-${STACK_NAME}.${BASE_HOSTNAME}"
-                    env.CFGOV_SITE_URL = "${CFGOV_SITE_SCHEME}://${CFGOV_SITE_DOMAIN}"
-
-                    // Docker tag names
-                    env.IMAGE_TAG="${stackBaseName}-${BUILD_NUMBER}"
-                    env.CFGOV_WEB_REPO="${DOCKER_REGISTRY}/${DOCKER_REGISTRY_ORG}/cf-gov"
-                    env.CFGOV_WEB_IMAGE="${CFGOV_WEB_REPO}:${IMAGE_TAG}"
                 }
                 sh 'env | sort'
             }
@@ -84,11 +69,15 @@ pipeline {
                 scanImage(env.IMAGE_REPO, env.IMAGE_TAG)
             }
         }
-
+        
         stage('Push Image') {
+            // Push image only on master branch or deploy is set to true
             when {
-                expression { return params.DEPLOY }
-            } 
+                anyOf { 
+                    branch 'master'
+                    expression { return params.DEPLOY }
+                }
+            }
             steps {
                 script {
                     docker.withRegistry(dockerRegistry.url, dockerRegistry.credentialsId) {
@@ -101,36 +90,14 @@ pipeline {
                 }
             }
         }
-        stage ('"master" Override') {
-            when {
-                branch 'master'
-            }
-            environment {
-                AUTH_OIDC_CLIENT_CREDS = credentials('collab-monolith-oidc-client-master')
-            }
-            steps {
-                script {
-                    env.AUTH_MODE = 'oidc'
-                    env.AUTH_OIDC_CLIENT_ID = env.AUTH_OIDC_CLIENT_CREDS_USR
-                    
-                    env.COLLAB_SITE_DOMAIN = "cfgov.${BASE_HOSTNAME}"
-                    env.COLLAB_SITE_URL = "${CFGOV_SITE_SCHEME}://${CFGOV_SITE_DOMAIN}"
-                }
-                sh 'env | sort'
-                // FIXME: If we ever go to production with this, we'll need a better
-                //        way of setting mod_auth_openidc's crypto passphrase.  For now,
-                //        it's just the stack name to make Swarm happy since it won't let
-                //        you change secrets on deploys. 
-                sh """
-                echo '${AUTH_OIDC_CLIENT_CREDS_PSW}' > ${WORKSPACE}/auth_oidc_client_secret
-                echo '${STACK_NAME}' > ${WORKSPACE}/auth_oidc_crypto_passphrase
-                """
-            }
-        }
 
         stage('Deploy Stack') {
+            // Deploys only on master branch or deploy is set to true
             when {
-                expression { return params.DEPLOY }
+                anyOf { 
+                    branch 'master'
+                    expression { return params.DEPLOY }
+                }
             } 
             steps {
                 script {

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -7,6 +7,10 @@ services:
         image: elasticsearch:2.4-alpine
         networks:
             - app
+        deploy:
+            placement:
+                constraints:
+                - node.role!=manager
 
     postgres:
         image: postgres:10-alpine
@@ -20,6 +24,10 @@ services:
             - app
         secrets:
             - PGPASSWORD
+        deploy:
+            placement:
+                constraints:
+                - node.role!=manager
 
     python:
         image: ${CFGOV_PYTHON_IMAGE}


### PR DESCRIPTION
This ticket seeks to address performance issues with psql and elasticsearch when they run on manager nodes, and adds the same constraints used for the python deployment

## Additions

- 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
