### PR TITLE
Tables: Fix striped tables

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -62,7 +62,7 @@
 <table class="o-table
               {{- ' o-table__row-links' if value.row_links else '' -}}
               {{- ' o-table__stack-on-small' if value.is_stacked else '' -}}
-              {{- ' table__striped' if value.is_striped else '' -}}
+              {{- ' o-table__striped' if value.is_striped else '' -}}
               {{- ' u-w100pct' if value.is_full_width else '' -}}
               {{- ' o-table__sortable' if value.is_sortable else '' -}}">
     {% set row_index = 0 %}


### PR DESCRIPTION
Striped tables weren't actually getting striped because of a slightly wrong class getting applied.

## Changes

- The `table__striped` class that was being applied to striped tables is now the correct `o-table__striped`  

## How to test this PR

1. Add a table to a page in Wagtail and check the "striped rows" option.
2. Preview that table and make sure the table is striped as [shown in the Design System](https://cfpb.github.io/design-system/components/tables#striped-table).

## Screenshots

![striped-table](https://user-images.githubusercontent.com/1862695/83690847-7ba57900-a5bf-11ea-91b0-60d977b4f8dc.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases),
    so good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing,
    e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)