### PR TITLE
Create new sub-app for research reports

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -92,6 +92,7 @@ INSTALLED_APPS = (
     "diversity_inclusion",
     "mega_menu.apps.MegaMenuConfig",
     "form_explainer.apps.FormExplainerConfig",
+    "research_reports",
 
     # Satellites
     "comparisontool",

--- a/cfgov/research_reports/models.py
+++ b/cfgov/research_reports/models.py
@@ -1,0 +1,3 @@
+# new page models and any supporting models will go here
+# Once model code is in this file, generate migrations with:
+#    cfgov/manage.py makemigrations research_reports -n create_research_report_models


### PR DESCRIPTION
❗ Note: This PR is for the Reports as Webpages project and is not going into Master! If merged, it will go into the `reports-as-webpages` branch. ❗ 


I think this is all we need to start a new sub-app. `research_reports` sub-app will hold all code related to the Office of Research Reports as Webpages project.

## Notes

- You can still use atomic elements from v1
- Templates specific to reports-as-webages can go in `cfgov/research_reports/jinja2/`
- I created the `models.py` with the sample command for how to run migrations (since it's slightly different for a new app, which confused me when I did this for my proof-of-concept)