### PR TITLE
Override new .u-hidden class on sidenav and read-more "expandables"

### DIFF
--- a/cfgov/unprocessed/css/organisms/read-more.less
+++ b/cfgov/unprocessed/css/organisms/read-more.less
@@ -43,19 +43,16 @@
 */
 
 .o-expandable__read-more-mobile {
-    .o-expandable_target__collapsed {
+    .o-expandable_target__collapsed,
+    .o-expandable_content__collapsed:after {
         display: none;
     }
 
-    .o-expandable_content__collapsed {
+    .o-expandable_content {
         // These two !important values override basic expandable styling,
         // because these don't function like expandables on sm+ screens.
         display: block !important;
         max-height: 100% !important;
-
-        &:after {
-            display: none;
-        }
     }
 
     @media only screen and (max-width: @bp-xs-max) {

--- a/cfgov/unprocessed/css/organisms/read-more.less
+++ b/cfgov/unprocessed/css/organisms/read-more.less
@@ -48,6 +48,9 @@
     }
 
     .o-expandable_content__collapsed {
+        // These two !important values override basic expandable styling,
+        // because these don't function like expandables on sm+ screens.
+        display: block !important;
         max-height: 100% !important;
 
         &:after {
@@ -55,7 +58,7 @@
         }
     }
 
-    @media only screen and (max-width:@bp-xs-max) {
+    @media only screen and (max-width: @bp-xs-max) {
         .o-expandable_target__collapsed {
             display: block;
 

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -94,6 +94,9 @@
         }
 
         .o-expandable_content {
+            // These two !important values override basic expandable styling,
+            // because these don't function like expandables on med+ screens.
+            display: block !important;
             max-height: 100% !important;
             padding: 0;
 


### PR DESCRIPTION
cfpb-expandables 0.1.0 added the `.u-hidden` utility class to expandable 
content on init, in order to prevent focus from entering collapsed 
expandables. This was inadvertently hiding the content that should 
always be visible at certain screen sizes on these two special types of 
"expandables", secondary navigation and read-more.

## Additions

- `display: block !important` overrides added to sidenav and read-more `o-expandable_content` at the screen sizes where they should always been open

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android
