### PR TITLE
Update TDP requirement to 1.5.0 and install separate crtool app

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -103,6 +103,7 @@ INSTALLED_APPS = (
     "ccdb5_ui",
     "mptt",
     "teachers_digital_platform",
+    "crtool",
 )
 
 MIDDLEWARE = (

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -481,6 +481,11 @@ urlpatterns = [
     ),
 
     re_path(
+        r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
+        include('crtool.urls')
+    ),
+
+    re_path(
         r'^regulations3k-service-worker.js',
         TemplateView.as_view(
             template_name='regulations3k/regulations3k-service-worker.js',

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -47,4 +47,4 @@ https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.4.2/ccdb5_api-1.4.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.1.1/ccdb5_ui-2.1.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.1/comparisontool-1.15.1-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.4.2/teachers_digital_platform-1.4.2-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.5.0/teachers_digital_platform-1.5.0-py3-none-any.whl


### PR DESCRIPTION
Version 1.5.0 of the teachers_digital_platform package moved the Curriculum Review Tool into its own separate crtool Django app. This commit updates the teachers_digital_platform requirement to 1.5.0 and installs crtool as a separate app, including the necessary addition to the main project `urls.py` file.


## Additions

- `crtool` added to `INSTALLED_APPS`
- `crtool.urls` imported in `urlpatterns` 

## Changes

- teachers_digital_platform requirement updated to 1.5.0


## How to test this PR

1. Pull branch
1. `pip install -r requirements/local.txt` or `docker-compose build python`
1. Run your local server and visit http://localhost:8000/practitioner-resources/youth-financial-education/curriculum-review/
1. Go through some of the curriculum review process and verify that everything continues to work as expected.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
