### PR TITLE
Fix Firefox cutting off content after 1 page when printing

### DIFF
--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -69,4 +69,23 @@
     .rss-subscribe {
         display: none;
     }
+
+    // Solving Firefox's longstanding issue of cutting off inline-block
+    // elements after one page.
+    @-moz-document url-prefix() {
+        html,
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        .content_main {
+            margin: 0;
+            display: block !important;
+        }
+
+        .content_sidebar {
+            display: block !important;
+        }
+    }
 });


### PR DESCRIPTION
Firefox cuts off `inline-block` elements after 1 page when printing. These changes, extracted from. never-completed PR #2526, solve that problem for our main content and sidebar elements.

Thanks to @virginiacc for the original research and code!

## Additions

- Print styles to override the display of `.content_main` and `.content_sidebar` in Firefox

## Testing

1. In Firefox, visit https://www.consumerfinance.gov/about-us/blog/avoid-scams-find-help-during-quarantine/ and print preview to see the bug in question
1. Pull this branch
1. `gulp styles`
1. Use Sauce Connect to test http://localhost:8000/about-us/blog/avoid-scams-find-help-during-quarantine/ in Firefox
1. Print preview and confirm that you can see all of the main and sidebar content now


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
