### PR TITLE
Add print button to articles

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -43,7 +43,8 @@
             'category': page.categories.all(),
             'heading': page.title,
             'date': page.date_published,
-            'has_social': True
+            'has_social': True,
+            'social_options': {'is_printable': true}
         } %}
 
         {% for block in page.header -%}

--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -44,7 +44,7 @@
             'heading': page.title,
             'date': page.date_published,
             'has_social': True,
-            'social_options': {'is_printable': true}
+            'social_options': { 'is_printable': true }
         } %}
 
         {% for block in page.header -%}

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -129,7 +129,7 @@
 
         {% set print_info = {
             'name': 'Print this page',
-            'share_url': 'javascript:window.print();',
+            'share_url': 'window.print();',
             'icon': 'print'
         } %}
 

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -17,6 +17,10 @@
    value.is_share_view:     Whether the "Share this" heading is shown.
                             Default is true.
 
+   value.is_printable:      Whether the molecule is on a page meant to be
+                            printed and should thus show the print link.
+                            Default is false.
+
    value.email_title        Sets subject for email
 
    value.email_text         Sets body for email
@@ -50,6 +54,7 @@
                 'Look what I found on the CFPB’s site!') %}
 {% set parsed_url = request.build_absolute_uri() | urlencode %}
 {% set is_share_view = value.is_share_view | default( true ) %}
+{% set is_printable = value.is_printable | default( false ) %}
 {% set email_title = value.email_title or blurb %}
 {% set email_text = value.email_text or 'Check out this page from the CFPB - ' %}
 {% set email_signature = ' ' + value.email_signature if value.email_signature else '' %}
@@ -110,6 +115,12 @@
             'icon': 'flickr'
         } %}
 
+        {% set print_info = {
+            'name': 'Print this page',
+            'share_url': 'javascript:window.print();',
+            'icon': 'print-round'
+        } %}
+
         {% if is_share_view %}
             {% set links = [
                 facebook_info,
@@ -148,6 +159,15 @@
                 </li>
             {% endif %}
         {% endfor %}
+        {% if is_share_view and is_printable %}
+            <li class="m-list_item m-social-media_print">
+                <a class="m-social-media_icon"
+                    href="{{print_info.share_url}}"
+                    aria-label="{{print_info.name}}">
+                     {{ svg_icon(print_info.icon) }}
+                </a>
+            </li>
+        {% endif %}
 
     </ul>
 </div>

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -174,11 +174,12 @@
 
         {% if is_share_view and is_printable %}
             <li class="m-list_item m-social-media_print">
-                <a class="m-social-media_icon"
-                   href="{{ print_info.share_url }}"
-                   aria-label="{{ print_info.name }}">
+                <button class="a-btn a-btn__link m-social-media_icon"
+                   onclick="{{ print_info.share_url }}"
+                   aria-label="{{ print_info.name }}"
+                   type="button">
                     {{ svg_icon(print_info.icon) }}
-                </a>
+                </button>
             </li>
         {% endif %}
 

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -171,12 +171,13 @@
                 </li>
             {% endif %}
         {% endfor %}
+
         {% if is_share_view and is_printable %}
             <li class="m-list_item m-social-media_print">
                 <a class="m-social-media_icon"
-                    href="{{print_info.share_url}}"
-                    aria-label="{{print_info.name}}">
-                     {{ svg_icon(print_info.icon) }}
+                   href="{{ print_info.share_url }}"
+                   aria-label="{{ print_info.name }}">
+                    {{ svg_icon(print_info.icon) }}
                 </a>
             </li>
         {% endif %}

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -67,8 +67,20 @@
 <div class="m-social-media
             m-social-media__{{ 'share' if is_share_view else 'follow' }}">
     {% if is_share_view %}
-        <div class="h5 m-social-media_heading">Share this</div>
-        <div class="h5 m-social-media_heading m-social-media_heading__es">Compartir</div>
+        <div class="h5 m-social-media_heading">
+            {% if is_printable %}
+                Share &amp; print
+            {% else %}
+                Share this
+            {% endif %}
+        </div>
+        <div class="h5 m-social-media_heading m-social-media_heading__es">
+            {% if is_printable %}
+                Compartir e imprimir
+            {% else %}
+                Compartir
+            {% endif %}
+        </div>
     {% endif %}
 
     <ul class="m-list
@@ -118,7 +130,7 @@
         {% set print_info = {
             'name': 'Print this page',
             'share_url': 'javascript:window.print();',
-            'icon': 'print-round'
+            'icon': 'print'
         } %}
 
         {% if is_share_view %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -18,6 +18,7 @@
 
    value.date:             A datetime for the post.
    value.has_social:       Whether to show the share icons or not.
+   value.social_options:   An object with options for the share icons
 
    ========================================================================== #}
 
@@ -31,6 +32,7 @@
 {% set filter_page_url = pageurl(filter_page) if filter_page else none %}
 {% set published_date = value.date %}
 {% set has_authors = page.authors.exists() %}
+{% set social_options = value.social_options or {} %}
 
 <div class="o-item-introduction">
     {% if filter_page_url and page.categories.count() > 0 and value.show_category %}
@@ -66,7 +68,7 @@
     {% endif %}
 
     {% if value.has_social %}
-        {{ social_media.render() }}
+        {{ social_media.render(social_options) }}
     {% endif %}
 </div>
 

--- a/cfgov/unprocessed/css/molecules/social-media.less
+++ b/cfgov/unprocessed/css/molecules/social-media.less
@@ -85,7 +85,7 @@
     }
 
     &_print {
-        padding-left: unit( 13px / @base-font-size-px, em );
+        padding-left: unit( (@grid_gutter-width / 2) / @base-font-size-px, em );
         border-left: 1px solid @black;
     }
 

--- a/cfgov/unprocessed/css/molecules/social-media.less
+++ b/cfgov/unprocessed/css/molecules/social-media.less
@@ -84,12 +84,21 @@
         .u-link__no-border();
     }
 
+    &_print {
+        padding-left: unit( 13px / @base-font-size-px, em );
+        border-left: 1px solid @black;
+    }
+
     // Hide on print.
     .respond-to-print( {
         & {
             display: none;
         }
     } );
+}
+
+.no-js .m-social-media_print {
+    display: none;
 }
 
 /* topdoc


### PR DESCRIPTION
Now that we have improved print styles, we want to add a print button to page types that visitors are likely to want to print (namely, blog posts and newsroom articles). This PR does that by adding a new option to the social media molecule to show the print button in particular contexts.

See GHE/CFGOV/platform/issues/3751 for more details.

## Additions

- `value.is_printable` variable in the social media molecule to set whether or not the print button should appear
- Markup and styles for the print button
- `data.social_options` to the article template to pass `true` to the social media molecule's `value.is_printable` via the item introduction template
- `value.social_options` to the item introduction template to be able to pass `value.is_printable` to the social media molecule

## Changes

- Render the social media molecule with data in the item introduction template

## Testing

1. In this branch running locally, visit a blog page, like http://localhost:8000/about-us/blog/tools-to-help-pay-bills/. Verify that the new print button appears in the social sharing section and that clicking it brings up the browser's print dialog. Everything in that print dialog should match what you see if you choose `File > Print` in the browser.
2. Visit a newsroom page (like http://localhost:8000/about-us/newsroom/cfpb-issues-final-rule-raising-data-reporting-thresholds-under-hmda/) and verify that the print button is working there, too (the newsroom page extends the blog page template, so it should be the same).
3. Visit some other places where the social media molecule is used and verify that the print button does *not* appear there. Some places to try:
    - The video player on http://localhost:8000/data-research/prepaid-accounts/issuer-instructions/
    - Any event page (like http://localhost:8000/about-us/events/archive-past-events/evolutions-in-consumer-debt-relief-event/)
    - Any report detail page that has the share buttons enabled in its item introduction in Wagtail, like http://localhost:8000/data-research/research-reports/office-servicemember-affairs-annual-report-fy-2019/
    - Any Wagtail page that the Wagtail block inventory shows as having the social media molecule on it, like http://localhost:8000/owning-a-home/beware-mortgage-closing-scams/
4. Disable JS, and make sure the print button does not appear on any blog posts or newsroom articles.

## Screenshots

Large screens | Small screens
---- | ----
![circle-large](https://user-images.githubusercontent.com/1862695/79789129-bd33da80-8317-11ea-9540-901c8f6cb87f.png) | ![circle-small](https://user-images.githubusercontent.com/1862695/79789143-c1f88e80-8317-11ea-86f4-1fd9e0afe4e7.png)

## Notes

I have so many questions about the implementation of this one:

- Is the way I did the transfer of the `is_printable` value from `article.html` to `item-introduction.html` to `social-media.html` the right way to do it? Can anyone see any issues that might cause on non-article pages? I think setting the default for `is_printable` to `false` will prevent those issues, but I'm not sure.
- Is triggering the print dialog with `<a href="javascript:window.print();">` the right way to do that? Should that instead be extracted out of the HTML into a JS function somewhere? That seemed like a lot of work for a single line of JS, but I also don't know that much about JS 😄 .
- Are there any additional tests needed?

## Todos

- We're still figuring out if we want to change the "share this" label to something else and if we want to stick with the circle print icon or go with the no-circle print icon, so those changes might be coming.
- Once this is deployed to UCP, I want to check the print button in more browsers to make sure it behaves—especially on mobile.
- Right now I only have the print button showing on any pages that use the `article.html` template, which (as far as I can tell) are blog posts and newsroom articles. We may want to turn that button on on other types of pages, but for now, I think it makes sense to limit it to those two page types, as that's where all the requests to print pages we've heard about have come from.
- We might also eventually want to add an option to the Wagtail social media block to show the print button on a one-off basis when it's added to a page, but that's outside the scope of this initial work.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing