### PR TITLE
Update TDP to 1.5.1 to fix missing activity search static assets

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -47,4 +47,4 @@ https://github.com/cfpb/retirement/releases/download/0.12.0/retirement-0.12.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.4.2/ccdb5_api-1.4.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.1.1/ccdb5_ui-2.1.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.1/comparisontool-1.15.1-py3-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.5.0/teachers_digital_platform-1.5.0-py3-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.5.1/teachers_digital_platform-1.5.1-py3-none-any.whl


### PR DESCRIPTION
Fixes an issue with missing static assets in the wheel.

## Checklist

- [x] PR has an informative and human-readable titleUpdate content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
