### PR TITLE
Change the final estimation paragraph to avoid use of "certificate"

### DIFF
--- a/cfgov/paying_for_college/templates/paying_for_college/disclosure.html
+++ b/cfgov/paying_for_college/templates/paying_for_college/disclosure.html
@@ -2957,8 +2957,7 @@
                                 <h2 class="step_heading step_settlement">
                                     It's estimated you'll owe <span
                                     data-financial="loanLifetime">[XX]</span>
-                                    to earn a <span data-section="degreeType"
-                                    data-currency="false">[degree/certificate]</span> in {{program.program_name}} at
+                                    to complete this program in {{program.program_name}} at
                                     {{school.primary_alias}}. Do you better
                                     understand how this may impact your future
                                     finances?


### PR DESCRIPTION
The logic in the last section of the EFIP disclosure tool is failing and always
calls the program's document a certificate, regardless of the degree earned.

This can be misleading, and we need a hot fix to remove the reference to certificate.

A longer-term solution will be to rewrite js code to pick up program level information.
