### PR TITLE
Fix missing closing div tag around Related Posts in sidefoot

### DIFF
--- a/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
+++ b/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
@@ -6,7 +6,8 @@
     {% for block in streamfield %}
         {% if 'related_posts' in block.block_type %}
             <div class="block{{ ' block__flush-top' if loop.first else '' }}">
-            {% include_block block %}
+                {% include_block block %}
+            </div>
         {% elif 'related_metadata' in block.block_type %}
             <div class="block{{ ' block__flush-top' if loop.first else '' }}">
                 {{ related_metadata.render(block.value) }}


### PR DESCRIPTION
My bad: https://github.com/cfpb/cfgov-refresh/pull/4622/files#r416953702

## Additions

- Re-adds accidentally removed closing `</div>` tag after including the Related Posts module in a sidefoot

## Testing

1. Go to https://validator.w3.org/#validate_by_uri
1. Validate a page like https://www.consumerfinance.gov/about-us/blog/avoid-scams-find-help-during-quarantine/
1. Observe these errors toward the bottom of the list:
   ![snippet of validation results showing two errors: "End tag `aside` seen, but there were open elements" and "Unclosed element `div`"](https://user-images.githubusercontent.com/1044670/80542965-fd303880-897b-11ea-985a-647e9b571de4.png)
1. Pull branch
1. Load up http://localhost:8000/about-us/blog/avoid-scams-find-help-during-quarantine/
1. View source and copy it all
1. Go to https://validator.w3.org/#validate_by_input
1. Paste the source into the field and validate it
1. See that the aforementioned errors are not returned

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
