### PR TITLE
Update django-treebeard to 4.2.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -15,7 +15,7 @@ django-localflavor==3.0
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-storages==1.7.1
-django-treebeard==3.0
+django-treebeard==4.2.0
 django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==2.4.1


### PR DESCRIPTION
Fix the following when running tox:
`ERROR: wagtail 2.3 has requirement django-treebeard<5.0,>=4.2.0, but you'll have django-treebeard 3.0 which is incompatible.`

## Changes

- Update version of `django-treebeard` in `requirements/libraries.txt` from `3.0` to `4.2.0`

## Testing

1. tox -e lint
2. tox -e unittest-current
3. tox -e unittest-future

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: