### PR TITLE
Remove unnecessary request params from flag_enabled template tags

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -30,7 +30,7 @@
            or 'cta' in block_type and block.value.is_inset %}
             <div class="m-inset
                     {{ 'm-inset__test'
-                       if flag_enabled('INSET_TEST', request) else '' }}">
+                       if flag_enabled('INSET_TEST') else '' }}">
                 {{ block | safe }}
             </div>
         {% elif block_type in ['email_signup'] %}

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -25,7 +25,7 @@
 
 <header class="o-header{% if mega_menu_content %} o-header__mega-menu{% endif %}">
 
-    {% if flag_enabled('BETA_NOTICE', request) and show_banner %}
+    {% if flag_enabled('BETA_NOTICE') and show_banner %}
     {% import 'molecules/notification.html' as notification with context %}
     <div class="m-global-banner">
       <div class="wrapper
@@ -51,23 +51,23 @@
         {% endfor %}
     {% endif %}
 
-    {% if flag_enabled('COLLECT_OUTAGE', request) %}
+    {% if flag_enabled('COLLECT_OUTAGE') %}
         {{ collect_outage_banner(request) }}
     {% endif %}
 
-    {% if flag_enabled('COMPLAINT_INTAKE_TECHNICAL_ISSUES', request) %}
+    {% if flag_enabled('COMPLAINT_INTAKE_TECHNICAL_ISSUES') %}
         {{ complaint_issue_banner(request) }}
     {% endif %}
 
-    {% if flag_enabled('COMPLAINT_INTAKE_MAINTENANCE', request) %}
+    {% if flag_enabled('COMPLAINT_INTAKE_MAINTENANCE') %}
         {{ complaint_maintenance_banner(request) }}
     {% endif %}
 
-    {% if flag_enabled('HMDA_OUTAGE', request) %}
+    {% if flag_enabled('HMDA_OUTAGE') %}
         {{ hmda_outage_banner(request) }}
     {% endif %}
 
-    {% if flag_enabled('OMWI_SALESFORCE_OUTAGE', request) %}
+    {% if flag_enabled('OMWI_SALESFORCE_OUTAGE') %}
         {{ omwi_salesforce_outage_banner(request) }}
     {% endif %}
 

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -6,7 +6,7 @@
   {% set language = 'en' %}
 {% endif -%}
 <!DOCTYPE html>
-{% if flag_enabled('CFPB_RECRUITING', request) %}
+{% if flag_enabled('CFPB_RECRUITING') %}
 <!--
     ============================================================================
 
@@ -178,7 +178,7 @@
     </script>
     {% endblock javascript_loader %}
 
-    {% if flag_enabled('AB_TESTING', request) %}
+    {% if flag_enabled('AB_TESTING') %}
     {# Google Optimize page-hiding snippet #}
     <style>
         .optimize-loading { opacity: 0 !important; }
@@ -336,7 +336,7 @@
           {% if js_source | length > 0 %}
             s.push( '{{ static('js/routes/' + app_page_url(request) + 'index.js') }}' );
           {% endif %}
-          {% if flag_enabled('TURBOLINKS', request) %}
+          {% if flag_enabled('TURBOLINKS') %}
             s.push( '{{ static('js/routes/on-demand/turbolinks.js') }}' );
           {% endif %}
           {# Pass scripts to JavaScript loader. #}

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -27,7 +27,7 @@
 {%- endblock %}
 
 {% block content_main %}
-<div {% if flag_enabled('HOW_TO_SCHEMA', request) %}
+<div {% if flag_enabled('HOW_TO_SCHEMA') %}
         itemscope=""
         itemtype="http://schema.org/HowTo"
      {% endif %}>
@@ -37,7 +37,7 @@
         {% if last_edited %}
         <time datetime='{{ last_edited }}' class="answer-edited-date">{{ _('updated') }} {{ dt.format_date(last_edited) }}</time>
         {% endif %}
-        <h1 {% if flag_enabled('HOW_TO_SCHEMA', request) %}itemprop="name"{% endif %}>
+        <h1 {% if flag_enabled('HOW_TO_SCHEMA') %}itemprop="name"{% endif %}>
             {{ page.question | striptags }}
         </h1>
     </div>

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -20,7 +20,7 @@
         </div>
 
         {% if results %}
-            {% if flag_enabled('ASK_SEARCH_TYPOS', request) %}
+            {% if flag_enabled('ASK_SEARCH_TYPOS') %}
                 {% if tag %}
                     <h3 class="results-header">{{ _('Showing results for ') }} “{{ tag }}”</h3>
                 {% else %}
@@ -74,7 +74,7 @@
                     <h3 class="results-header">{{ _('No results found for') }} “{{ page.query }}”</h3>
                 {% endif %}
 
-                {% if flag_enabled('ASK_SEARCH_TYPOS', request) %}
+                {% if flag_enabled('ASK_SEARCH_TYPOS') %}
                     {% if page.suggestion %}
                     <p>{{ _('Search instead for') }} <a href="{{ _('/ask-cfpb/search') }}?q={{ page.suggestion }}">{{ page.suggestion }}</a></p>
                     {% endif %}


### PR DESCRIPTION
A [PR to django-flags a year and a half ago](https://github.com/cfpb/django-flags/pull/14) made the passing of `request` to the `flag_enabled()` and `flag_disabled()` template tags unnecessary.

The inclusion of `request` breaks Wagtail revision comparisons for pages that include a template with such, because the Wagtail revision comparison view has no `request`.

## Removals

- Removes extraneous `request` params from our `flag_enabled()` template tags


## Testing

1. With a fresh database dump, try to view http://localhost:8000/admin/pages/13866/revisions/compare/212395...212582/ on the master branch and observe a 500 error.
1. Pull branch
1. Refresh http://localhost:8000/admin/pages/13866/revisions/compare/212395...212582/ and see that it now works

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
