### PR TITLE
Adjust notification tester and comments

### DIFF
--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -18,53 +18,62 @@ BINGET = "https://httpbin.org/get"
 OID = '9e0280139f3238cbc9702c7b0d62e5c238a835d0'
 ERRORS = 'INVALID: test notification via Python'
 REPORT = ('URL is {}\nOK is {}\nReason is {}\n'
-          'Status is {}\nTime sent is {}\nHeaders are {}\n'
-          'Origin is {}')
+          'Status is {}\nTime sent is {}')
 
 
-def send_test_notification(url, oid, errors):
+def send_test_notifications(url=None, oid=OID, errors=ERRORS):
     """
-    Send fake notifiations to various endpoints to help troubleshoot.
+    Send fake notifiations to school endpoints to help troubleshoot.
 
-    You can send a test notification to a school's endpoint to confirm
+    You can send test notifications to school endpoints to confirm
     reception, or send to httpbin to check the outbound IP (origin),
     headers, and the data payload.
     Examples:
-    - print(send_test_notification(EDMC_PROD, OID, ERRORS))
-    - print(send_test_notification(BPI_PROD, OID, ERRORS))
-    - print(send_test_notification(BINPOST, OID, ERRORS))
+    - print(send_test_notifications())
+    - print(send_test_notifications(url=BINPOST))
     """
     prod_endpoints = {
         'edmc': Contact.objects.get(name='EDMC').endpoint,
         'bpi': Contact.objects.get(name='Bridgepoint Education').endpoint
     }
-    if url in prod_endpoints:
-        _url = prod_endpoints[url]
+    if not url:
+        urls = list(prod_endpoints.values())
     else:
-        _url = url
+        urls = [url]
     payload = {
         'oid': oid,
-        'time': "{0}+00:00".format(datetime.datetime.now().isoformat()),
+        'time': f"{datetime.datetime.now().isoformat()}+00:00",  # noqa
         'errors': errors
     }
-    try:
-        resp = requests.post(_url, data=payload, timeout=10)
-    except requests.exceptions.ConnectTimeout:
-        return "post to {} timed out".format(url)
-    if not resp.content:
-        print("Got a blank response from {}".format(url))
-        return
-    json_content = resp.json()
-    report = REPORT.format(
-        url,
-        resp.ok,
-        resp.reason,
-        resp.status_code,
-        payload['time'],
-        json_content.get('headers'),
-        json_content.get('origin')
-    )
-    return report
+    msg = ""
+    for _url in urls:
+        try:
+            resp = requests.post(_url, data=payload, timeout=10)
+        except requests.exceptions.ConnectTimeout:
+            msg += f"Post to {_url} timed out.\n"
+        else:
+            report = REPORT.format(
+                _url,
+                resp.ok,
+                resp.reason,
+                resp.status_code,
+                payload['time'],
+            )
+            msg += f"{report}\n"
+            if resp.content:
+                msg += f"Response content: {resp.content}\n"
+    return msg
 
-# curl test example:
-# curl -v -X POST --data "oid=f38283b5b7c939a058889f997949efa566c616c5&errors=INVALID: test notification via curl&time=2016-01-21T18:36:09.922690+00:00" --url "https://dev.exml.edmc.edu/cfpb"  # noqa
+
+# curl_examples
+"""
+curl -v https://httpbin.org/get
+curl -v -X POST https://httpbin.org/post
+
+export XDATA="oid='f38283b5b7c939a058889f997949efa566c616c5'&errors='INVALID: test notification via curl'&time='2020-06-24T18:36:09.922690+00:00'". # noqa
+export BPI="https://sissecureservices.bpiedu.com/routingmanager/api/cfpb"
+export EDMC="https://exml.dcedh.org/cfpb"
+
+curl -v -X POST --data "$XDATA" --url "$BPI"
+curl -v -X POST --data "$XDATA" --url "$EDMC"
+"""

--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -23,7 +23,7 @@ REPORT = ('URL is {}\nOK is {}\nReason is {}\n'
 
 def send_test_notifications(url=None, oid=OID, errors=ERRORS):
     """
-    Send fake notifiations to school endpoints to help troubleshoot.
+    Send fake notifications to school endpoints to help troubleshoot.
 
     You can send test notifications to school endpoints to confirm
     reception, or send to httpbin to check the outbound IP (origin),

--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -70,7 +70,7 @@ def send_test_notifications(url=None, oid=OID, errors=ERRORS):
 curl -v https://httpbin.org/get
 curl -v -X POST https://httpbin.org/post
 
-export XDATA="oid='f38283b5b7c939a058889f997949efa566c616c5'&errors='INVALID: test notification via curl'&time='2020-06-24T18:36:09.922690+00:00'". # noqa
+export XDATA="oid='f38283b5b7c939a058889f997949efa566c616c5'&errors='INVALID: test notification via curl'&time='2020-06-24T18:36:09.922690+00:00'"  # noqa
 export BPI="https://sissecureservices.bpiedu.com/routingmanager/api/cfpb"
 export EDMC="https://exml.dcedh.org/cfpb"
 

--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -74,6 +74,6 @@ export XDATA="oid='f38283b5b7c939a058889f997949efa566c616c5'&errors='INVALID: te
 export BPI="https://sissecureservices.bpiedu.com/routingmanager/api/cfpb"
 export EDMC="https://exml.dcedh.org/cfpb"
 
-curl -v -X POST --data "$XDATA" --url "$BPI"
-curl -v -X POST --data "$XDATA" --url "$EDMC"
+curl -v --data "$XDATA" --url "$BPI"
+curl -v --data "$XDATA" --url "$EDMC"
 """


### PR DESCRIPTION
We've had to check our PFC notifications a lot in the past few days. These changes will make that easier.

Originally we got back json responses from schools, but they stopped doing that, and the absence was obscuring test success.

## Testing

The script can only be fully tested from a productions server, because otherwise your outbound IP may be blocked.  
However, you can test it locally against httpbin, and you can see it time out for requests to schools that use a blocklist.

To test:

```bash
./cfgov/manage.py shell
```

```python
from paying_for_college.disclosures.scripts.notification_tester import *
print(send_test_notifications(url=BINPOST))
print(send_test_notifications())
```

- The httpbin request should succeed, and the response's 'origin' field should reflect your outbound IP.
- The bare `send_test_notifications()` should return at least one time-out message; one may succeed.
