### PR TITLE
Coronavirus page redirect

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -998,3 +998,6 @@ RedirectMatch permanent (?i)^/askcfpb/search/(.*) /ask-cfpb/search/$1
 RedirectMatch permanent (?i)^/how-to-prepare-your-finances-for-buying-a-home/(.*) /owning-a-home/process/prepare/
 Redirect /owning-a-home/help-us-improve/ /owning-a-home/feedback/
 RedirectMatch permanent (?i)^/wp-content/uploads/(.*) https://files.consumerfinance.gov/f/$1
+
+# Redirect placeholder page created to appear in secondary nav on coronavirus child pages
+Redirect permanent /coronavirus/mortgage-and-housing/ /coronavirus/mortgage-and-housing-assistance/


### PR DESCRIPTION
Redirect for placeholder browse page created to appear in the side nav of other coronavirus child pages to sublanding page at `/coronavirus/mortgage-and-housing-assistance/`.