### PR TITLE
Handle bad POSTs when StreamField has no form

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -266,7 +266,8 @@ class CFGOVPage(Page):
         If form_id is found, it returns the response from the block method
         retrieval.
 
-        If form_id is not found, it returns an error response.
+        If form_id is not found, or if form_id is not a block that implements
+        get_result() to process the POST, it returns an error response.
         """
         form_module = None
         form_id = request.POST.get('form_id', None)

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -290,15 +290,15 @@ class CFGOVPage(Page):
                         except IndexError:
                             form_module = None
 
-        if form_module is None:
+        try:
+            result = form_module.block.get_result(
+                self,
+                request,
+                form_module.value,
+                True
+            )
+        except AttributeError:
             return self._return_bad_post_response(request)
-
-        result = form_module.block.get_result(
-            self,
-            request,
-            form_module.value,
-            True
-        )
 
         if isinstance(result, HttpResponse):
             return result

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -73,6 +73,19 @@ class TestCFGOVPage(TestCase):
         response = page.serve_post(request)
         self.assertIsInstance(response, HttpResponseBadRequest)
 
+    def test_serve_post_returns_400_for_invalid_form_id_no_form_present(self):
+        page = BrowsePage(title='test', slug='test')
+        page.content = blocks.StreamValue(
+            page.content.stream_block,
+            [{'type': 'full_width_text', 'value': []}],
+            True
+        )
+        save_new_page(page)
+
+        request = self.factory.post('/', {'form_id': 'form-content-0'})
+        response = page.serve_post(request)
+        self.assertIsInstance(response, HttpResponseBadRequest)
+
     def test_serve_post_valid_calls_feedback_block_handler(self):
         """A valid post should call the feedback block handler.
 


### PR DESCRIPTION
Previously, attempted form POSTs on pages where the main content StreamField had no form were not correctly returning a 400 response. This change fixes that.

See errors from the evening of 5/31/20 documented at https://GHE/CFGOV/cfgov-alerts/issues/23 and Mattermost discussion at: https://MM/cfpb/pl/bdqukr8frtynbkimq43jbbgu5w

## Changes

- Moves result = `form_module.block.get_result(…)` into `try`/`except` block to ensure that an improperly-derived `form_module` doesn't throw a 500 there.

## Testing

Tests pass; new test added for this particular scenario.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: