### PR TITLE
Support Django 2.2

### DIFF
--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -95,13 +95,10 @@ class CFGovErrorHandler(logging.Handler):
         except Exception:
             get = '<could not parse>'
 
-        if request._post_parse_error:
+        try:
+            post = pformat(POST_override)
+        except Exception:
             post = '<could not parse>'
-        else:
-            try:
-                post = pformat(POST_override)
-            except Exception:
-                post = '<could not parse>'
 
         try:
             cookies = pformat(request.COOKIES)

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -8,6 +8,11 @@ from django.test import RequestFactory, TestCase
 from mock import patch
 
 
+class ObjectThatCantBeRepresented(object):
+    def __repr__(self):
+        raise Exception
+
+
 @patch('alerts.sqs_queue.SQSQueue.post')
 class TestLoggingHandlers(TestCase):
     @classmethod
@@ -110,10 +115,6 @@ class TestLoggingHandlers(TestCase):
 
     def test_body_handles_unparseable_dict(self, sqs_queue_post):
         """Handle when calls to format request.COOKIES or META fail."""
-        class ObjectThatCantBeRepresented(object):
-            def __repr__(self):
-                raise Exception
-
         request = RequestFactory().get('/')
         request.COOKIES = {'test': ObjectThatCantBeRepresented()}
         request.META = {'test': ObjectThatCantBeRepresented()}
@@ -125,7 +126,7 @@ class TestLoggingHandlers(TestCase):
     def test_body_handles_request_with_invalid_post(self, sqs_queue_post):
         """Handle case when a request was generated with an invalid POST."""
         request = RequestFactory().post('/')
-        request._mark_post_parse_error()
+        request._post = {'test': ObjectThatCantBeRepresented()}
         self.logger.error('something', extra={'request': request})
 
         args, kwargs = sqs_queue_post.call_args

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -135,6 +135,7 @@ class JobListingPageFormTests(TestCase, WagtailTestUtils):
             'usajobs_application_links-INITIAL_FORMS': 0,
             'usajobs_application_links-TOTAL_FORMS': 0,
             'language': 'en',
+            'schema_json': '',
         }
 
         post_data.update(kwargs)

--- a/cfgov/v1/admin_forms.py
+++ b/cfgov/v1/admin_forms.py
@@ -1,7 +1,6 @@
 import zipfile
 from io import BytesIO, StringIO
 
-import django
 from django import forms
 from django.core.management import call_command
 
@@ -74,24 +73,16 @@ class ExportFeedbackForm(forms.Form):
 
     def generate_zipfile_csv(self, name, pages, exclude=False):
         csv_contents = StringIO()
-        csv_filename = 'feedback_%s_%s.csv' % (name, self.get_filename_dates())
 
-        if django.VERSION > (2, 1):
-            call_command(
-                'export_feedback',
-                exclude=exclude,
-                from_date=self.cleaned_data['from_date'],
-                to_date=self.cleaned_data['to_date'],
-                stdout=csv_contents
-            )
-        else:
-            call_command(
-                'export_feedback',
-                pages=pages,
-                exclude=exclude,
-                from_date=self.cleaned_data['from_date'],
-                to_date=self.cleaned_data['to_date'],
-                stdout=csv_contents
-            )
+        call_command(
+            'export_feedback',
+            *pages,
+            exclude=exclude,
+            from_date=self.cleaned_data['from_date'],
+            to_date=self.cleaned_data['to_date'],
+            stdout=csv_contents
+        )
+
+        csv_filename = 'feedback_%s_%s.csv' % (name, self.get_filename_dates())
 
         return csv_filename, csv_contents.getvalue()

--- a/cfgov/v1/tests/handlers/blocks/test_feedback.py
+++ b/cfgov/v1/tests/handlers/blocks/test_feedback.py
@@ -201,12 +201,15 @@ class TestFeedbackHandler(TestCase):
     def _post_feedback(self, page=None, referrer='None', is_helpful='None'):
         page = page or CFGOVPage.objects.first()
 
+        post_data = {}
+        if referrer is not None:
+            post_data['referrer'] = referrer
+        if is_helpful is not None:
+            post_data['is_helpful'] = is_helpful
+
         request = self.factory.post(
             '/',
-            {
-                'referrer': referrer,
-                'is_helpful': is_helpful,
-            },
+            post_data,
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
 

--- a/cfgov/v1/tests/test_admin_views.py
+++ b/cfgov/v1/tests/test_admin_views.py
@@ -6,6 +6,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
+from wagtail.core.models import Site
+from wagtail.tests.testapp.models import SimplePage
+
 import mock
 
 from v1.admin_views import ExportFeedbackView
@@ -162,8 +165,12 @@ class TestExportFeedbackView(TestCase):
         )
 
     def test_post_generates_zipfile(self):
+        root_page = Site.objects.get(is_default_site=True).root_page
+        page = SimplePage(title='owning-a-home', slug='owning-a-home', content='owning-a-home', live=True)
+        root_page.add_child(instance=page)
+
         request = RequestFactory().post(
-            "/", {"from_date": "2019-01-01", "to_date": "2019-03-31",}
+            "/", {"from_date": "2019-01-01", "to_date": "2019-03-31"}
         )
         request.user = get_user_model().objects.get(is_superuser=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,7 @@ deps=
 # To run unittests with the upcoming versions specified here.
 basepython=python3.6
 deps=
-    Django>=2.0,<2.1
+    Django>=2.2,<3.0
     wagtail>=2.3,<2.4
 
 


### PR DESCRIPTION
This PR makes a few modifications to support Django 2.2:

- The undocumented `request._post_parse_error`, used in our logging alert handler, was removed in Django 2.1. This PR simply removes the check for it, as we have a generic `Exception` handler for formatting post data.
- `None` is no longer encoded in post data by `RequestFactory`, and values that would be `None` should. instead be omitted. This PR makes a modification to the feedback tests where `referrer` and `is_helpful` were being passed as `None` if no other value was given.
- `schema_json` must have a JSON-parsable value. In the jobmanager tests we perform a post to the Wagtail admin and `schema_json` was not defined. This PR defines it with a blank string.
- Django 2.1+ enforces the use of positional arguments when calling management commands with `call_command`. In the feedback admin export, we use `call_command` to call the `export_feedback` management command, and were previously providing `pages` as a keyword argument. This PR explodes `pages` as positional arguments instead.

There is one final category of test failures we're currently seeing, with `is_safe_url`. @cwdavies has addressed these in #5680. `unittest-future` will fail here until #5680 is merged and this PR is rebased.

## Testing

1.`tox -e unittest-future`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
