### PR TITLE
Remove Django's LocaleMiddleware from the app

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -114,7 +114,6 @@ POSTGRES_APPS = []
 
 MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
Because we always activate Spanish-language content via the inclusion of 
an `/es/` path segment that triggers the setting of the `language` 
context variable to `es`, we do not need this middleware for anything 
currently, and its presence can cause unwanted appearance of Spanish on 
English pages if a user has set their browser's primary language to 
Spanish.


## Removals

- `django.middleware.locale.LocaleMiddleware` removed from `MIDDLEWARE` in our base settings file


## Testing

1. Pull branch
1. Visit various Spanish-language pages on your local server and compare to how they look in production
1. Update your browser settings to prefer Spanish (e.g. in Chrome, Settings, Advanced, Languages, Language)
1. Visit `/data-research/consumer-complaints/` using your favorite way to bypass Akamai, observe some parts of the global header and footer appearing in Spanish
1. Visit http://localhost:8000/data-research/consumer-complaints/ and observe those same parts now in English
1. Remember to set your browser language preferences back when done testing


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

