### PR TITLE
Release satellite apps and libraries with Wagtail 2.9 support

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -36,10 +36,10 @@ sha3==0.2.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1
-wagtail-flags==4.1.1
-wagtail-inventory==1.0
-wagtail-sharing==2.1
-wagtail-treemodeladmin==1.1.1
+wagtail-flags==4.2.1
+wagtail-inventory==1.1
+wagtail-sharing==2.2
+wagtail-treemodeladmin==1.2.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.15.0/owning_a_home_api-0.15.0-py3-none-any.whl


### PR DESCRIPTION
To support Wagtail 2.9 update versions of the following:
* wagtail-flags
* wagtail-inventory
* wagtail-sharing
* wagtail-treemodeladmin

## How to test this PR

1. git checkout wagtail29
2. source .env
3. ./setup.sh
4. tox

## Checklist

  - [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code documentation on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

_[When new or significantly modified front-end functionality is present, the following things should be tested. Feel free to delete this section if not applicable to this PR.]_

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

[Further guidance on browser support](https://github.com/cfpb/development/blob/master/guides/browser-support.md)

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens