### PR TITLE
Drop the use of unicodecsv

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -1,10 +1,9 @@
+import csv
 import datetime
 import html
 
 from django.http import HttpResponse
 from django.utils import html as html_util
-
-import unicodecsv
 
 from ask_cfpb.models.pages import AnswerPage
 
@@ -119,15 +118,10 @@ def assemble_output():
 
 def export_questions(path='/tmp', http_response=False):
     """
-    A script for exporting Ask CFPB Answer content
-    to a CSV that can be opened easily in Excel.
+    A script for exporting Ask CFPB Answer content to an Excel-friendly CSV.
 
     Run from within cfgov-refresh with:
     `python cfgov/manage.py runscript export_ask_data`
-
-    CEE staffers use a version of Excel that can't easily import UTF-8
-    non-ascii encodings. So we throw in the towel and encode the CSV
-    with windows-1252.
 
     By default, the script will dump the file to `/tmp/`,
     unless a path argument is supplied,
@@ -135,7 +129,6 @@ def export_questions(path='/tmp', http_response=False):
     A command that passes in path would look like this:
     `python cfgov/manage.py runscript export_ask_data --script-args [PATH]`
     """
-
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d")
     slug = 'ask-cfpb-{}.csv'.format(timestamp)
     if http_response:
@@ -144,12 +137,12 @@ def export_questions(path='/tmp', http_response=False):
         write_questions_to_csv(response)
         return response
     file_path = '{}/{}'.format(path, slug).replace('//', '/')
-    with open(file_path, 'w') as f:
+    with open(file_path, 'w', encoding='windows-1252') as f:
         write_questions_to_csv(f)
 
 
 def write_questions_to_csv(csvfile):
-    writer = unicodecsv.writer(csvfile, encoding='windows-1252')
+    writer = csv.writer(csvfile)
     writer.writerow(HEADINGS)
     for row in assemble_output():
         writer.writerow([row.get(key) for key in HEADINGS])

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -133,7 +133,8 @@ class ExportAskDataTests(TestCase, WagtailTestUtils):
         with mock.patch("builtins.open", m, create=True):
             export_questions()
         self.assertEqual(mock_output.call_count, 1)
-        m.assert_called_once_with("/tmp/{}".format(slug), "w")
+        m.assert_called_once_with(
+            "/tmp/{}".format(slug), "w", encoding='windows-1252')
 
     @mock.patch("ask_cfpb.scripts.export_ask_data.assemble_output")
     def test_export_from_admin_post(self, mock_output):

--- a/cfgov/data_research/blocks.py
+++ b/cfgov/data_research/blocks.py
@@ -73,20 +73,12 @@ class ConferenceRegistrationForm(AbstractFormBlock):
         answer = cleaned.get('govdelivery_answer_id')
 
         # Question and answer values must both exist or neither exist
-        if question and not answer:
+        if (question and not answer) or (answer and not question):
             raise ValidationError(
                 'Validation error in Conference Registration Form: '
                 'GovDelivery question ID requires answer ID, and vice versa.',
                 params={'govdelivery_answer_id': ErrorList([
                     'Required if a GovDelivery question ID is entered.'
-                ])}
-            )
-        if answer and not question:
-            raise ValidationError(
-                'Validation error in Conference Registration Form: '
-                'GovDelivery question ID requires answer ID, and vice versa.',
-                params={'govdelivery_question_id': ErrorList([
-                    'Required if a GovDelivery answer ID is entered.'
                 ])}
             )
 

--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -1,8 +1,7 @@
+import csv
 import logging
 
 from django.conf import settings
-
-import unicodecsv
 
 
 PROJECT_ROOT = settings.PROJECT_ROOT
@@ -210,9 +209,9 @@ def load_fips_meta(counties=True):
         4: county_name
     """
     for filename in ['state_county_fips.csv', 'msa_county_crosswalk.csv']:
-        with open("{}/{}".format(FIPS_DATA_PATH, filename), 'rb') as f:
-            reader = unicodecsv.DictReader(f)
-            fips_data = [row for row in reader]
+        with open("{}/{}".format(FIPS_DATA_PATH, filename), 'r') as f:
+            reader = csv.DictReader(f)
+            fips_data = list(reader)
             if 'state' in filename:
                 FIPS.county_fips = {row['complete_fips']:
                                     {'county': row['county_name'],

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -1,11 +1,11 @@
+import csv
 import datetime
-from io import BytesIO
+from io import StringIO
 
 from django.conf import settings
 
 import boto3
 import requests
-import unicodecsv
 
 
 # bake_to_s3 functions require S3 secrets to be stored in the env
@@ -20,8 +20,8 @@ S3_SOURCE_FILE = 'latest_county_delinquency.csv'
 
 def read_in_s3_csv(url):
     response = requests.get(url)
-    f = BytesIO(response.content)
-    reader = unicodecsv.DictReader(f)
+    f = StringIO(response.content.decode('utf-8'))
+    reader = csv.DictReader(f)
     return reader
 
 

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -1,8 +1,8 @@
+import csv
 import datetime
 import logging
-from io import BytesIO
+from io import StringIO
 
-import unicodecsv
 from dateutil import parser
 
 from core.utils import format_file_size
@@ -105,8 +105,9 @@ def fill_nation_row_date_values(date_set):
 
 def export_downloadable_csv(geo_type, late_value):
     """
-    Export a dataset to S3 as a UTF-8 CSV file, adding single quotes
-    to FIPS codes so that Excel doesn't strip leading zeros.
+    Export a dataset to S3 as a UTF-8 CSV file.
+
+    We add single quotes to FIPS codes so Excel doesn't strip leading zeros.
 
     geo_types are County, MetroArea or State.
     late_values are percent_30_60 or percent_90.
@@ -115,7 +116,7 @@ def export_downloadable_csv(geo_type, late_value):
     Each CSV is to start with a National row for comparison.
 
     CSVs are posted at
-    https://files.consumerfinance.gov/data/mortgage-performance/downloads/  # noqa: E501
+    https://files.consumerfinance.gov/data/mortgage-performance/downloads/
 
     The script also stores URLs and file sizes for use in page footnotes.
     """
@@ -156,8 +157,8 @@ def export_downloadable_csv(geo_type, late_value):
         geo_type, LATE_VALUE_TITLE[late_value], thru_month)
     _map = geo_dict.get(geo_type)
     fips_list = _map['fips_list']
-    csvfile = BytesIO()
-    writer = unicodecsv.writer(csvfile)
+    csvfile = StringIO()
+    writer = csv.writer(csvfile)
     writer.writerow(_map['headings'] + date_list)
     nation_starter = [NATION_STARTER[heading]
                       for heading in _map['headings']]

--- a/cfgov/data_research/scripts/process_mortgage_data.py
+++ b/cfgov/data_research/scripts/process_mortgage_data.py
@@ -1,10 +1,10 @@
+import csv
 import datetime
 import logging
 import os
 import sys
 from io import StringIO
 
-import unicodecsv
 from dateutil import parser
 
 from data_research.models import (
@@ -39,8 +39,8 @@ def dump_as_csv(rows_out, dump_slug):
     Sample output row:
     1,01001,2008-01-01,268,260,4,1,0,3,2891
     """
-    with open('{}.csv'.format(dump_slug), 'wb') as f:
-        writer = unicodecsv.writer(f)
+    with open('{}.csv'.format(dump_slug), 'w') as f:
+        writer = csv.writer(f)
         for row in rows_out:
             writer.writerow(row)
 

--- a/cfgov/data_research/tests/test_blocks.py
+++ b/cfgov/data_research/tests/test_blocks.py
@@ -26,22 +26,34 @@ class TestConfRegFormBlockValidation(TestCase):
             'at_capacity_message': 'At capacity message',
             'failure_message': 'Failure message'
         })
-
-        try:
-            block.clean(value)
-        except ValidationError:
-            self.fail('no question and no answer should not fail validation')
+        self.assertTrue(block.clean(value))
 
     def test_conf_reg_block_with_question_but_no_answer_fails_validation(self):
         block = ConferenceRegistrationForm()
-        value = block.to_python({'govdelivery_question_id': '12345'})
+        value = block.to_python({
+            'govdelivery_code': 'USCFPB_999',
+            'govdelivery_question_id': '12345',
+            'govdelivery_answer_id': '',
+            'capacity': 123,
+            'success_message': 'Success message',
+            'at_capacity_message': 'At capacity message',
+            'failure_message': 'Failure message'
+        })
 
         with self.assertRaises(ValidationError):
             block.clean(value)
 
     def test_conf_reg_block_with_answer_but_no_question_fails_validation(self):
         block = ConferenceRegistrationForm()
-        value = block.to_python({'govdelivery_answer_id': '67890'})
+        value = block.to_python({
+            'govdelivery_code': 'USCFPB_999',
+            'govdelivery_question_id': '',
+            'govdelivery_answer_id': '67890',
+            'capacity': 123,
+            'success_message': 'Success message',
+            'at_capacity_message': 'At capacity message',
+            'failure_message': 'Failure message'
+        })
 
         with self.assertRaises(ValidationError):
             block.clean(value)
@@ -57,8 +69,4 @@ class TestConfRegFormBlockValidation(TestCase):
             'at_capacity_message': 'At capacity message',
             'failure_message': 'Failure message'
         })
-
-        try:
-            block.clean(value)
-        except ValidationError:
-            self.fail('question with answer should not fail validation')
+        self.assertTrue(block.clean(value))

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -1,12 +1,12 @@
+import csv
 import datetime
 import tempfile
 import unittest
-from io import BytesIO
+from io import StringIO
 
 import django
 
 import mock
-import unicodecsv
 from dateutil import parser
 from model_bakery import baker
 
@@ -181,9 +181,9 @@ class DataLoadIntegrityTest(django.test.TestCase):
             valid=True)
 
         # real values from a base CSV row
-        self.data_header = (b'date,fips,open,current,thirty,sixty,ninety,'
-                            b'other\n')
-        self.data_row = b'09/01/16,12081,1952,1905,21,5,10,11\n'
+        self.data_header = ('date,fips,open,current,thirty,sixty,ninety,'
+                            'other\n')
+        self.data_row = '09/01/16,12081,1952,1905,21,5,10,11\n'
         self.data_row_dict = {'date': '09/01/16',
                               'fips': '12081',
                               'open': '1952',
@@ -194,18 +194,12 @@ class DataLoadIntegrityTest(django.test.TestCase):
                               'other': '11'}
 
     @mock.patch(
-        'data_research.scripts.load_mortgage_performance_csv.'
-        'read_in_s3_csv')
-    def test_data_creation_from_base_row(
-            self, mock_read_csv):
-        """
-        Confirm that loading a single row of real base data creates
-        a CountyMortgageData object with the base row's values,
-        and that the object's calculated API values are correct.
-        """
-
-        f = BytesIO(self.data_header + self.data_row)
-        reader = unicodecsv.DictReader(f)
+        'data_research.scripts.load_mortgage_performance_csv.read_in_s3_csv'
+    )
+    def test_data_creation_from_base_row(self, mock_read_csv):
+        """Confirm creation of a CountyMortgageData object from a CSV row."""
+        f = StringIO(self.data_header + self.data_row)
+        reader = csv.DictReader(f)
         mock_read_csv.return_value = reader
         load_values()
         self.assertEqual(CountyMortgageData.objects.count(), 1)

--- a/cfgov/data_research/urls.py
+++ b/cfgov/data_research/urls.py
@@ -1,12 +1,8 @@
+from django.urls import re_path
+
 from data_research.views import (
     MapData, MetaData, TimeSeriesData, TimeSeriesNational
 )
-
-
-try:
-    from django.urls import re_path
-except ImportError:
-    from django.conf.urls import url as re_path
 
 
 urlpatterns = [

--- a/cfgov/scripts/export_enforcement_actions.py
+++ b/cfgov/scripts/export_enforcement_actions.py
@@ -1,3 +1,4 @@
+import csv
 import datetime
 import html
 import re
@@ -5,9 +6,7 @@ import re
 from django.http import HttpResponse
 from django.utils import html as html_util
 
-import unicodecsv
-
-from v1.models import DocumentDetailPage
+from v1.models.learn_page import EnforcementActionPage
 from v1.util.migrations import get_stream_data
 
 
@@ -31,7 +30,7 @@ def clean_and_strip(data):
 def assemble_output():
     strip_tags = re.compile(r'<[^<]+?>')
     rows = []
-    for page in DocumentDetailPage.objects.all():
+    for page in EnforcementActionPage.objects.all():
         if not page.live:
             continue
         url = 'https://consumerfinance.gov' + page.get_url()
@@ -77,10 +76,6 @@ def export_actions(path='/tmp', http_response=False):
     Run from within cfgov-refresh with:
     `python cfgov/manage.py runscript export_enforcement_actions`
 
-    CFPB staffers use a version of Excel that can't easily import UTF-8
-    non-ascii encodings. So we throw in the towel and encode the CSV
-    with windows-1252.
-
     By default, the script will dump the file to `/tmp/`,
     unless a path argument is supplied,
     or http_response is set to True (for downloads via the Wagtail admin).
@@ -97,12 +92,12 @@ def export_actions(path='/tmp', http_response=False):
         write_questions_to_csv(response)
         return response
     file_path = '{}/{}'.format(path, slug).replace('//', '/')
-    with open(file_path, 'w') as f:
+    with open(file_path, 'w', encoding='windows-1252') as f:
         write_questions_to_csv(f)
 
 
 def write_questions_to_csv(csvfile):
-    writer = unicodecsv.writer(csvfile, encoding='windows-1252')
+    writer = csv.writer(csvfile)
     writer.writerow(HEADINGS)
     for row in assemble_output():
         writer.writerow([row.get(key) for key in HEADINGS])

--- a/cfgov/scripts/tests/test_export_enforcement_actions.py
+++ b/cfgov/scripts/tests/test_export_enforcement_actions.py
@@ -6,7 +6,7 @@ from wagtail.core.models import Page, Site
 
 from scripts.export_enforcement_actions import assemble_output
 
-from v1.models import DocumentDetailPage
+from v1.models.learn_page import EnforcementActionPage
 from v1.tests.wagtail_pages.helpers import save_new_page
 from v1.util.migrations import set_stream_data
 
@@ -28,8 +28,9 @@ class TestExportEnforcementActions(TestCase):
         self.actions_page = Page(title='Actions', slug='actions')
         save_new_page(self.actions_page, root=self.enforcement_page)
 
-        self.test_all_data_page = DocumentDetailPage(
+        self.test_all_data_page = EnforcementActionPage(
             title="Great Test Page",
+            institution_type="Bank",
             live=True,
             preview_description='This is a great test page.'
         )
@@ -84,15 +85,17 @@ class TestExportEnforcementActions(TestCase):
             ]
         )
 
-        self.test_no_data_page = DocumentDetailPage(
+        self.test_no_data_page = EnforcementActionPage(
             title="Terrible Test Page",
+            institution_type="Bank",
             live=False,
             preview_description='This is a terrible test page.'
         )
         save_new_page(self.test_no_data_page, root=self.actions_page)
 
-        self.test_wrong_page = DocumentDetailPage(
+        self.test_wrong_page = EnforcementActionPage(
             title="Wrong Test Page",
+            institution_type="Bank",
             live=True,
             preview_description='This is the wrong test page.'
         )

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -33,7 +33,6 @@ regdown==1.0.2
 requests==2.22.0
 requests_toolbelt==0.8.0
 sha3==0.2.1
-unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1


### PR DESCRIPTION
Now that we can use Python3's csv module, we no longer need unicodecsv.

This removes a dependency originating from a Python2 weakness and also restores functionality 
to the export-enforcement-actions script, which had stopped working.

## Changes
- Removes unicodecsv from requirements/libraries.txt
- Imports the Python3 csv package instead of unicodecsv
- Keeps byte strings out of our code
- Fixes tests that weren't running
- Fixes the enforcement actions export script, which stopped working
when we introduced EnforcementActionPages in March. The script was written to
harvest content from DocumentDetailPages. Currently, the export produces a blank CSV.

## Testing
- In the Wagtail admin, run the Enforcement Actions and Ask CFPB exports before and after. There should be no change in Ask, but the Enforcement Actions export should work again.
- All tox tests should succeed and test coverage should increase. 

## Satellite note
Our satellite apps don't use unicodecsv anymore, but two of them,
[ccdb5-api](https://github.com/cfpb/ccdb5-api/blob/master/setup.py#L21) and [owning-a-home-api](https://github.com/cfpb/owning-a-home-api/blob/master/setup.py#L13), still include it as an install requirement in setup.py. PRs are pending to remove those references.

Thank you for your service, unicodecsv!

