### PR TITLE
Fix Elasticsearch synonyms in Dockerfile

### DIFF
--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
 FROM elasticsearch:2.3
 RUN plugin install org.codelibs/elasticsearch-dataformat/2.3.0
-COPY cfgov/search/resources/synonyms_en.txt config/analysis
-COPY cfgov/search/resources/synonyms_es.txt config/analysis
+COPY cfgov/search/resources/synonyms_en.txt config/analysis/synonyms_en.txt
+COPY cfgov/search/resources/synonyms_es.txt config/analysis/synonyms_es.txt


### PR DESCRIPTION
This change ensures the synonym files are placed correctly in the Elasticsearch Dockerfile. Previously they were overwriting `config/analysis` as a file rather than being places inside `config/analysis` as a directory.

## How to test this PR

```shell
docker-compose build elasticsearch
docker-compose up
```

In a separate terminal:

```shell
docker-compose exec python bash
./cfgov/manage.py rebuild_index
```

Observe the **lack** of any errors about the synonym file location from the elasticsearch container:

```
elasticsearch_1  | [content_haystack] IndexCreationException[failed to create index]; nested: IllegalArgumentException[IOException while reading synonyms_path_path: /usr/share/elasticsearch/config/analysis/synonyms_en.txt (Not a directory)];
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
