### PR TITLE
Add __str__ method to Banner model

### DIFF
--- a/cfgov/v1/models/banners.py
+++ b/cfgov/v1/models/banners.py
@@ -46,3 +46,6 @@ class Banner(models.Model):
         StreamFieldPanel('content'),
         FieldPanel('enabled'),
     ]
+
+    def __str__(self):
+        return self.title

--- a/cfgov/v1/tests/models/test_banners.py
+++ b/cfgov/v1/tests/models/test_banners.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+
+from v1.models.banners import Banner
+
+
+class TestBanner(TestCase):
+    def test_banner_str_method(self):
+        test_banner = Banner(title="Test banner")
+        self.assertEqual(str(test_banner), test_banner.title)


### PR DESCRIPTION
This will display the title of the banner in various places in the Wagtail admin, instead of generic text like "Banner object (2)".


## Additions

- `__str__` method added to `Banner` model


## Testing

With a recent database dump:

1. Visit http://localhost:8000/admin/v1/banner/edit/2/ and see that the header reads: "EDITING Banner object (2)"
1. Pull branch
1. Refresh the page and see that the header now reads: "EDITING Interagency mortgage and housing assistance pages"


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
