### PR TITLE
Always deactivate Django translations after each request

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -117,6 +117,7 @@ MIDDLEWARE = (
     "flags.middleware.FlagConditionsMiddleware",
     "wagtail.core.middleware.SiteMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    "core.middleware.DeactivateTranslationsMiddleware",
 )
 
 CSP_MIDDLEWARE = ("csp.middleware.CSPMiddleware",)

--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -1,6 +1,7 @@
 import re
 
 from django.conf import settings
+from django.utils import translation
 from django.utils.encoding import force_str
 
 from wagtail.core.rich_text import expand_db_html
@@ -80,3 +81,13 @@ class ParseLinksMiddleware(object):
             re.search(regex, request_path)
             for regex in settings.PARSE_LINKS_EXCLUSION_LIST
         )
+
+
+class DeactivateTranslationsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        translation.deactivate()
+        return response


### PR DESCRIPTION
Currently we have various places in our code where we call [`translation.activate`](https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.translation.activate) to activate Django translations. We do this both for English and Spanish; for example [our base `CFGOVPage` makes this call every time it gets served](https://github.com/cfpb/cfgov-refresh/blob/50c67eb1917c2b02f9f1efff1ae6ac26895ae3ac/cfgov/v1/models/base.py#L248).

Under the hood, Django translations work by setting the current language [on the local thread](https://github.com/django/django/blob/69e0d9c553bb55dde8d7d1d479a78bfa7093f406/django/utils/translation/trans_real.py#L279). Unfortunately, subsequent Django requests may be handled by that same thread, meaning they incorrectly inherit that language.

As a simple test, try the following with a local server:

1. First visit [this page](http://localhost:8000/rural-or-underserved-tool/), and note header and footer are properly in English.
2. Then visit [this page](http://localhost:8000/consumer-tools/financial-well-being/es/), which activates Spanish translations. Note the header and footer are (properly) in Spanish there.
3. Next visit [the first page](http://localhost:8000/rural-or-underserved-tool/) again. The header and footer get stuck in Spanish!

This happens because the second page stuck Spanish on the local thread, which was then reused when the first page was revisited.

Currently (as mentioned above) we always set the language on all Wagtail pages; it's only non-Wagtail pages where this bug might show up. In production this will happen less often because Apache uses multiple threads.

(This isn't a problem when using Django [`LocaleMiddleware`](https://docs.djangoproject.com/en/2.2/ref/middleware/#django.middleware.locale.LocaleMiddleware), as we did until recently, because there the language gets set _at the start_ of every request. So requests never have a chance to inherit an old language, because a new one always gets set. Since we don't use that middleware any longer, we can't ever assume that the language is default when a request starts.)

There are some other possible ways of fixing this:

1. Instead create a new middleware that always activates the default translation at the start of each request.
2. Replace all of our uses of `translation.activate` with a [`translation.override`](https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.translation.override) context manager, ensuring that the set language only lasts during the render. This is the approach I originally started pursuing, but it gets tricky in certain cases, see for example https://github.com/wagtail/wagtail/pull/5910.

I'm open to other suggestions from BEWDs and others if there's a more holistic way to do this.

## Notes and todos

Ping @sephcoster FYI, as I know you've seen some unexpected behavior around Spanish content recently. I don't know for sure that this bug is the cause of what you've seen, but it might be related. Also ping @anselmbradford as we've seen this other places.

## Checklist

_[Feel free to delete any checkboxes that are not applicable to this PR.]_

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)