### PR TITLE
Disable concurrent builds in Jenkins multibranch pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,34 +11,35 @@ pipeline {
     }
 
     environment {
-        IMAGE_REPO="cfpb/cfgov-python"
-        IMAGE_TAG="${JOB_BASE_NAME}-${BUILD_NUMBER}"
+        IMAGE_REPO = "cfpb/cfgov-python"
+        IMAGE_TAG = "${JOB_BASE_NAME}-${BUILD_NUMBER}"
         STACK_PREFIX = 'cfgov'
         NOTIFICATION_CHANNEL = 'cfgov-deployments'
     }
 
     parameters {
         booleanParam(
-            name: 'DEPLOY',
-            defaultValue: false,
-            description: 'Deploy the stack?'
+                name: 'DEPLOY',
+                defaultValue: false,
+                description: 'Deploy the stack?'
         )
         booleanParam(
-            name: 'REFRESH_DB',
-            defaultValue: false,
-            description: 'Refresh the database?'
+                name: 'REFRESH_DB',
+                defaultValue: false,
+                description: 'Refresh the database?'
         )
     }
 
     options {
         ansiColor('xterm')
         parallelsAlwaysFailFast()
+        disableConcurrentBuilds()
         timestamps()
     }
-    
+
     stages {
 
-        stage ('Init') {
+        stage('Init') {
             steps {
                 script {
                     env.STACK_NAME = dockerStack.sanitizeStackName("${env.STACK_PREFIX}-${JOB_BASE_NAME}")
@@ -61,7 +62,7 @@ pipeline {
 
         stage('Build Image') {
             environment {
-                DOCKER_BUILDKIT='1'
+                DOCKER_BUILDKIT = '1'
             }
             steps {
                 script {
@@ -75,11 +76,11 @@ pipeline {
                 scanImage(env.IMAGE_REPO, env.IMAGE_TAG)
             }
         }
-        
+
         stage('Push Image') {
             // Push image only on master branch or deploy is set to true
             when {
-                anyOf { 
+                anyOf {
                     branch 'master'
                     expression { return params.DEPLOY }
                 }
@@ -100,11 +101,11 @@ pipeline {
         stage('Deploy Stack') {
             // Deploys only on master branch or deploy is set to true
             when {
-                anyOf { 
+                anyOf {
                     branch 'master'
                     expression { return params.DEPLOY }
                 }
-            } 
+            }
             steps {
                 script {
                     timeout(time: 15, unit: 'MINUTES') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,14 +19,14 @@ pipeline {
 
     parameters {
         booleanParam(
-                name: 'DEPLOY',
-                defaultValue: false,
-                description: 'Deploy the stack?'
+            name: 'DEPLOY',
+            defaultValue: false,
+            description: 'Deploy the stack?'
         )
         booleanParam(
-                name: 'REFRESH_DB',
-                defaultValue: false,
-                description: 'Refresh the database?'
+            name: 'REFRESH_DB',
+            defaultValue: false,
+            description: 'Refresh the database?'
         )
     }
 

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -228,6 +228,7 @@ class TestParseLinks(TestCase):
 
 class DeactivateTranslationsMiddlewareTests(SimpleTestCase):
     def test_deactivates_translations(self):
+        translation.activate('en-us')
         self.assertEqual(translation.get_language(), 'en-us')
 
         translation.activate('es')


### PR DESCRIPTION
Builds running concurrently can sometimes hang, so let's not do that.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
