### PR TITLE
Downgrade wagtail-autocomplete

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -577,7 +577,8 @@ class AnswerPage(CFGOVPage):
             SnippetChooserPanel('related_resource'),
             AutocompletePanel(
                 'related_questions',
-                target_model='ask_cfpb.AnswerPage')],
+                page_type='ask_cfpb.AnswerPage',
+                is_single=False)],
             heading="Related resources",
             classname="collapsible"),
         MultiFieldPanel([
@@ -593,7 +594,7 @@ class AnswerPage(CFGOVPage):
             classname="collapsible"),
         MultiFieldPanel([
             AutocompletePanel(
-                'redirect_to_page', target_model='ask_cfpb.AnswerPage')],
+                'redirect_to_page', page_type='ask_cfpb.AnswerPage')],
             heading="Redirect to another answer",
             classname="collapsible"),
         MultiFieldPanel([

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -36,7 +36,7 @@ sha3==0.2.1
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
-wagtail-autocomplete==0.5
+wagtail-autocomplete==0.1.1
 wagtail-flags==4.1.1
 wagtail-inventory==1.0
 wagtail-sharing==2.1


### PR DESCRIPTION
wagtail-autocomplete 0.5's README.st is UTF-8 encoded, and somewhere along our build pipeline the README.st is not being opened UTF-8 encoded (I believe because the locale is not set to UTF-8 in a way that it needs to be). This downgrades to unbreak the build while we figure that out.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
