### PR TITLE
Mega Menu: Fix featured link area spacing

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -975,7 +975,7 @@ body {
             // Move the first link in each mega menu list group up a bit so that it aligns
             // with the featured links box. We do this instead of removing the top padding
             // to preserve the links' hover state.
-            &-item:first-child &-link {
+            &-list:not( &-list__featured ) &-item:first-child &-link {
                 margin-top: unit( -12px / @base-font-size-px, em );
             }
 
@@ -1023,6 +1023,14 @@ body {
                 & .cf-icon-svg {
                     color: @gold;
                     width: 100%;
+                }
+            }
+
+            &-list__featured &-item {
+                margin-bottom: unit( 15px / @base-font-size-px, em );
+
+                &:last-child {
+                    margin-bottom: 0;
                 }
             }
 


### PR DESCRIPTION
@chosak noticed the featured link area was off, and we realized https://github.com/cfpb/cfgov-refresh/pull/5578 moved the featured link up. This omits the featured link from the selector in that PR and adds margin between multiple featured links.

## Changes

- Make featured link top/bottom margin equal and add margin between links when there are more than one.

## Testing

1. Pull branch and build.
2. Compare local mega menu featured link to production.
3. Add a second or more featured link and see that there is a gap between them.

## Screenshots

Production with simulated second link:
<img width="1289" alt="Screen Shot 2020-05-27 at 5 02 09 PM" src="https://user-images.githubusercontent.com/704760/83072227-615a2100-a03c-11ea-8109-0fd9e5e8fcee.png">

Local changes:
<img width="1239" alt="Screen Shot 2020-05-27 at 5 02 51 PM" src="https://user-images.githubusercontent.com/704760/83072249-6cad4c80-a03c-11ea-9e8c-75fea98704b4.png">
