### PR TITLE
Remove Apache configuration preventing prepaid-cards section from being cached

### DIFF
--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -26,11 +26,9 @@ Header always set X-Content-Type-Options: nosniff
         ExpiresDefault "now plus 1000 days"
 </LocationMatch>
 
-# this was a test, that we may want to refer back to later. Leaving it (but commented) for posterity
-#<LocationMatch ^\/company-signup\/$>
-#        Header always set Edge-Control: no-store
-#</LocationMatch>
-
-<LocationMatch ^\/consumer-tools/prepaid-cards\/>
-        Header always set Edge-Control: no-store
-</LocationMatch>
+# Example of how we can block Akamai from caching a page with code in this repo,
+# in case we ever want to do that again in the future.
+#
+# <LocationMatch ^\/company-signup\/$>
+#         Header always set Edge-Control: no-store
+# </LocationMatch>


### PR DESCRIPTION
We can't recall why we would have done that, and can't think of a good reason to still be doing it.


## Removals

- Apache configuration directive setting the `Edge-Control: no-store` header for `/consumer-tools/prepaid-cards/` and its children

## Changes

- Makes comment that preceded that a little more explicit


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
