### PR TITLE
Fix the iRegs wayfinder to account for newly hidden expandable content

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -1,3 +1,5 @@
+import { closest } from '../../../js/modules/util/dom-traverse';
+
 // Array that tracks paragraph positions
 let paragraphPositions;
 const regs3kMainContent = document.querySelector( '.regulations3k' );
@@ -236,20 +238,6 @@ const updateWayfinder = function( scroll, wayfinder, mainContent ) {
   }
 };
 
-
-/**
- * toggleInterpDisplay - Toggles the 'u-hidden' class (which sets display: none)
- * in inline interpretation expandables so that their positions can be correctly
- * calculated
- */
-const toggleInterpDisplay = () => {
-  const interpContents = document.querySelectorAll( '.inline-interpretation .o-expandable_content__collapsed' );
-  // IE doesn't support `forEach` w/ node lists
-  for ( let i = 0; i < interpContents.length; i++ ) {
-    interpContents[i].classList.toggle( 'u-hidden' );
-  }
-};
-
 /**
  * updateParagraphPositions - Update the array that tracks paragraph positions
  *
@@ -257,9 +245,15 @@ const toggleInterpDisplay = () => {
  */
 const updateParagraphPositions = () => {
   const paragraphs = document.querySelectorAll( '.regdown-block' );
-  toggleInterpDisplay();
-  paragraphPositions = getParagraphPositions( paragraphs );
-  toggleInterpDisplay();
+  let visibleParagraphs = [];
+  // IE doesn't support `forEach` w/ node lists
+  for ( let i = 0; i < paragraphs.length; i++ ) {
+    let hiddenParagraphContainer = closest( paragraphs[i], '.u-hidden' );
+    if ( !hiddenParagraphContainer ) {
+      visibleParagraphs.push( paragraphs[i] );
+    }
+  }
+  paragraphPositions = getParagraphPositions( visibleParagraphs );
   return paragraphPositions;
 };
 
@@ -283,7 +277,7 @@ const debounce = ( event, delay, cb ) => {
   return timeout;
 };
 
-module.exports = {
+export {
   debounce,
   getCommentMarker,
   getWayfinderInfo,
@@ -292,7 +286,6 @@ module.exports = {
   getParagraphPositions,
   getYLocation,
   scrollY,
-  toggleInterpDisplay,
   updateParagraphPositions,
   updateUrlHash,
   updateWayfinder

--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -236,6 +236,20 @@ const updateWayfinder = function( scroll, wayfinder, mainContent ) {
   }
 };
 
+
+/**
+ * toggleInterpDisplay - Toggles the 'u-hidden' class (which sets display: none)
+ * in inline interpretation expandables so that their positions can be correctly
+ * calculated
+ */
+const toggleInterpDisplay = () => {
+  const interpContents = document.querySelectorAll( '.inline-interpretation .o-expandable_content__collapsed' );
+  // IE doesn't support `forEach` w/ node lists
+  for ( let i = 0; i < interpContents.length; i++ ) {
+    interpContents[i].classList.toggle( 'u-hidden' );
+  }
+};
+
 /**
  * updateParagraphPositions - Update the array that tracks paragraph positions
  *
@@ -243,7 +257,9 @@ const updateWayfinder = function( scroll, wayfinder, mainContent ) {
  */
 const updateParagraphPositions = () => {
   const paragraphs = document.querySelectorAll( '.regdown-block' );
+  toggleInterpDisplay();
   paragraphPositions = getParagraphPositions( paragraphs );
+  toggleInterpDisplay();
   return paragraphPositions;
 };
 
@@ -276,6 +292,7 @@ module.exports = {
   getParagraphPositions,
   getYLocation,
   scrollY,
+  toggleInterpDisplay,
   updateParagraphPositions,
   updateUrlHash,
   updateWayfinder

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -40,33 +40,6 @@ const HTML_SNIPPET3 = `
   <p class="regdown-block level-0" data-label="33-a-2-Interp-2" id="33-a-2-Interp-2">Foo.</p>
 `;
 
-const HTML_SNIPPET4 = `
-<div class="o-expandable o-expandable__padded o-expandable__background o-expandable__border inline-interpretation">
-  <button class="o-expandable_header o-expandable_target o-expandable_target__collapsed" data-section="Paragraph A">
-    <span class="o-expandable_header-left o-expandable_label">
-        Official interpretation of Paragraph A
-    </span>
-    <span class="o-expandable_header-right o-expandable_link">
-        <span class="o-expandable_cue o-expandable_cue-open">
-            <span class="u-visually-hidden-on-mobile">
-                Show
-            </span>
-        </span>
-        <span class="o-expandable_cue o-expandable_cue-close">
-            <span class="u-visually-hidden-on-mobile">
-                Hide
-            </span>
-        </span>
-    </span>
-  </button>
-  <div class="o-expandable_content o-expandable_content__transition o-expandable_content__collapsed u-hidden">
-    <p class="regdown-block level-0" data-label="A-1" id="A-1">
-      Offical comment A-1
-    </p>
-  </div>
-</div>
-`;
-
 describe( 'The Regs3K permalinks utils', () => {
 
   describe( 'Debounce', () => {
@@ -151,20 +124,6 @@ describe( 'The Regs3K permalinks utils', () => {
       expect( utils.getParagraphPositions( paragraphs ) ).toEqual(
         [ { id: 'z-14-i', position: -30 }, { id: 'c', position: -30 }, { id: 'Interp-1', position: -30 } ]
       );
-    } );
-
-  } );
-
-  describe( 'toggle display of expandable interpretation contents', () => {
-
-    it( 'should toggle the u-hidden class', () => {
-      document.body.innerHTML = HTML_SNIPPET4;
-      utils.toggleInterpDisplay();
-      expect( document.querySelectorAll( '.o-expandable_content' )[0].classList.value)
-        .toEqual( 'o-expandable_content o-expandable_content__transition o-expandable_content__collapsed' );
-      utils.toggleInterpDisplay();
-      expect( document.querySelectorAll( '.o-expandable_content' )[0].classList.value)
-        .toEqual( 'o-expandable_content o-expandable_content__transition o-expandable_content__collapsed u-hidden' );
     } );
 
   } );

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -40,6 +40,33 @@ const HTML_SNIPPET3 = `
   <p class="regdown-block level-0" data-label="33-a-2-Interp-2" id="33-a-2-Interp-2">Foo.</p>
 `;
 
+const HTML_SNIPPET4 = `
+<div class="o-expandable o-expandable__padded o-expandable__background o-expandable__border inline-interpretation">
+  <button class="o-expandable_header o-expandable_target o-expandable_target__collapsed" data-section="Paragraph A">
+    <span class="o-expandable_header-left o-expandable_label">
+        Official interpretation of Paragraph A
+    </span>
+    <span class="o-expandable_header-right o-expandable_link">
+        <span class="o-expandable_cue o-expandable_cue-open">
+            <span class="u-visually-hidden-on-mobile">
+                Show
+            </span>
+        </span>
+        <span class="o-expandable_cue o-expandable_cue-close">
+            <span class="u-visually-hidden-on-mobile">
+                Hide
+            </span>
+        </span>
+    </span>
+  </button>
+  <div class="o-expandable_content o-expandable_content__transition o-expandable_content__collapsed u-hidden">
+    <p class="regdown-block level-0" data-label="A-1" id="A-1">
+      Offical comment A-1
+    </p>
+  </div>
+</div>
+`;
+
 describe( 'The Regs3K permalinks utils', () => {
 
   describe( 'Debounce', () => {
@@ -124,6 +151,20 @@ describe( 'The Regs3K permalinks utils', () => {
       expect( utils.getParagraphPositions( paragraphs ) ).toEqual(
         [ { id: 'z-14-i', position: -30 }, { id: 'c', position: -30 }, { id: 'Interp-1', position: -30 } ]
       );
+    } );
+
+  } );
+
+  describe( 'toggle display of expandable interpretation contents', () => {
+
+    it( 'should toggle the u-hidden class', () => {
+      document.body.innerHTML = HTML_SNIPPET4;
+      utils.toggleInterpDisplay();
+      expect( document.querySelectorAll( '.o-expandable_content' )[0].classList.value)
+        .toEqual( 'o-expandable_content o-expandable_content__transition o-expandable_content__collapsed' );
+      utils.toggleInterpDisplay();
+      expect( document.querySelectorAll( '.o-expandable_content' )[0].classList.value)
+        .toEqual( 'o-expandable_content o-expandable_content__transition o-expandable_content__collapsed u-hidden' );
     } );
 
   } );


### PR DESCRIPTION
The iRegs wayfinder broke when we started adding `u-hidden` classes to collapsed expandable content in https://github.com/cfpb/design-system/pull/406 and added to cfgov-refresh in #5617. The `u-hidden` class gives those elements a `display: none`, which means their positions can't be correctly calculated for the map of all paragraphs on the page that powers the wayfinder. That was causing the wayfinder to always show the ID of the last interpretation paragraph on the page no matter where you scrolled.

This change fixes that by toggling the `u-hidden` class off while the map of paragraph positions is being constructed, then toggling it back on again after the map is done.

## Changes

- Changed `updateParagraphPositions` to only get the positions of *visible* paragraphs instead of all paragraphs (i.e. only paragraphs that aren't in a `u-hidden` container)

## Testing

Note that, because we have an iRegs service worker that caches the JS that powers the wayfinder, you might have to test in an incognito window or hard refresh some pages to get the new JS.

1. Visit any iRegs page with inline interpretations (like http://localhost:8000/policy-compliance/rulemaking/regulations/1026/18/, which has a *bunch* of paragraphs if you want to test on a big page). Without expanding any of the interps, scroll up and down the page to make sure the wayfinder updates correctly.
2. Expand some interps and verify that the wayfinder still shows the correct paragraph IDs as you scroll up and down the page. Also try collapsing some interps and checking that the wayfinder still looks good.
3. Visit an iRegs page without inline interpretations (any page in Supplement I of any reg will work) and make sure the wayfinder still works there.

## Notes

Yeesh, my JavaScript is so rusty, so definitely let me know if anyone can think of a better way to do this.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing