### PR TITLE
Make interpretation location a variable in iRegs

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -1,3 +1,6 @@
+{#- Part 1004 (Reg D) houses interps in Appendix A instead of Supplement I like every other reg -#}
+{%- set interp_location = 'Appendix A' if regulation and regulation.part_number == '1004' else 'Supplement I' -%}
+
 <div data-qa-hook="expandable"
      class="o-expandable
             o-expandable__padded
@@ -28,7 +31,7 @@
     <div class="o-expandable_content">
         {{ contents }}
 
-        <p><a href="{{ url }}">See interpretation of {% if section_title %}{{ section_title }}{% else %}this section{% endif %} in Supplement I</a></p>
+        <p><a href="{{ url }}">See interpretation of {% if section_title %}{{ section_title }}{% else %}this section{% endif %} in {{ interp_location }}</a></p>
     </div>
 
 </div>


### PR DESCRIPTION
We're adding inline interpretations to Regulation D. Unlike all of our other regs, Reg D houses its interpretations in Appendix A instead of Supplement I. We had "Supplement I" hardcoded into the text of the links at the end of all inline interpretations, which didn't make sense for inline interps in Reg D. This PR fixes that by making the reference to the location of the interps in those links a variable and sets up a special case for Reg D interps.

## Changes

- The part of the link in inline interpretations that points to the interp in the regulation text is now a variable that will be "Appendix A" only for Reg D and "Supplement I" everywhere else.

## Testing

1. Make sure you have the latest production database.
2. Go to the version of Reg D that has inline interpretations in it, http://localhost:8000/policy-compliance/rulemaking/regulations/1004/2021-07-22/
3. Verify that the links at the end of all the inline interps there say "See interpretation of {{whatever}} in Appendix A"
4. Check the inline interps in other regs to make sure the links at the end of those continues to say "See interpretation of {{whatever}} in Supplement I"

## Screenshots

![reg-d-interp](https://user-images.githubusercontent.com/1862695/81218735-abeffc80-8fac-11ea-854f-4564fab25596.png)

## Notes

@willbarton and I were chatting about this one, and we both agree that hardcoding a special case for Reg D in the `inline_interp` template isn't the best way to handle this. A much better way would be to make the location of each inline interp available as a context variable in the template instead. But that's a much tricker change that needs some more thought, so we agreed to go with this change in the template for now. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing