### PR TITLE
Fix middleware test by starting with clean state

### DIFF
--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -228,8 +228,8 @@ class TestParseLinks(TestCase):
 
 class DeactivateTranslationsMiddlewareTests(SimpleTestCase):
     def test_deactivates_translations(self):
-        translation.deactivate_all()
-        self.assertIs(translation.get_language(), None)
+        translation.activate('en-us')
+        self.assertEqual(translation.get_language(), 'en-us')
 
         translation.activate('es')
         self.assertEqual(translation.get_language(), 'es')

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -228,7 +228,8 @@ class TestParseLinks(TestCase):
 
 class DeactivateTranslationsMiddlewareTests(SimpleTestCase):
     def test_deactivates_translations(self):
-        self.assertEqual(translation.get_language(), 'en-us')
+        translation.deactivate_all()
+        self.assertIs(translation.get_language(), None)
 
         translation.activate('es')
         self.assertEqual(translation.get_language(), 'es')


### PR DESCRIPTION
I'm not sure what changed, but our translation middleware tests are failing in master because of a state issue. 

~~If we start the test with a clean slate by deactivating all translations, the test can't be tripped up by another test.~~

Since the test is checking deactivation, it would make more sense to explicitly set the language first, rather than first deactivating. 