### PR TITLE
Fix: Ignore request headers for mega menu language

### DIFF
--- a/cfgov/mega_menu/jinja2tags.py
+++ b/cfgov/mega_menu/jinja2tags.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.utils.translation import get_language_from_request
 
 from jinja2 import contextfunction
 from jinja2.ext import Extension
@@ -8,17 +7,14 @@ from mega_menu.models import Menu
 
 
 def select_menu_for_context(context):
+    # First try to find a menu for the language from the context.
     language = context.get('language')
 
-    if not language:
-        request = context['request']
-        language = get_language_from_request(request, check_path=True)
-
-    # First try to find a menu for the language from the context.
-    try:
-        return Menu.objects.get(language=language[:2])
-    except Menu.DoesNotExist:
-        pass
+    if language:
+        try:
+            return Menu.objects.get(language=language)
+        except Menu.DoesNotExist:
+            pass
 
     # Next try to find a menu for the default Django language.
     try:

--- a/cfgov/mega_menu/tests/test_jinja2tags.py
+++ b/cfgov/mega_menu/tests/test_jinja2tags.py
@@ -16,33 +16,28 @@ class MegaMenuTests(TestCase):
             {'type': 'submenu', 'value': {'title': 'Spanish'}},
         ]))
 
-    def test_empty_context_fails_due_to_missing_request(self):
-        with self.assertRaises(KeyError):
-            get_mega_menu_content({})
-
     def test_returns_none_if_no_menus_exist(self):
         Menu.objects.all().delete()
 
         request = RequestFactory().get('/')
         self.assertIsNone(get_mega_menu_content({'request': request}))
 
-    def test_uses_request_falls_back_to_default_language(self):
+    def test_empty_context_falls_back_to_default_language(self):
+        content = get_mega_menu_content({})
+        self.assertIn('English', json.dumps(content))
+
+    def test_ignores_request_falls_back_to_default_language(self):
         request = RequestFactory().get('/')
         content = get_mega_menu_content({'request': request})
         self.assertIn('English', json.dumps(content))
 
-    def test_uses_request_language_if_set(self):
+    def test_ignores_request_language_if_set(self):
         request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='es')
-        content = get_mega_menu_content({'request': request})
-        self.assertIn('Spanish', json.dumps(content))
-
-    def test_unsupported_language_falls_back_to_default_language(self):
-        request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='fr')
         content = get_mega_menu_content({'request': request})
         self.assertIn('English', json.dumps(content))
 
     def test_uses_language_from_context_instead_of_request(self):
-        request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='en')
+        request = RequestFactory().get('/')
         content = get_mega_menu_content({'request': request, 'language': 'es'})
         self.assertIn('Spanish', json.dumps(content))
 


### PR DESCRIPTION
Currently it's possible for request headers to impact the language that the mega menu displays in. Specifically, setting the `HTTP_ACCEPT_LANGUAGE` header to Spanish could cause the menu to appear in Spanish on certain English pages using a legacy base template.

## Testing

To test, update your browser settings to prefer Spanish (e.g. in Chrome, Settings, Advanced, Languages, Language) and visit

http://localhost:8000/data-research/consumer-complaints/

On master, the mega menu will be in Spanish. On this branch, it'll be in English.

! Note that other parts of the page may still incorrectly be in Spanish -- this is a separate issue unrelated to the mega menu code.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: