### PR TITLE
Remove PyYAML from libraries and update it in docs

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,6 +10,6 @@ mkdocs-bootstrap==1.0.1
 mkdocs-bootswatch==1.0
 mkdocs-rtd-dropdown==1.0.2
 pymdown-extensions==5.0
-PyYAML==3.13
+PyYAML==5.3.1
 singledispatch==3.4.0.3
 tornado==5.1.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -29,7 +29,6 @@ openpyxl==2.5.8
 psycopg2==2.7.3.2
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3
-PyYAML==3.13
 regdown==1.0.2
 requests==2.22.0
 requests_toolbelt==0.8.0


### PR DESCRIPTION
This PR is identical to #5713. Snyk refused to run on that PR for reasons that their support were unhelpful in determining. This PR is an attempt to get around that by opening a new PR.

--

This upgrade is to address CVE-2017-18342. As of #5714 it's no longer required in libraries.txt.

There was a vulnerability in PyYAML 3.1.13 that we determined didn't effect us in the way we use the library, but the vulnerability still gets flagged. Previously we couldn't upgrade PyYAML because non-vulnerable versions did not support Python 2. Now we can!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
