### PR TITLE
Re-enable venv-update and resolve dependencies for Django 2.2

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -92,25 +92,17 @@ INSTALLED_APPS = (
     "diversity_inclusion",
     "mega_menu.apps.MegaMenuConfig",
     "form_explainer.apps.FormExplainerConfig",
+
+    # Satellites
+    "comparisontool",
+    "retirement_api",
+    "ratechecker",
+    "countylimits",
+    "complaint_search",
+    "ccdb5_ui",
+    "mptt",
+    "teachers_digital_platform",
 )
-
-OPTIONAL_APPS = [
-    {"import": "comparisontool", "apps": ("comparisontool", "haystack",)},
-    {"import": "retirement_api", "apps": ("retirement_api",)},
-    {"import": "ratechecker", "apps": ("ratechecker", "rest_framework")},
-    {"import": "countylimits", "apps": ("countylimits", "rest_framework")},
-    {
-        "import": "complaint_search",
-        "apps": ("complaint_search", "rest_framework"),
-    },
-    {"import": "ccdb5_ui", "apps": ("ccdb5_ui",)},
-    {
-        "import": "teachers_digital_platform",
-        "apps": ("teachers_digital_platform", "mptt", "haystack"),
-    },
-]
-
-POSTGRES_APPS = []
 
 MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -413,18 +405,6 @@ if os.environ.get("S3_ENABLED", "False") == "True":
 
 # GovDelivery
 GOVDELIVERY_ACCOUNT_CODE = os.environ.get("GOVDELIVERY_ACCOUNT_CODE")
-
-# LOAD OPTIONAL APPS
-# code from https://gist.github.com/msabramo/945406
-for app in OPTIONAL_APPS:
-    try:
-        __import__(app["import"])
-        for name in app.get("apps", ()):
-            if name not in INSTALLED_APPS:
-                INSTALLED_APPS += (name,)
-        MIDDLEWARE += app.get("middleware", ())
-    except ImportError:
-        pass
 
 # Removes wagtail version update check banner from admin page
 WAGTAIL_ENABLE_UPDATE_CHECK = False

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -11,7 +11,7 @@ django-haystack==2.8.1
 # django-js-asset is required by teachers-digital-platform
 django-js-asset==1.1.0
 # django-localflavor is required by django-college-costs-comparison
-django-localflavor==3.0
+django-localflavor==2.2
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-storages==1.7.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -49,4 +49,4 @@ https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.4.0/ccdb5_api-1.4.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.0.3/ccdb5_ui-2.0.3-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.0/comparisontool-1.15.0-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.4.0/teachers_digital_platform-1.4.0-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.4.1/teachers_digital_platform-1.4.1-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -7,7 +7,7 @@ djangorestframework==3.9.1
 django-csp==3.4
 django-extensions==2.1.3
 django-flags==4.2.4
-django-haystack==2.7.0
+django-haystack==2.8.1
 # django-js-asset is required by teachers-digital-platform
 django-js-asset==1.1.0
 # django-localflavor is required by django-college-costs-comparison

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,5 @@ github3.py==0.9.6
 mock==2.0.0
 model-bakery==1.1.0
 moto==1.3.6
-pip==20.0.2
+pip==18.1
 responses==0.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 skipsdist=True
-# Temporarily disabling this to deliberately support conflicting versions
-# of django-treebeard and djangorestframework.
-# tox_pip_extensions_ext_venv_update=True
+tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
 envlist=lint-{current}, unittest-{current,future}
 
@@ -140,7 +138,7 @@ deps=
 basepython=python3.6
 deps=
     Django>=2.2,<3.0
-    wagtail>=2.3,<2.4
+    wagtail>=2.3,<2.6
 
 
 [acceptance-config]


### PR DESCRIPTION
This PR does two major things:

1. Re-enables `tox_pip_extensions_ext_venv_update` in tox, which will automatically update our local test envs with dependency changes, and will enforce dependency resolution, and updates dependencies based on what they collectively require to achieve a set of dependencies that match.
2. Pins Wagtail to `<2.6` in `unittest-future`. Wagtail 2.5 is the first version to support Django 2.2, so this satisfies `venv-update`'s requirement for matching version ranges.

There is one other minor change as well:

- `OPTIONAL_APPS` in settings has been removed as part of the dependency/app updates. There's no practical change here, as our satellite apps have been non-optional for a while now.

And there's one thing to highlight:

- `venv-update` is not exactly under *active* development (it doesn't seem inactive, but it just seems like many of our own libraries — maintained as Yelp needs to), but it requires `pip` `>=18.1`. This is a couple years old at this point, and I'd hope not to keep it there long-term. I do think for now the benefit of using `venv-update` is worth the limited risk in pinning an older `pip` for now.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
