### PR TITLE
Deprecate unused ImageBasicUrl

### DIFF
--- a/cfgov/v1/atomic_elements/atoms.py
+++ b/cfgov/v1/atomic_elements/atoms.py
@@ -132,38 +132,3 @@ class ImageBasic(blocks.StructBlock):
     class Meta:
         icon = 'image'
         value_class = ImageBasicStructValue
-
-
-class ImageBasicUrl(ImageBasic):
-    url = blocks.CharBlock(required=False)
-
-    def clean(self, data):
-        error_dict = {}
-
-        try:
-            data = super(ImageBasicUrl, self).clean(data)
-        except ValidationError as e:
-            error_dict.update(e.params)
-
-        if not self.required and not data['upload'] and not data['url']:
-            return data
-
-        if not data['upload'] and not data['url']:
-            img_err = ['Please upload or enter an image path']
-            error_dict.update({
-                'upload': img_err,
-                'url': img_err,
-                'alt': is_required('Image alt')
-            })
-
-        if data['upload'] and data['url']:
-            img_err = ['Please select one method of image rendering']
-            error_dict.update({
-                'upload': img_err,
-                'url': img_err})
-
-        if error_dict:
-            raise ValidationError("ImageBasicUrlAlt validation errors",
-                                  params=error_dict)
-        else:
-            return data


### PR DESCRIPTION
This custom StructBlock [isn't used anywhere in the codebase](https://github.com/cfpb/cfgov-refresh/search?q=ImageBasicUrl), and seemingly never has been.

## Checklist

_[Feel free to delete any checkboxes that are not applicable to this PR.]_

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentialy one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code documentation on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance