### PR TITLE
Fix Mattermost alert webhook call

### DIFF
--- a/cfgov/alerts/mattermost_alert.py
+++ b/cfgov/alerts/mattermost_alert.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import requests
@@ -24,6 +23,6 @@ class MattermostAlert(object):
         }
         resp = requests.post(
             self.webhook_url,
-            data=json.dumps(payload),
+            json=payload,
         )
         resp.raise_for_status()

--- a/cfgov/alerts/tests/test_mattermost_alert.py
+++ b/cfgov/alerts/tests/test_mattermost_alert.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 
 from django.test import TestCase
 
@@ -24,7 +23,9 @@ class TestMattermostAlert(TestCase):
         MattermostAlert(credentials, icon_url=icon).post(text)
         mock.assert_called_once_with(
             webhook_url,
-            data=json.dumps({'text': text,
-                             'username': username,
-                             'icon_url': icon})
+            json={
+                'text': text,
+                'username': username,
+                'icon_url': icon
+            }
         )


### PR DESCRIPTION
Mattermost seems to have gotten more particular about the `Content-Type` header of incoming webhooks in the upgrade from 5.18 to 5.22.

We were seeing errors of this kind:

```json
{
  "level": "error",
  "ts": 1588614108.121396,
  "caller": "mlog/log.go:175",
  "msg": "Could not decode the multipart payload of incoming webhook.",
  "path": "/hooks/<hook_id>",
  "request_id": "wsb5g1xiqine7knmgj9yo9887w",
  "ip_addr": "<ip>",
  "user_id":"",
  "method": "POST",
  "err_where": "incomingWebhook",
  "http_code": 400,
  "err_details": "mime: no media type"
}
```

This change switches our alert webhook's `requests.post` call from using Requests' `data` param to using its `json` param, which sets the `Content-Type` to `application/json`, as Mattermost now requires.

See: https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests


## Changes

- Switches Mattermost alert webhook `requests.post` call from `data` to `json`


## Testing

In your cfgov-refresh virtualenv, open the Python console and walk through the following:

```py
>>> import json
>>> import requests
# Be sure to replace the `GHE` in the string below.
>>> payload = {
...     'text': 'Manual MM webhook testing',
...     'username': 'alertbot',
...     'icon_url': 'https://GHE/raw/CFGOV/platform/master/alerts/scream.png'
... }

# Confirm existing error behavior:
# (Contact me for the full URL you should use.)
>>> resp = requests.post(
...     'https://mattermost/hooks/<hook_id>',
...     data=json.dumps(payload)
... )
>>> resp
<Response [400]>
>>> resp.content
b'{
    "id": "api.webhook.incoming.error",
    "message": "Could not decode the multipart payload of incoming webhook.",
    "detailed_error": "",
    "request_id": "b38mndqaz7y8zche3dtwjfj1zc",
    "status_code": 400
}'
# If you have MM system console access, you can also see an error in the logs there.

# Try the new behavior:
# (Contact me for the full URL you should use.)
>>> resp = requests.post(
...     'https://mattermost/hooks/<hook_id>',
...     json=payload
... )
>>> resp
<Response [200]>
# You will also see the successful post in the cf.gov Alerts channel.
```

## Notes

- I think this may have the interesting side effect of actually using the scream emoji for the bot's avatar, instead of the stock webhook logo.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
