### PR TITLE
Parse links only within HTML body

### DIFF
--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_str
 
 from wagtail.core.rich_text import expand_db_html
 
-from core.utils import add_link_markup, get_link_tags
+from core.utils import add_link_markup, get_body_html, get_link_tags
 
 
 class DownstreamCacheControlMiddleware(object):
@@ -36,7 +36,12 @@ def parse_links(html, request_path=None, encoding=None):
     # Wagtail pages, documents, and images to their proper link URLs.
     expanded_html = expand_db_html(html_as_text)
 
-    link_tags = get_link_tags(expanded_html)
+    # Parse links only in the <body> of the HTML
+    body_html = get_body_html(expanded_html)
+    if body_html is None:
+        return expanded_html
+
+    link_tags = get_link_tags(body_html)
     for tag in link_tags:
         tag_with_markup = add_link_markup(tag, request_path)
         if tag_with_markup:

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -84,32 +84,36 @@ class TestShouldParseLinks(TestCase):
 class TestParseLinks(TestCase):
     def test_relative_link_remains_unmodified(self):
         self.assertEqual(
-            parse_links('<a href="/something">text</a>'),
-            '<a href="/something">text</a>'
+            parse_links('<body><a href="/something">text</a></body>'),
+            '<body><a href="/something">text</a></body>'
         )
 
     def test_works_properly_on_bytestrings(self):
         self.assertEqual(
-            parse_links(b'<a href="/something">text</a>'),
-            '<a href="/something">text</a>'
+            parse_links(b'<body><a href="/something">text</a></body>'),
+            '<body><a href="/something">text</a></body>'
         )
 
     def test_non_gov_link(self):
         """Non gov links get external link icon and redirect."""
-        link = '<a href="https://wwww.google.com">external link</a>'
+        link = '<body><a href="https://google.com">external link</a></body>'
         output = parse_links(link)
         self.assertIn('external-site', output)
         self.assertIn('cf-icon-svg', output)
 
     def test_gov_link(self):
         """Gov links get external link icon but not redirect."""
-        link = '<a href="https://www.fdic.gov/bar">gov link</a>'
+        link = '<body><a href="https://www.fdic.gov/bar">gov link</a></body>'
         output = parse_links(link)
         self.assertIn('cf-icon-svg', output)
 
     def test_internal_link(self):
         """Internal links get neither icon nor redirect."""
-        link = '<a href="https://www.consumerfinance.gov/foo">cfpb link</a>'
+        link = '''
+        <body>
+            <a href="https://www.consumerfinance.gov/foo">cfpb link</a>
+        </body>
+        '''
         output = parse_links(link)
         self.assertNotIn('external-site', output)
         self.assertNotIn('cf-icon-svg', output)
@@ -117,68 +121,105 @@ class TestParseLinks(TestCase):
     def test_files_get_download_icon(self):
         file_types = ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'zip']
         for file_type in file_types:
-            link = '<a href="/something.{}">link</a>'.format(file_type)
+            link = f'<body><a href="/something.{file_type}">link</a></body>'
             output = parse_links(link)
             self.assertIn('cf-icon-svg', output)
 
     def test_different_case_pdf_link_gets_download_icon(self):
-        link = '<a href="/something.PDF">link</a>'
+        link = '<body><a href="/something.PDF">link</a></body>'
         output = parse_links(link)
         self.assertIn('cf-icon-svg', output)
 
     def test_rich_text_links_get_expanded(self):
         page = CFGOVPage(title='foo bar', slug='foo-bar')
         publish_page(page)
-        link = '<a id="{}" linktype="page">foo bar</a>'.format(page.id)
+        link = f'<body><a id="{page.id}" linktype="page">foo bar</a></body>'
         output = parse_links(link)
-        self.assertEqual('<a href="/foo-bar/">foo bar</a>', output)
+        self.assertEqual(
+            '<body><a href="/foo-bar/">foo bar</a></body>',
+            output
+        )
 
     def test_non_default_encoding(self):
-        s = '<a href="/something">哈哈</a>'
+        s = '<body><a href="/something">哈哈</a></body>'
         encoding = 'gb2312'
         parsed = parse_links(s.encode(encoding), encoding=encoding)
         self.assertEqual(parsed, s)
 
+    def test_external_link_outside_body(self):
+        s = '''
+        <a href="https://somewhere/foo">Link</a>
+        <body>
+        </body>
+        '''
+        output = parse_links(s)
+        self.assertNotIn('external-site', output)
+        self.assertNotIn('cf-icon-svg', output)
+
+    def test_external_link_outside_body_with_attributes(self):
+        s = '''
+        <a href="https://somewhere/foo">Link</a>
+        <body class="test">
+        </body>
+        '''
+        output = parse_links(s)
+        self.assertNotIn('external-site', output)
+        self.assertNotIn('cf-icon-svg', output)
+
     def test_external_link_with_attribute(self):
-        s = '<a href="https://somewhere/foo" data-thing="something">Link</a>'
+        s = '''
+        <body>
+            <a href="https://somewhere" data-thing="something">Link</a>
+        </body>
+        '''
         output = parse_links(s)
         self.assertIn('external-site', output)
         self.assertIn('cf-icon-svg', output)
 
     def test_external_link_with_img(self):
-        s = '<a href="https://somewhere/foo"><img src="some.png"></a>'
+        s = '<body><a href="https://somewhere"><img src="some.png"></a></body>'
         output = parse_links(s)
         self.assertIn('external-site', output)
         self.assertNotIn('cf-icon-svg', output)
 
     def test_external_link_with_background_img(self):
-        s = ('<a href="https://somewhere/foo"><span>'
-             '<div style="background-image: url(\'some.png\')"></div>'
-             '</span></a>')
+        s = '''
+        <body>
+            <a href="https://somewhere"><span>
+                <div style="background-image: url(\'some.png\')"></div>
+            </span></a>
+        </body>
+        '''
         output = parse_links(s)
         self.assertIn('external-site', output)
         self.assertNotIn('cf-icon-svg', output)
 
     def test_external_link_with_header(self):
-        s = '<a href="https://somewhere/foo"><h3>Header</h3></a>'
+        s = '<body><a href="https://somewhere"><h3>Header</h3></a></body>'
         output = parse_links(s)
         self.assertIn('external-site', output)
         self.assertNotIn('cf-icon-svg', output)
 
     def test_multiline_external_gov_link(self):
-        s = '''<a class="m-list_link a-link"
-        href="https://usa.gov/">
-        <span>
-        USA
-        .gov</span>
-        </a>
+        s = '''
+        <body>
+            <a class="m-list_link a-link"
+               href="https://usa.gov/">
+                <span>USA
+                .gov</span>
+            </a>
+        </body>
         '''
         output = parse_links(s)
         self.assertIn('cf-icon-svg', output)
 
     def test_multiple_links(self):
-        s = ('<a href="https://first.com">one</a>'
-             '<a href="https://second.com">two</a>')
+        s = '''
+        <body>
+            <a href="https://first.com">one</a>
+            <a href="https://second.com">two</a>
+        </body>
+        '''
         output = parse_links(s)
         soup = BeautifulSoup(output, 'html.parser')
         self.assertEqual(len(soup.find_all('a')), 2)
@@ -189,38 +230,50 @@ class TestParseLinks(TestCase):
         self.assertEqual(len(soup.find_all('svg')), count)
 
     def test_link_ending_with_svg_doesnt_get_another_svg(self):
-        self.check_after_parse_links_has_this_many_svgs(1, (
+        self.check_after_parse_links_has_this_many_svgs(
+            1,
+            '<body>'
             '<a href="https://external.gov">'
-            '<span>Text before icon</span> '
+            '<span>Text before icon</span>'
             '<svg>something</svg>'
             '</a>'
-        ))
+            '</body>'
+        )
 
     def test_link_ending_with_svg_and_whitespace_doesnt_get_another_svg(self):
-        self.check_after_parse_links_has_this_many_svgs(1, (
+        self.check_after_parse_links_has_this_many_svgs(
+            1,
+            '<body>'
             '<a href="https://external.gov">'
             '<span>Text before icon</span> '
             '<svg>something</svg>   \n\t'
             '</a>'
-        ))
+            '</body>'
+        )
 
     def test_with_svg_not_at_the_end_still_gets_svg(self):
-        self.check_after_parse_links_has_this_many_svgs(2, (
+        self.check_after_parse_links_has_this_many_svgs(
+            2,
+            '<body>'
             '<a href="https://external.gov">'
             '<span><svg>something</svg> Text after icon</span>'
             '</a>'
-        ))
+            '</body>'
+        )
 
     def test_with_svg_then_span_still_gets_svg(self):
-        self.check_after_parse_links_has_this_many_svgs(2, (
+        self.check_after_parse_links_has_this_many_svgs(
+            2,
+            '<body>'
             '<a href="https://external.gov">'
             '<svg>something</svg>'
             '<span>Text after icon</span>'
             '</a>'
-        ))
+            '</body>'
+        )
 
     def test_in_page_anchor_links_have_current_path_stripped(self):
-        s = '<a href="/foo/bar/#anchor">Anchor</a>'
+        s = '<body><a href="/foo/bar/#anchor">Anchor</a></body>'
         output = parse_links(s, request_path='/foo/bar/')
         self.assertNotIn('/foo/bar/', output)
         self.assertIn('href="#anchor"', output)

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -2,7 +2,10 @@ import unittest
 
 from django.test import TestCase
 
-from core.utils import extract_answers_from_request, format_file_size
+from core.utils import (
+    extract_answers_from_request, format_file_size, get_body_html,
+    get_link_tags
+)
 
 
 class FakeRequest(object):
@@ -46,3 +49,44 @@ class FormatFileSizeTests(unittest.TestCase):
 
     def test_format_file_size_terabytes(self):
         self.assertEqual(format_file_size(1024 * 9000000000), '8 TB')
+
+
+class LinkUtilsTests(TestCase):
+
+    def test_get_body_html_simple(self):
+        self.assertEqual(
+            get_body_html('outer <body>inner</body>'), '<body>inner</body>'
+        )
+
+    def test_get_body_html_full(self):
+        self.assertEqual(
+            get_body_html(
+                '<html><head>outer</head>'
+                '<body><span>inner</span></body>'
+                '</html>'
+            ),
+            '<body><span>inner</span></body>'
+        )
+
+    def test_get_body_html_with_attributes(self):
+        self.assertEqual(
+            get_body_html('outer <body class="test">inner</body>'),
+            '<body class="test">inner</body>'
+        )
+
+    def test_get_body_html_empty(self):
+        self.assertEqual(
+            get_body_html('outer <body></body>'), None
+        )
+
+    def test_get_link_tags(self):
+        self.assertEqual(
+            get_link_tags('outer <a href="">inner</a>'),
+            ['<a href="">inner</a>', ]
+        )
+
+    def test_get_link_tags_does_not_match_aside(self):
+        self.assertEqual(
+            get_link_tags('outer <aside>inner <a href="">link</a></aside>'),
+            ['<a href="">link</a>', ]
+        )

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -90,3 +90,12 @@ class LinkUtilsTests(TestCase):
             get_link_tags('outer <aside>inner <a href="">link</a></aside>'),
             ['<a href="">link</a>', ]
         )
+
+    def test_get_link_tags_spacing(self):
+        """ Handle a case where there's a conditional in a template, i.e.
+        <a {% if some_condition %}class="some-class"{% endif %}>, that renders
+        a space following the tag name, `<a >`"""
+        self.assertEqual(
+            get_link_tags('outer <a  >inner</a>'),
+            ['<a  >inner</a>', ]
+        )

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -92,9 +92,13 @@ class LinkUtilsTests(TestCase):
         )
 
     def test_get_link_tags_spacing(self):
-        """ Handle a case where there's a conditional in a template, i.e.
-        <a {% if some_condition %}class="some-class"{% endif %}>, that renders
-        a space following the tag name, `<a >`"""
+        """Test for case where tag renders with only whitespace after tag name
+
+        Template conditions within a tag, e.g.,
+        `<a {% if some_condition %}class="some-class"{% endif %}>`
+        can result in output with only whitespace following the tag name
+        if the condition is false, like: `<a >`.
+        """
         self.assertEqual(
             get_link_tags('outer <a  >inner</a>'),
             ['<a  >inner</a>', ]

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -29,7 +29,7 @@ LINK_ICON_TEXT_CLASSES = ['a-link_text']
 TAG_RE = (
     # Match an <tag_name[ attributes]>. If tag_name is not followed by a space
     # and any characters except >, it must be followed by >.
-    r'<{tag_name}(?:\s[^>]+?|)>'
+    r'<{tag_name}(?:\s+[^>]*?|)>'
     # And match everything inside before the closing </tag>
     r'.+?(?=</{tag_name}>)'
     # Then match the closing </tag>

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -24,17 +24,25 @@ LINK_ICON_CLASSES = ['a-link', 'a-link__icon']
 
 LINK_ICON_TEXT_CLASSES = ['a-link_text']
 
-# Regular expression to match <a> links in HTML strings
-A_TAG = re.compile(
-    # Match an <a containing any attributes
-    r'<a [^>]*?>'
-    # And match everything inside before the closing </a>
-    r'.+?(?=</a>)'
-    # Then match the closing </a>
-    r'</a>'
+# Regular expression format string that will match any tag <tag_name> (that is
+# not self-closing) and group its contents.
+TAG_RE = (
+    # Match an <tag_name[ attributes]>. If tag_name is not followed by a space
+    # and any characters except >, it must be followed by >.
+    r'<{tag_name}(?:\s[^>]+?|)>'
+    # And match everything inside before the closing </tag>
+    r'.+?(?=</{tag_name}>)'
+    # Then match the closing </tag>
+    r'</{tag_name}>'
     # Make '.' match new lines, ignore case
     r'(?s)(?i)'
 )
+
+# Match <body…>…</body>
+BODY_TAG_RE = re.compile(TAG_RE.format(tag_name="body"))
+
+# Match <a…>…</a>
+A_TAG_RE = re.compile(TAG_RE.format(tag_name="a"))
 
 # If a link contains these elements, it should *not* get an icon
 ICONLESS_LINK_CHILD_ELEMENTS = [
@@ -84,8 +92,14 @@ def format_file_size(bytecount, suffix='B'):
     return "{:.0f} {}{}".format(bytecount, 'T', suffix)
 
 
+def get_body_html(html):
+    body_match = BODY_TAG_RE.search(html)
+    if body_match is not None:
+        return body_match.group(0)
+
+
 def get_link_tags(html):
-    return A_TAG.findall(html)
+    return A_TAG_RE.findall(html)
 
 
 def add_link_markup(tag, request_path):


### PR DESCRIPTION
This change makes our `ParseLinksMiddleware` only parse links within the HTML `body` tag. This should avoid inserting the external link SVG icon in header meta tags.

It does this by added step to fetch the `body` tag and then discovering `a` tags within that.

I've tried to genericize the original `a` tag matching regular expression for this purpose — so we have a RE that can match any specific tag name.

## How to test this PR

1. On the `master` branch, visit any page with a link in its `meta name="description"` tag and notice the external link icon appearing at the very top of the page, for example: http://localhost:8000/ask-cfpb/i-am-tired-of-receiving-credit-card-mailings-what-can-i-do-en-7/
2. Checkout this branch, `fix-parse-links`, and visit the same page. Note the external link icon is gone.


## Screenshots

Before this PR:
![image](https://user-images.githubusercontent.com/10562538/85448277-8a4ed280-b564-11ea-9b19-4b78f60763bb.png)

After this PR:
![image](https://user-images.githubusercontent.com/10562538/85448799-0cd79200-b565-11ea-9dd9-3b33ed893433.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
