### PR TITLE
Remove HOW_TO_SCHEMA flag and its effects on AnswerPages

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -1128,15 +1128,3 @@ class AnswerPageTestCase(TestCase):
         request = HttpRequest()
         request.GET.update({"page": "<script>Boo</script>"})
         self.assertEqual(validate_page_number(request, paginator), 1)
-
-    def test_schema_html_does_not_appear_when_flag_is_off(self):
-        with override_settings(FLAGS={"HOW_TO_SCHEMA": [("boolean", False)]}):
-            response = self.client.get(self.page1.url)
-            self.assertNotContains(
-                response, 'itemtype="http://schema.org/HowTo"'
-            )
-
-    def test_schema_html_appears_when_flag_is_on(self):
-        with override_settings(FLAGS={"HOW_TO_SCHEMA": [("boolean", True)]}):
-            response = self.client.get(self.page1.url)
-            self.assertContains(response, 'itemtype="http://schema.org/HowTo"')

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -666,12 +666,6 @@ FLAGS = {
             "required": True,
         },
     ],
-    # Add HowTo schema markup to answer page
-    # Intended for use with path conditions in admin for specific ask pages,
-    # such as: is enabled when path matches ^/ask-cfpb/what-is-an-ach-en-1065/
-    # Delete after Google schema pilot completes and schema usage is
-    # discontinued or implemented with a toggle in answer page admin.
-    "HOW_TO_SCHEMA": [],
     # Manually enabled when Beta is being used for an external test.
     # Controls the /beta_external_testing endpoint, which Jenkins jobs
     # query to determine whether to refresh Beta database.

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -27,17 +27,13 @@
 {%- endblock %}
 
 {% block content_main %}
-<div {% if flag_enabled('HOW_TO_SCHEMA') %}
-        itemscope=""
-        itemtype="http://schema.org/HowTo"
-     {% endif %}>
     <div class="block
                 block__flush-top
                 block__sub">
         {% if last_edited %}
         <time datetime='{{ last_edited }}' class="answer-edited-date">{{ _('updated') }} {{ dt.format_date(last_edited) }}</time>
         {% endif %}
-        <h1 {% if flag_enabled('HOW_TO_SCHEMA') %}itemprop="name"{% endif %}>
+        <h1>
             {{ page.question | striptags }}
         </h1>
     </div>
@@ -110,7 +106,6 @@
         </div>
 
     </div>
-</div>
 {{ email_popup(request) }}
 {% endblock %}
 


### PR DESCRIPTION
Since modifying the HowTo block to be usable on BlogPage (chiefly, adding in a `title` field that outputs the overall HowTo's `name` property, this flag's effects are no longer helpful, and are, in fact, causing errors in how the HowTo markup on Ask pages is being interpreted.

In truth, I screwed up by not fully understanding how the HowTo implementation within Ask CFPB worked when I extended it to BlogPage, causing this situation we're in now with the double markup. But, it seems like the HowTo schema will be fairly stable and worthwhile, so it makes sense to take this out of a flag-based setup and have it be controlled exclusively by the presence of the block, anyhow.

/cc @kelleyholden 

## Removals

- `HOW_TO_SCHEMA` flag and related code

## Testing

1. To reproduce the problem with a database dump prior to the night of 5/12/20 (the day in which I turned the flags off in production) look at http://localhost:8000/ask-cfpb/what-is-the-best-way-to-negotiate-a-settlement-with-a-debt-collector-en-1447/
1. Right click, view source, and copy it all
1. Paste it into the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool)'s code snippet entry field
1. See the errors
1. Pull branch
1. Repeat the above steps and see that the tool returns no errors anymore

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: