### PR TITLE
Update wagtail-autocomplete from 0.1.1 to 0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:7 AS cfgov-dev
 
+# Ensure that the environment uses UTF-8 encoding by default
+ENV LANG en_US.UTF-8  
+
 # Specify SCL-based Python version
 # Currently used option: rh-python36
 # See: https://www.softwarecollections.org/en/scls/user/rhscl/?search=python

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -577,8 +577,7 @@ class AnswerPage(CFGOVPage):
             SnippetChooserPanel('related_resource'),
             AutocompletePanel(
                 'related_questions',
-                page_type='ask_cfpb.AnswerPage',
-                is_single=False)],
+                target_model='ask_cfpb.AnswerPage')],
             heading="Related resources",
             classname="collapsible"),
         MultiFieldPanel([
@@ -594,7 +593,7 @@ class AnswerPage(CFGOVPage):
             classname="collapsible"),
         MultiFieldPanel([
             AutocompletePanel(
-                'redirect_to_page', page_type='ask_cfpb.AnswerPage')],
+                'redirect_to_page', target_model='ask_cfpb.AnswerPage')],
             heading="Redirect to another answer",
             classname="collapsible"),
         MultiFieldPanel([

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,7 +37,7 @@ sha3==0.2.1
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
-wagtail-autocomplete==0.1.1
+wagtail-autocomplete==0.5
 wagtail-flags==4.1.1
 wagtail-inventory==1.0
 wagtail-sharing==2.1


### PR DESCRIPTION
This change is required for the following:
* Add Django 3.0 support
* Remove Wagtail 1.x support (Wagtail 2.3 or later now required)

## Changes ##
Replace `page_type` keyword argument with more accurate `target_model` keyword argument.
The old argument still works, but is deprecated.
Deprecate `is_single option`, make `target_model` optional.
`AutocompletePanel` will now automatically derive these attributes from the field.

https://wagtail-autocomplete.readthedocs.io/en/latest/changelog.html

## Testing

1. tox -e unittest-current
1. tox -e unittest-future

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: