### PR TITLE
Docs: Update docker-compose installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -285,7 +285,7 @@ browser, and see a database error.
     With that all set, we're ready to install the latest Docker Compose.
 
     ```bash
-    pipx install git+https://github.com/docker/compose.git
+    pipx install docker-compose
     ```
 
     Confirm that it installed properly by running `which docker-compose`


### PR DESCRIPTION
Compose 1.26 has been released, so we no longer need to point directly to the GitHub repo.


## Checklist

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases), so good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [ ] Changes are limited to a single goal (no scope creep)
