### PR TITLE
pin isort version until we handle new deprecations

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,7 @@ combine_as_imports=1
 lines_after_imports=2
 multi_line_output=5
 skip=.tox,migrations
+not_skip=__init__.py
 use_parentheses=1
 known_django=django,haystack
 known_wagtail=wagtail,wagtailsharing

--- a/tox.ini
+++ b/tox.ini
@@ -77,10 +77,10 @@ commands=
 # To run Python linting.
 deps=
     flake8
-    isort
+    isort == 4.3.21
 commands=
     flake8
-    isort --check-only --diff cfgov
+    isort --check-only --diff --recursive cfgov
 
 
 [unittest-config]


### PR DESCRIPTION
Our tox file did not pin the isort version, and GitHub actions started using the latest version for our CI tests, which started failing 7/6. There are at least two deprecated options/configs that we'll need to adjust:

- the `--recursive` flag, which is deprecated
- the `not_skip` configuration, which is deprecated

These two settings were removed in an attempt to get past linting failures for a hotfix. This restores them and pins isort at 4.3.21 until we can sort out the changes in 5.x.