### PR TITLE
Add FAQ and HowTo blocks to Ask CFPB search "text" field

### DIFF
--- a/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
+++ b/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
@@ -6,7 +6,7 @@
     {% if block.block_type == 'text' or block.block_type == 'tip' or block.block_type == 'table' %}
         {{ block.value.content | striptags }}
     {% elif block.block_type == 'faq_schema' %}
-        {{ block.value.description.content }}
+        {{ block.value.description }}
         {% for value in block.value.questions %}
             {{ value.question }} 
             {% for answer_block in value.answer_content %}
@@ -17,7 +17,7 @@
         {% endfor %}
     {% elif block.block_type == 'how_to_schema' %}
         {{ block.value.title }}
-        {{ block.value.description.content }}
+        {{ block.value.description }}
         {% for step in block.value.steps %}
             {{ step.title }} 
             {% for content_block in step.step_content %}
@@ -37,7 +37,7 @@
         {% if block.block_type == 'text' or block.block_type == 'tip' or block.block_type == 'table' %}
             {{ block.value.content | striptags | stripaccents}}
         {% elif block.block_type == 'faq_schema' %}
-            {{ block.value.description.content | stripaccents }}
+            {{ block.value.description | stripaccents }}
             {% for value in block.value.questions %}
                 {{ value.question | stripaccents }} 
                 {% for answer_block in value.answer_content %}
@@ -48,7 +48,7 @@
             {% endfor %}
         {% elif block.block_type == 'how_to_schema' %}
             {{ block.value.title | stripaccents }}
-            {{ block.value.description.content | stripaccents }}
+            {{ block.value.description | stripaccents }}
             {% for step in block.value.steps %}
                 {{ step.title | stripaccents }} 
                 {% for content_block in step.step_content %}

--- a/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
+++ b/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
@@ -1,23 +1,68 @@
 {% load accent_stripper %}
+
 {{ object.short_answer | striptags }}
+
 {% for block in object.answer_content %}
-{% if block.block_type == 'text' %}
-{{ block.value.content | striptags }}
-{% endif %}{% endfor %}
-{% for block in object.answer_content %}
-{% if block.block_type == 'tip' or block.block_type == 'table' %}
-{{ block.value.content | striptags }}
-{% endif %}{% endfor %}
+    {% if block.block_type == 'text' or block.block_type == 'tip' or block.block_type == 'table' %}
+        {{ block.value.content | striptags }}
+    {% elif block.block_type == 'faq_schema' %}
+        {{ block.value.description.content }}
+        {% for value in block.value.questions %}
+            {{ value.question }} 
+            {% for answer_block in value.answer_content %}
+                {% if answer_block.block_type == 'text' %}
+                    {{ answer_block.value.content | striptags }}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% elif block.block_type == 'how_to_schema' %}
+        {{ block.value.title }}
+        {{ block.value.description.content }}
+        {% for step in block.value.steps %}
+            {{ step.title }} 
+            {% for content_block in step.step_content %}
+                {% if content_block.block_type == 'text' %}
+                    {{ content_block.value.content | striptags }}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+{% endfor %}
+
 {{ object.question }}
+
 {% if object.language == 'es' %}
-{{ object.short_answer|striptags|stripaccents|safe }}
-{% for block in object.answer_content %}
-{% if block.block_type == 'text' %}
-{{ block.value.content | striptags | stripaccents }}
-{% endif %}{% endfor %}
-{{ object.question | stripaccents }}
+    {{ object.short_answer | striptags | stripaccents | safe }}
+    {% for block in object.answer_content %}
+        {% if block.block_type == 'text' or block.block_type == 'tip' or block.block_type == 'table' %}
+            {{ block.value.content | striptags | stripaccents}}
+        {% elif block.block_type == 'faq_schema' %}
+            {{ block.value.description.content | stripaccents }}
+            {% for value in block.value.questions %}
+                {{ value.question | stripaccents }} 
+                {% for answer_block in value.answer_content %}
+                    {% if answer_block.block_type == 'text' %}
+                        {{ answer_block.value.content | striptags | stripaccents }}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% elif block.block_type == 'how_to_schema' %}
+            {{ block.value.title | stripaccents }}
+            {{ block.value.description.content | stripaccents }}
+            {% for step in block.value.steps %}
+                {{ step.title | stripaccents }} 
+                {% for content_block in step.step_content %}
+                    {% if content_block.block_type == 'text' %}
+                        {{ content_block.value.content | striptags | stripaccents }}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    {{ object.question | stripaccents }}
 {% endif %}
+
 {% for tag in tags %}
-{{ tag }}
-{{tag | stripaccents}}
+    {{ tag }}
+    {{tag | stripaccents}}
 {% endfor %}

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -341,11 +341,11 @@ ELASTICSEARCH_INDEX_SETTINGS = {
                     "filter": ["haystack_edgengram"],
                 },
                 "synonym_en": {
-                    "tokenizer": "whitespace",
+                    "tokenizer": "standard",
                     "filter": ["synonyms_en"],
                 },
                 "synonym_es": {
-                    "tokenizer": "whitespace",
+                    "tokenizer": "standard",
                     "filter": ["synonyms_es"],
                 },
             },
@@ -359,7 +359,7 @@ ELASTICSEARCH_INDEX_SETTINGS = {
                     "type": "edgeNGram",
                     "min_gram": 3,
                     "max_gram": 15,
-                    "side": "front",
+                    "token_chars": [ "letter", "digit" ]
                 },
             },
             "filter": {


### PR DESCRIPTION
This PR will add Ask CFPB FAQ and HowTo blocks to the Ask CFPB "text" search field to make their content searchable by the Ask CFPB search box just like other answer content.

This PR also corrects a couple of issues with the Elasticsearch settings:

- The synonym analyzers (used for the "text" field) were using the `whitespace` tokenizer, which left punctuation in place for tokens. That resulted in searches for words at the end of sentences, for example, to fail unless the search term included the period. I've changed the tokenizer to `standard` for these.
- The ["side" parameter was deprecated](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis-edgengram-tokenizer.html#_literal_side_literal_deprecated)

## How to test this PR

1. Add a unique term to the HowTo block on a page with one, for example: http://localhost:8000/admin/pages/6532/edit/
2. Add a unique term to the FAQ block on a page with one, for example http://localhost:8000/admin/pages/6788/edit/
3. Rebuild your Haystack index (either locally or in the Docker python container):

   ```shell
   ./cfgov/manage.py rebuild_index
   ```

4. Search of those unique terms you added: http://localhost:8000/ask-cfpb/search/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
