### PR TITLE
Hotfix: Update CSP allowlists for intercept survey

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -489,6 +489,7 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-inline'",
     "'unsafe-eval'",
+    "*.consumerfinance.gov",
     "*.google-analytics.com",
     "*.googletagmanager.com",
     "tagmanager.google.com",
@@ -512,8 +513,6 @@ CSP_SCRIPT_SRC = (
     "connect.facebook.net",
     "www.federalregister.gov",
     "storage.googleapis.com",
-    "api.consumerfinance.gov",
-    "files.consumerfinance.gov",
     "*.qualtrics.com",
 )
 
@@ -521,6 +520,7 @@ CSP_SCRIPT_SRC = (
 CSP_STYLE_SRC = (
     "'self'",
     "'unsafe-inline'",
+    "*.consumerfinance.gov",
     "fast.fonts.net",
     "tagmanager.google.com",
     "optimize.google.com",
@@ -531,12 +531,12 @@ CSP_STYLE_SRC = (
 # These specify valid image sources
 CSP_IMG_SRC = (
     "'self'",
+    "*.consumerfinance.gov",
     "www.ecfr.gov",
     "s3.amazonaws.com",
     "www.gstatic.com",
     "ssl.gstatic.com",
     "stats.g.doubleclick.net",
-    "files.consumerfinance.gov",
     "img.youtube.com",
     "*.google-analytics.com",
     "trk.cetrk.com",
@@ -553,11 +553,13 @@ CSP_IMG_SRC = (
     "data:",
     "www.facebook.com",
     "www.gravatar.com",
+    "*.qualtrics.com",
 )
 
 # These specify what URL's we allow to appear in frames/iframes
 CSP_FRAME_SRC = (
     "'self'",
+    "*.consumerfinance.gov",
     "*.googletagmanager.com",
     "*.google-analytics.com",
     "optimize.google.com",
@@ -567,25 +569,26 @@ CSP_FRAME_SRC = (
     "www.facebook.com",
     "staticxx.facebook.com",
     "mediasite.yorkcast.com",
+    "*.qualtrics.com",
 )
 
 # These specify where we allow fonts to come from
 CSP_FONT_SRC = (
     "'self'",
     "data:",
+    "*.consumerfinance.gov",
     "fast.fonts.net",
     "fonts.google.com",
     "fonts.gstatic.com",
-    "files.consumerfinance.gov",
 )
 
 # These specify hosts we can make (potentially) cross-domain AJAX requests to
 CSP_CONNECT_SRC = (
     "'self'",
+    "*.consumerfinance.gov"
     "*.google-analytics.com",
     "*.tiles.mapbox.com",
     "bam.nr-data.net",
-    "files.consumerfinance.gov",
     "s3.amazonaws.com",
     "public.govdelivery.com",
     "n2.mouseflow.com",


### PR DESCRIPTION
The production website is currently not allowing iframes from surveys.consumerfinance.gov. Chrome console error:

> Refused to frame 'https://surveys.consumerfinance.gov/' because it violates the following Content Security Policy directive: "frame-src 'self' *.googletagmanager.com *.google-analytics.com optimize.google.com www.youtube.com *.doubleclick.net universal.iperceptions.com www.facebook.com staticxx.facebook.com mediasite.yorkcast.com".

## Additions

- Adds `*.consumerfinance.gov` to all CSP allowlists
- Adds `*.qualtrics.com` to image and frame CSP allowlists 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)