### PR TITLE
Ask CFPB: Remove extra newlines from AnswerPage search index

### DIFF
--- a/cfgov/ask_cfpb/search_indexes.py
+++ b/cfgov/ask_cfpb/search_indexes.py
@@ -39,9 +39,7 @@ class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
         boost=10.0)
     autocomplete = indexes.EdgeNgramField(
         use_template=True)
-    url = indexes.CharField(
-        use_template=True,
-        indexed=False)
+    url = indexes.CharField(model_attr='url', indexed=False)
     tags = indexes.MultiValueField(
         boost=10.0)
     language = indexes.CharField(

--- a/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_autocomplete.txt
+++ b/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_autocomplete.txt
@@ -1,1 +1,1 @@
-{{ object.question|striptags|safe }}
+{{ object.question | striptags | safe }}

--- a/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_url.txt
+++ b/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_url.txt
@@ -1,1 +1,0 @@
-{{ object.url }}


### PR DESCRIPTION
Currently when we index Ask CFPB AnswerPages into Elasticsearch, both the URL and autocomplete text have extra newlines at the end due to the use of templates. This doesn't affect the functionality of the site in practice, but can be observed by inspecting the HTML on certain Ask pages, and would be good to fix for purposes of index cleanliness.

## Testing

To test, if you query an example document using the master branch, you'll see something like this:

```
$ curl "http://localhost:9200/content_haystack/_search?size=1&fields=autocomplete,url&pretty=true"
{
  ...
  "hits" : {
    ...
    "hits" : [ {
      "_index" : "content_haystack",
      "_type" : "modelresult",
      "_id" : "ask_cfpb.answerpage.5782",
      "_score" : 1.0,
      "fields" : {
        "autocomplete" : [ "What should I do if my EBT card or PIN is lost or stolen or I see unauthorized charges?\n" ],
        "url" : [ "/ask-cfpb/what-should-i-do-if-my-ebt-card-or-pin-is-lost-or-stolen-or-i-see-unauthorized-charges-en-2055/\n" ]
      }
    } ]
  }
}
```

Note the extra newlines at the end of the autocomplete and URL fields.

After this change and a reindex, those are correctly removed:

```
$ cfgov/manage.py update_index ask_cfpb
$ curl "http://localhost:9200/content_haystack/_search?size=1&fields=autocomplete,url&pretty=true"
{
  ...
  "hits" : {
    ...
    "hits" : [ {
      "_index" : "content_haystack",
      "_type" : "modelresult",
      "_id" : "ask_cfpb.answerpage.5782",
      "_score" : 1.0,
      "fields" : {
        "autocomplete" : [ "What should I do if my EBT card or PIN is lost or stolen or I see unauthorized charges?" ],
        "url" : [ "/ask-cfpb/what-should-i-do-if-my-ebt-card-or-pin-is-lost-or-stolen-or-i-see-unauthorized-charges-en-2055/" ]
      }
    } ]
  }
}
```

## Screenshots

Before this change:

Search autocomplete on [the main Ask page](https://www.consumerfinance.gov/ask-cfpb/):
![image](https://user-images.githubusercontent.com/654645/79479491-d4eb2600-7fda-11ea-891a-0a4b51d9885c.png)

List of questions on a search results page:
![image](https://user-images.githubusercontent.com/654645/79479632-0d8aff80-7fdb-11ea-9b28-94c3109f539e.png)

Note that both of these include newlines both in the text and the URL.

After this change:

![image](https://user-images.githubusercontent.com/654645/79479782-47f49c80-7fdb-11ea-8709-aa2ffb9829a0.png)
![image](https://user-images.githubusercontent.com/654645/79479817-50e56e00-7fdb-11ea-9dea-632573e6c7f5.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: