### PR TITLE
Restore 'files.consumerfinance.gov' to CSP allowlists

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,7 +3,6 @@ combine_as_imports=1
 lines_after_imports=2
 multi_line_output=5
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django,haystack
 known_wagtail=wagtail,wagtailsharing

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -490,6 +490,7 @@ CSP_SCRIPT_SRC = (
     "'unsafe-inline'",
     "'unsafe-eval'",
     "*.consumerfinance.gov",
+    "files.consumerfinance.gov",
     "*.google-analytics.com",
     "*.googletagmanager.com",
     "tagmanager.google.com",
@@ -532,6 +533,7 @@ CSP_STYLE_SRC = (
 CSP_IMG_SRC = (
     "'self'",
     "*.consumerfinance.gov",
+    "files.consumerfinance.gov",
     "www.ecfr.gov",
     "s3.amazonaws.com",
     "www.gstatic.com",
@@ -577,6 +579,7 @@ CSP_FONT_SRC = (
     "'self'",
     "data:",
     "*.consumerfinance.gov",
+    "files.consumerfinance.gov",
     "fast.fonts.net",
     "fonts.google.com",
     "fonts.gstatic.com",
@@ -586,6 +589,7 @@ CSP_FONT_SRC = (
 CSP_CONNECT_SRC = (
     "'self'",
     "*.consumerfinance.gov",
+    "files.consumerfinance.gov",
     "*.google-analytics.com",
     "*.tiles.mapbox.com",
     "bam.nr-data.net",

--- a/cfgov/v1/tests/management/commands/test_add_images.py
+++ b/cfgov/v1/tests/management/commands/test_add_images.py
@@ -49,4 +49,3 @@ class TestAddImages(TestCase):
         }
         response = self.client.post("/", post_data, follow=True)
         self.assertEqual(response.status_code, 400)
- 

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ deps=
     isort
 commands=
     flake8
-    isort --check-only --diff --recursive cfgov
+    isort --check-only --diff cfgov
 
 
 [unittest-config]


### PR DESCRIPTION
We may have assumed that '*.consumerfinance.gov' would cover it,
but our CCDB map is proving that wrong.

This is a hotfix.