### PR TITLE
Properly handle missing YouTube thumbnail images

### DIFF
--- a/cfgov/unprocessed/js/organisms/VideoPlayer.js
+++ b/cfgov/unprocessed/js/organisms/VideoPlayer.js
@@ -120,10 +120,23 @@ function VideoPlayer( element ) {
    * @param {string} imageURL - The URL to load in the image.
    */
   function _imageLoad( imageURL ) {
-    _imageDom.addEventListener( 'load', _imageShow );
+    _imageDom.addEventListener( 'load', _imageLoaded );
     _imageDom.addEventListener( 'error', _imageLoadDefault );
 
     _imageDom.src = imageURL;
+  }
+
+  /**
+   * Event handler for when image src attribute is set.
+   */
+  function _imageLoaded() {
+    /* 120px is the natural width of the default YouTube image.
+     * This condition will be true when there isn't a custom image set. */
+    if ( _imageDom.naturalWidth === 120 ) {
+      _imageLoadDefault();
+    }
+
+    _imageShow();
   }
 
   /**


### PR DESCRIPTION
Certain YouTube videos don't make thumbnails available via the URL pattern that we use. The recent changes in #5781 broken the appearance of the player for these videos; this commit fixes that.

To test, use a video like R0rp_LIUTLQ, where this thumbnail URL 404s:

https://img.youtube.com/vi/R0rp_LIUTLQ/maxresdefault.jpg

## How to test this PR

Using a recent production dump, try visiting http://localhost:8000/coronavirus/mortgage-and-housing-assistance/rent-protections-covid-19/ on master and on this branch (after building the JS assets).

## Notes and todos

It would be better to use the YouTube JS API to retrieve the proper thumbnail (as the comment in the code says), but this would require a YouTube API key. Alternatively we could do an AJAX request for the thumbnail and check the status code, but it'd be slower with no real benefit.

## Checklist

_[Feel free to delete any checkboxes that are not applicable to this PR.]_

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentialy one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code documentation on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance