### PR TITLE
Fix naive datetime warning in Python test

### DIFF
--- a/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
+++ b/cfgov/prepaid_agreements/tests/test_scripts_write_prepaid_agreements.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta
 from unittest import mock
 
 from django.test import TestCase
+from django.utils.timezone import make_aware
 
 from prepaid_agreements.models import PrepaidAgreement, PrepaidProduct
 from prepaid_agreements.scripts.write_prepaid_agreements_data_to_csv import (
@@ -25,7 +26,7 @@ class TestViews(TestCase):
         self.product2.save()
 
         effective_date = date(month=2, day=3, year=2019)
-        created_date = datetime(month=4, day=1, year=2020)
+        created_date = make_aware(datetime(month=4, day=1, year=2020))
         self.agreement_old = PrepaidAgreement(
             effective_date=effective_date,
             created_time=created_date - timedelta(hours=1),


### PR DESCRIPTION
#5658 (specifically 4169aa4c0072583507ed658e94627dcc343c3b3c) introduced some new tests that generate warnings like:

> RuntimeWarning: DateTimeField PrepaidAgreement.created_time received a
naive datetime (2020-04-01 00:00:00) while time zone support is active.

This change fixes that warning by ensuring that `created_time` gets a timezone-aware datetime.

## Testing

Run `tox`, no warnings about timezones.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: