### PR TITLE
Update prepaid CSV export encodings

### DIFF
--- a/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
+++ b/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
@@ -27,6 +27,10 @@ def write_agreements_data(path=''):
     agreements_file = open(agreements_location, 'w', encoding='utf-8')
     products_file = open(products_location, 'w', encoding='utf-8')
 
+    # Write a BOM at the top of the file so Excel knows it's UTF-8
+    agreements_file.write('\ufeff')
+    products_file.write('\ufeff')
+
     agreements_writer = csv.DictWriter(
         agreements_file,
         fieldnames=agreements_fieldnames

--- a/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
+++ b/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
@@ -62,10 +62,6 @@ def write_agreements_data(path=''):
         else:
             other_relevant_parties = 'No information provided'
 
-        program_manager = product.program_manager
-        if program_manager:
-            program_manager = program_manager
-
         data = {
             'issuer_name': product.issuer_name,
             'product_name': product.name,
@@ -76,7 +72,7 @@ def write_agreements_data(path=''):
             'current_status': product.status,
             'prepaid_product_type': product.prepaid_type,
             'program_manager_exists': product.program_manager_exists,
-            'program_manager': program_manager,
+            'program_manager': product.program_manager,
             'other_relevant_parties': other_relevant_parties,
             'path': agreement.bulk_download_path,
             'direct_download': agreement.compressed_files_url,

--- a/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
+++ b/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
@@ -24,8 +24,8 @@ def write_agreements_data(path=''):
 
     agreements_location = path + 'prepaid_metadata_all_agreements.csv'
     products_location = path + 'prepaid_metadata_recent_agreements.csv'
-    agreements_file = open(agreements_location, 'w')
-    products_file = open(products_location, 'w')
+    agreements_file = open(agreements_location, 'w', encoding='utf-8')
+    products_file = open(products_location, 'w', encoding='utf-8')
 
     agreements_writer = csv.DictWriter(
         agreements_file,
@@ -58,17 +58,17 @@ def write_agreements_data(path=''):
         if other_relevant_parties:
             other_relevant_parties = other_relevant_parties.replace(
                 '\n', '; '
-            ).encode('utf-8')
+            )
         else:
             other_relevant_parties = 'No information provided'
 
         program_manager = product.program_manager
         if program_manager:
-            program_manager = program_manager.encode('utf-8')
+            program_manager = program_manager
 
         data = {
-            'issuer_name': product.issuer_name.encode('utf-8'),
-            'product_name': product.name.encode('utf-8'),
+            'issuer_name': product.issuer_name,
+            'product_name': product.name,
             'product_id': product.pk,
             'agreement_effective_date': agreement.effective_date,
             'created_date': created_time,

--- a/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
+++ b/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
@@ -1,8 +1,7 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from unittest import mock
 
 from django.test import TestCase
-from django.utils import timezone
 
 from prepaid_agreements.models import PrepaidAgreement, PrepaidProduct
 from prepaid_agreements.scripts.write_prepaid_agreements_data_to_csv import (
@@ -26,28 +25,28 @@ class TestViews(TestCase):
         self.product2.save()
 
         effective_date = date(month=2, day=3, year=2019)
+        created_date = datetime(month=4, day=1, year=2020)
         self.agreement_old = PrepaidAgreement(
             effective_date=effective_date,
-            created_time=timezone.now() - timedelta(hours=1),
+            created_time=created_date - timedelta(hours=1),
             product=self.product1,
         )
         self.agreement_old.save()
         self.agreement_older = PrepaidAgreement(
             effective_date=effective_date,
-            created_time=timezone.now() - timedelta(hours=2),
+            created_time=created_date - timedelta(hours=2),
             product=self.product2,
         )
         self.agreement_older.save()
         self.agreement_new = PrepaidAgreement(
             effective_date=effective_date,
-            created_time=timezone.now(),
+            created_time=created_date,
             product=self.product1,
         )
         self.agreement_new.save()
 
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     def test_write_agreements_data(self, mock_open):
-
         # Run the write function
         write_agreements_data()
 
@@ -71,22 +70,22 @@ class TestViews(TestCase):
 
         # Make sure expected data rows exist
         mock_file_handle.write.assert_any_call(
-            'Bank of CFPB,,1,2019-02-03,1,No,2020-04-14 14:26:48,,,Tax,,,'
+            'Bank of CFPB,,1,2019-02-03,1,No,2020-04-01 03:00:00,,,Tax,,,'
             'No information provided,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'Bank of CFPB,,1,2019-02-03,3,2020-04-14 15:26:48,,,Tax,,,'
+            'Bank of CFPB,,1,2019-02-03,3,2020-04-01 04:00:00,,,Tax,,,'
             'No information provided,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'Bank of CFPB,,1,2019-02-03,3,Yes,2020-04-14 15:26:48,,,Tax,,,'
+            'Bank of CFPB,,1,2019-02-03,3,Yes,2020-04-01 04:00:00,,,Tax,,,'
             'No information provided,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'CFPB Bank,,2,2019-02-03,2,2020-04-14 13:26:48,,,Tax,,,'
+            'CFPB Bank,,2,2019-02-03,2,2020-04-01 02:00:00,,,Tax,,,'
             'Party,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'CFPB Bank,,2,2019-02-03,2,Yes,2020-04-14 13:26:48,,,Tax,,,'
+            'CFPB Bank,,2,2019-02-03,2,Yes,2020-04-01 02:00:00,,,Tax,,,'
             'Party,,\r\n'
         )

--- a/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
+++ b/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
@@ -1,0 +1,94 @@
+from datetime import date, timedelta
+from unittest import mock
+
+from django.test import TestCase
+from django.utils import timezone
+
+from prepaid_agreements.models import PrepaidAgreement, PrepaidProduct
+from prepaid_agreements.scripts.write_prepaid_agreements_data_to_csv import (
+    write_agreements_data
+)
+
+
+class TestViews(TestCase):
+
+    def setUp(self):
+        self.product1 = PrepaidProduct(
+            issuer_name='Bank of CFPB',
+            prepaid_type='Tax'
+        )
+        self.product1.save()
+        self.product2 = PrepaidProduct(
+            issuer_name='CFPB Bank',
+            prepaid_type='Tax',
+            other_relevant_parties='Party'
+        )
+        self.product2.save()
+
+        effective_date = date(month=2, day=3, year=2019)
+        self.agreement_old = PrepaidAgreement(
+            effective_date=effective_date,
+            created_time=timezone.now() - timedelta(hours=1),
+            product=self.product1,
+        )
+        self.agreement_old.save()
+        self.agreement_older = PrepaidAgreement(
+            effective_date=effective_date,
+            created_time=timezone.now() - timedelta(hours=2),
+            product=self.product2,
+        )
+        self.agreement_older.save()
+        self.agreement_new = PrepaidAgreement(
+            effective_date=effective_date,
+            created_time=timezone.now(),
+            product=self.product1,
+        )
+        self.agreement_new.save()
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    def test_write_agreements_data(self, mock_open):
+
+        # Run the write function
+        write_agreements_data()
+
+        print(mock_open.mock_calls)
+
+        mock_file_handle = mock_open()
+
+        # Make sure each file's headers exist
+        mock_file_handle.write.assert_any_call(
+            'issuer_name,product_name,product_id,'
+            'agreement_effective_date,agreement_id,most_recent_agreement,'
+            'created_date,current_status,withdrawal_date,'
+            'prepaid_product_type,program_manager_exists,program_manager,'
+            'other_relevant_parties,path,direct_download\r\n'
+        )
+        mock_file_handle.write.assert_any_call(
+            'issuer_name,product_name,product_id,'
+            'agreement_effective_date,agreement_id,'
+            'created_date,current_status,withdrawal_date,'
+            'prepaid_product_type,program_manager_exists,program_manager,'
+            'other_relevant_parties,path,direct_download\r\n'
+        )
+
+        # Make sure expected data rows exist
+        mock_file_handle.write.assert_any_call(
+            'Bank of CFPB,,1,2019-02-03,1,No,2020-04-14 14:26:48,,,Tax,,,'
+            'No information provided,,\r\n'
+        )
+        mock_file_handle.write.assert_any_call(
+            'Bank of CFPB,,1,2019-02-03,3,2020-04-14 15:26:48,,,Tax,,,'
+            'No information provided,,\r\n'
+        )
+        mock_file_handle.write.assert_any_call(
+            'Bank of CFPB,,1,2019-02-03,3,Yes,2020-04-14 15:26:48,,,Tax,,,'
+            'No information provided,,\r\n'
+        )
+        mock_file_handle.write.assert_any_call(
+            'CFPB Bank,,2,2019-02-03,2,2020-04-14 13:26:48,,,Tax,,,'
+            'Party,,\r\n'
+        )
+        mock_file_handle.write.assert_any_call(
+            'CFPB Bank,,2,2019-02-03,2,Yes,2020-04-14 13:26:48,,,Tax,,,'
+            'Party,,\r\n'
+        )

--- a/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
+++ b/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
@@ -51,8 +51,6 @@ class TestViews(TestCase):
         # Run the write function
         write_agreements_data()
 
-        print(mock_open.mock_calls)
-
         mock_file_handle = mock_open()
 
         # Make sure each file's headers exist

--- a/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
+++ b/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
@@ -70,22 +70,40 @@ class TestViews(TestCase):
 
         # Make sure expected data rows exist
         mock_file_handle.write.assert_any_call(
-            'Bank of CFPB,,1,2019-02-03,1,No,2020-04-01 03:00:00,,,Tax,,,'
+            'Bank of CFPB,,'
+            + str(self.product1.pk) +
+            ',2019-02-03,'
+            + str(self.agreement_old.pk) +
+            ',No,2020-04-01 03:00:00,,,Tax,,,'
             'No information provided,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'Bank of CFPB,,1,2019-02-03,3,2020-04-01 04:00:00,,,Tax,,,'
+            'Bank of CFPB,,'
+            + str(self.product1.pk) +
+            ',2019-02-03,'
+            + str(self.agreement_new.pk) +
+            ',2020-04-01 04:00:00,,,Tax,,,'
             'No information provided,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'Bank of CFPB,,1,2019-02-03,3,Yes,2020-04-01 04:00:00,,,Tax,,,'
+            'Bank of CFPB,,'
+            + str(self.product1.pk) +
+            ',2019-02-03,'
+            + str(self.agreement_new.pk) +
+            ',Yes,2020-04-01 04:00:00,,,Tax,,,'
             'No information provided,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'CFPB Bank,,2,2019-02-03,2,2020-04-01 02:00:00,,,Tax,,,'
-            'Party,,\r\n'
+            'CFPB Bank,,'
+            + str(self.product2.pk) +
+            ',2019-02-03,'
+            + str(self.agreement_older.pk) +
+            ',2020-04-01 02:00:00,,,Tax,,,Party,,\r\n'
         )
         mock_file_handle.write.assert_any_call(
-            'CFPB Bank,,2,2019-02-03,2,Yes,2020-04-01 02:00:00,,,Tax,,,'
-            'Party,,\r\n'
+            'CFPB Bank,,'
+            + str(self.product2.pk) +
+            ',2019-02-03,'
+            + str(self.agreement_older.pk) +
+            ',Yes,2020-04-01 02:00:00,,,Tax,,,Party,,\r\n'
         )


### PR DESCRIPTION
This change encodes the entire prepaid agreements CSV files as UTF-8 rather than individual fields.

The encoding on individual fields was causing them to be included in the CSV as bytestrings. The effect of this is that when someone opened the file in Excel, the field would appear as `b'Issuer Name'`, etc, since our upgrade to Python 3. This fixes that issue.

## Testing

1. On `master`, in either the Docker container or virtualenv, run:

   ```shell
   ./cfgov/manage.py runscript write_prepaid_agreements_data_to_csv --script-args './'
   ```

2. Observe that the values in the "issuer_name" and "product_name" columns in the output files are rendered Python bytestrings (`b'Issuer Name'`) rather than just a string (`Issuer Name`).

3. On this branch, `fix-prepaid-csv-encoding`, in either the Docker container or virtualenv, run:

   ```shell
   ./cfgov/manage.py runscript write_prepaid_agreements_data_to_csv --script-args './'
   ```

4. Observe that the values in the "issuer_name" and "product_name" columns in the output files are now just a string (`Issuer Name`), as expected.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
