### PR TITLE
Global Search: Fix cropped search focus rectangle

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -282,6 +282,9 @@
             &_content {
                 right: @margin_half__em;
                 width: auto;
+                // Add margin so that the focus rectangle isn't cropped by
+                // the hidden overflow of the search container element.
+                margin-left: 3px;
             }
         }
     } );

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -112,7 +112,9 @@
                 }
 
                 > .m-global-search {
-                    min-width: 340px;
+                    // Width should visually be 340px, plus 3px to accommodate
+                    // the focus state.
+                    min-width: 343px;
                 }
             }
         } );


### PR DESCRIPTION
I've had enough of looking at this issue, and turns out it's an easy fix!

## Changes

- Fix cropped search focus rectangle.

## Testing

1. Pull branch and build.
2. Click into the global search and see that the focus rectangle is not cropped on the left-hand side. Compare to production.

## Screenshots

Before:
<img width="378" alt="Screen Shot 2020-05-06 at 5 05 55 PM" src="https://user-images.githubusercontent.com/704760/81228409-0775b680-8fbc-11ea-80a3-030e96fbd114.png">

After:
<img width="384" alt="Screen Shot 2020-05-06 at 5 05 46 PM" src="https://user-images.githubusercontent.com/704760/81228422-0ba1d400-8fbc-11ea-9a31-d648af492746.png">
