### PR TITLE
Fix encoding of pagination URL parameters

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/util/url_parameters.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/url_parameters.html
@@ -17,7 +17,7 @@
     {%- for key in parameters.keys() -%}
         {% if parameters.getlist(key) and key not in ignored_params -%}
             {%- for value in parameters.getlist(key, []) -%}
-                &{{ key }}={{ value }}
+                &amp;{{ key }}={{ value }}
             {%- endfor -%}
         {%- endif %}
     {%- endfor -%}


### PR DESCRIPTION
Because modern browsers recognize HTML character entities (e.g., `&reg;`) without their semicolons, for backwards compatibility, we need to escape the ampersand when rendering pagination URLs to prevent the combination of the ampersand and an unulucky parameter name (like `reg`) from rendering a special character in the URL and breaking the pagination buttons.

See: https://GHE/CFGOV/platform/issues/3763


## Changes

- Escapes the ampersand in the `url_parameters()` Jinja macro

## Testing

1. Visit [a production regulation search](https://www.consumerfinance.gov/policy-compliance/rulemaking/regulations/search-regulations/results/?q=transfer&regs=1005&results=25&order=relevance), try to click the Next button in the pagination, and observe the `®` rendered in the URL, resulting in 0 results.
1. Pull this branch
1. Visit [the same search page](http://localhost:8000/policy-compliance/rulemaking/regulations/search-regulations/results/?q=transfer&regs=1005&results=25&order=relevance) locally
1. Click the Next button and see that it works


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
