### PR TITLE
Move search to the top of the Ask landing page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/ask-search.html
+++ b/cfgov/jinja2/v1/_includes/organisms/ask-search.html
@@ -8,17 +8,18 @@
 
    Output an ask search bar when given:
 
-   ask_query     The previous search query string.
+   ask_query      The previous search query string.
 
-   language:     page's language.
+   language:      page's language.
 
-   show_label:   Boolean; whether to show form label.
+   show_label:    Boolean; whether to show form label.
 
-   autocomplete: Boolean; whether to allow autocomplete.
+   autocomplete:  Boolean; whether to allow autocomplete.
 
-   placeholder: String; text to enter for the search input's placeholder value.
+   placeholder:   String; text to enter for the search input's placeholder value.
 
-   label_level:  String; heading level to use for the label.
+   is_subsection: Boolean; whether to mark up the form label with an h3 to fit
+                  into an exisitng section or with an h2 to be its own section
 
    ========================================================================== #}
 
@@ -28,13 +29,15 @@
     show_label=True,
     autocomplete=True,
     placeholder='',
-    label_level='h3'
+    is_subsection=True
 ) %}
 <div class="o-search-bar">
     <form method="get" action="{{ _('/ask-cfpb/search/') }}">
         {% if show_label %}
         <label for="o-search-bar_query">
-            <{{ label_level }}>{{ _('Search for your question') }}</{{ label_level }}>
+            <{{ 'h3' if is_subsection else 'h2' }}>
+                {{ _('Search for your question') }}
+            </{{ 'h3' if is_subsection else 'h2' }}>
         </label>
         {% endif %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/ask-search.html
+++ b/cfgov/jinja2/v1/_includes/organisms/ask-search.html
@@ -18,6 +18,8 @@
 
    placeholder: String; text to enter for the search input's placeholder value.
 
+   label_level:  String; heading level to use for the label.
+
    ========================================================================== #}
 
 {% macro render(
@@ -25,13 +27,14 @@
     language='en',
     show_label=True,
     autocomplete=True,
-    placeholder=''
+    placeholder='',
+    label_level='h3'
 ) %}
 <div class="o-search-bar">
     <form method="get" action="{{ _('/ask-cfpb/search/') }}">
         {% if show_label %}
         <label for="o-search-bar_query">
-            <h3>{{ _('Search for your question') }}</h3>
+            <{{ label_level }}>{{ _('Search for your question') }}</{{ label_level }}>
         </label>
         {% endif %}
 

--- a/cfgov/jinja2/v1/ask-cfpb/landing-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/landing-page.html
@@ -17,7 +17,7 @@
 {% block content_main %}
     <div class="content-l">
         <section class="ask-search block__sub block__flush-top">
-            {{ ask_search.render( language=page.language, label_level='h2' ) }}
+            {{ ask_search.render( language=page.language, is_subsection=False ) }}
         </section>
 
         <section class="ask-categories">

--- a/cfgov/jinja2/v1/ask-cfpb/landing-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/landing-page.html
@@ -16,8 +16,12 @@
 
 {% block content_main %}
     <div class="content-l">
+        <section class="ask-search block__sub block__flush-top">
+            {{ ask_search.render( language=page.language, label_level='h2' ) }}
+        </section>
+
         <section class="ask-categories">
-            <h2 class="u-show-on-mobile u-mt30">
+            <h2 class="u-show-on-mobile u-mt45">
                 {{ _('Browse questions by category') }}
             </h2>
             <ul class="u-show-on-mobile category_list m-list m-list__links u-mb0">
@@ -37,7 +41,7 @@
                 {% endfor %}
             </ul>
 
-            <div class="u-hide-on-mobile question-categories">
+            <div class="u-hide-on-mobile question-categories u-mb15">
 
                 {#
                     TODO: This can use the standard card-group.html template
@@ -80,13 +84,6 @@
 
             </div>
         </section>
-
-        <section class="ask-search block block__sub block__flush-bottom">
-            <h2>{{ _('Don\'t see what you\'re looking for?') }}</h2>
-            {{ ask_search.render( language=page.language ) }}
-        </section>
-
-
     </div>
 
 {% endblock %}

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -241,6 +241,15 @@
         max-width: 500px;
     }
 
+    // The max-width on the search bar cuts off the last few letters of the
+    // Spanish button text when the input and button are side by side; setting
+    // the width of that button to auto lets it overrun its container if needed
+    .respond-to-min( @bp-med-min, {
+        .o-form__input-w-btn_btn-container .a-btn {
+            width: auto;
+        }
+    } );
+
     .lead-paragraph {
         // This makes for line lengths between 85-95 characters
         max-width: 41.875rem;
@@ -299,6 +308,23 @@
      .o-search-bar_input {
         max-width: 31.25rem;
     }
+
+    label[for="o-search-bar_query"] h2 {
+        .heading-4();
+
+        .respond-to-min( @bp-med-min, {
+            .heading-3();
+        } );
+    }
+
+    // The max-width on the search bar cuts off the last few letters of the
+    // Spanish button text at widths where there's a sidebar; setting the width
+    // of that button to auto lets it overrun its container if needed
+    .respond-to-min( @bp-med-min, {
+        .o-form__input-w-btn_btn-container .a-btn {
+            width: auto;
+        }
+    } );
 
 }
 


### PR DESCRIPTION
Move the Ask search to the top of the Ask landing page. See [GHE]/CFGOV/platform/issues/3779 for more details.

## Additions

- Added the `label_level` parameter to the `ask-search` template. The `ask-search` template is used in a number of places. Previously, all of those places either didn't show the label (using `show_label=False`) or situated the form under an `h2`. Now that the search form is at the top of the Ask landing page, it needed an `h2` to be semantically correct. The new `label_level` parameter lets you set the heading level in the label to something other than `h3` if you need it.

## Changes

- The Ask search now appears at the top of the Ask landing page.
- Previously, the Spanish search button label, "búsqueda," was cut off (see the [current Spanish Ask landing page](https://www.consumerfinance.gov/es/obtener-respuestas/)); the search button now has a width of `auto` to allow it to break out of its container on Ask pages where the form's `max-width` is set to fix that issue.

## Testing

1. Visit http://localhost:8000/ask-cfpb/ and make sure the Ask search appears at the top of the Ask landing page, as in the screenshots.
2. Visit http://localhost:8000/es/obtener-respuestas/ and make sure the Ask search also appears at the top of the Spanish Ask landing page *and* that "búsqueda" isn't cut off in the submit button.
3. If you have Elasticsearch running locally, make sure the typeahead suggestions still work as they do in production.
4. Check the Ask search at a few screen sizes. The label should drop to `h4` size when all of the other headings on the page make their one-step drop (at the medium breakpoint, I think).
5. Visit some other pages where the Ask search is used (like http://localhost:8000/ask-cfpb/search/, http://localhost:8000/askcfpb/316/, and http://localhost:8000/complaint/) to confirm that nothing has changed on those pages.

## Screenshots

Small screens | Large screens
---- | ----
![ask-landing-small](https://user-images.githubusercontent.com/1862695/82375121-1877ec00-99ee-11ea-9485-879aeceee2ce.png) | ![ask-landing-large](https://user-images.githubusercontent.com/1862695/82375148-1f9efa00-99ee-11ea-9a7e-7ae2de4d8d75.png)

## Notes

- @anselmbradford and @virginiacc, I added you as reviewers since you've worked on the Ask search template before. Let me know if you spot anything that can be improved, but no worries if you don't have time to review this (I'll pester @Scotchester 😄 ).

## Todos

- I think the Spanish submit button text, "búsqueda," should be capitalized. But I see that it's also not capitalized in the global search's submit button, so I'm deeming that fix outside the scope of this PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing