### PR TITLE
Paying for College - Add program salaries to front-end

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
@@ -71,8 +71,8 @@
 
         <div class="block block__sub" data-state-based-visibility="school-has-programs">
           <h3 class="h4">Select your graduate program</h3>
-          <div>
-            <select class="a-select" id="program-select">
+          <div class="a-select">
+            <select id="program-select">
               
             </select>
           </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
@@ -72,7 +72,7 @@
         <div class="block block__sub" data-state-based-visibility="school-has-programs">
           <h3 class="h4">Select your graduate program</h3>
           <div>
-            <select id="program-select">
+            <select class="a-select" id="program-select">
               
             </select>
           </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
@@ -60,6 +60,23 @@
                 })
             }}
         </div>
+        <div data-state-based-visibility="school-no-programs">
+            {{ notification.render(
+                'default',
+                true,
+                '',
+                'Salary data is not available for any <span class="undergrad-content">under</span>graduate programs at your school. Please ask the school to provide you with earnings figures for recent graduates.' | safe
+            ) }}
+        </div>
+
+        <div class="block block__sub" data-state-based-visibility="school-has-programs">
+          <h3 class="h4">Select your graduate program</h3>
+          <div>
+            <select id="program-select">
+              
+            </select>
+          </div>
+        </div>
         <div class="block block__sub program-question">
             <h3 class="h4">How long do you expect your program to take?</h3>
             <div class="undergrad-content">

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/10-max-debt-guideline.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/10-max-debt-guideline.html
@@ -29,10 +29,10 @@
         })
     }}
     
-    <p data-state-based-visibility="no-program-selected">Median earnings of students working and not enrolled 6 years after starting at this school—includes students who did not graduate</p>
+    <p data-state-based-visibility="no-program-selected">Median earnings of federally-aided students working and not enrolled 6 years after starting at this school—includes students who did not graduate</p>
     <p data-state-based-visibility="program-is-selected">Median first-year earnings of federally-aided program graduates who were working and not enrolled during the first year following graduation</p>
 
-    <h4>Your projected debt vs. the median salary of recent students</h4>
+    <h4>Your projected debt vs. the median <span data-state-based-visibility="no-program-selected">salary of recent students</span><span data-state-based-visibility="program-is-selected">first-year salary of program graduates</span></h4>
     
     <div id="max-debt-guideline_chart"></div>
 
@@ -40,8 +40,8 @@
         {{ notification.render(
             'caution',
             true,
-            'Your projected total debt is more than the <span data-state-based-visibility="no-program-selected">median first-year salary of this school\'s graduates</span><span data-state-based-visibility="program-is-selected">first year salary of this program\'s graduates</span>. Consider whether this plan is right for you.' | safe,
-            'Your projected total debt is <span data-financial-item="other_debtGuideDifference">$XXXX</span> higher than the <span data-state-based-visibility="no-program-selected">median first-year salary of this school\'s graduates</span><span data-state-based-visibility="program-is-selected">first year salary of this program\'s graduates</span>. Your actual salary will depend on factors like your field of work and where you live. <a href="https://www.bls.gov/bls/blswage.htm" target="_blank" class="external-link" rel="noreferrer noopener">Visit the BLS Wage Data site for more information.</a>' | safe
+            'Your projected total debt is more than the <span data-state-based-visibility="no-program-selected">median salary of this school\'s recent students</span><span data-state-based-visibility="program-is-selected">median first-year salary of this program\'s graduates</span>. Consider whether this plan is right for you.' | safe,
+            'Your projected total debt is <span data-financial-item="other_debtGuideDifference">$XXXX</span> higher than the <span data-state-based-visibility="no-program-selected">median salary of this school\'s recent students</span><span data-state-based-visibility="program-is-selected">median first-year salary of this program\'s graduates</span>. Your actual salary will depend on factors like your field of work and where you live. <a href="https://www.bls.gov/bls/blswage.htm" target="_blank" class="external-link" rel="noreferrer noopener">Visit the BLS Wage Data site for more information.</a>' | safe
         ) }}
     </div>
 
@@ -49,7 +49,7 @@
         {{ notification.render(
             'default',
             true,
-            'Your projected total debt is not higher than the <span data-state-based-visibility="no-program-selected">median first-year salary of this school\'s graduates</span><span data-state-based-visibility="program-is-selected">first year salary of this program\'s graduates</span>'  | safe,
+            'Your projected total debt is not higher than the <span data-state-based-visibility="no-program-selected">median salary of this school\'s recent students</span><span data-state-based-visibility="program-is-selected">median first-year salary of this program\'s graduates</span>'  | safe,
             'Your actual salary will depend on factors like your field of work and where you live. <a href="https://www.bls.gov/bls/blswage.htm" target="_blank" class="external-link" rel="noreferrer noopener">Visit the BLS Wage Data site for more information.</a>' | safe
         ) }}        
     </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/10-max-debt-guideline.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/10-max-debt-guideline.html
@@ -1,6 +1,6 @@
 <section class="college-costs_tool-section college-costs_tool-section__debt-guideline" data-tool-section="max-debt-guideline">
     <h2>Could this be too much debt?</h2>
-    <p>A guideline that some find helpful: If you’re borrowing more than you’re likely to earn in your first year out of school, then you should consider whether you might be taking on more debt than you'll be able to afford.</p>
+    <p>A guideline that some find helpful: If you’re borrowing more than you’re likely to earn in your first year out of school, then you should consider whether you might be taking on more debt than you'll be able to afford. <span data-state-based-visibility="program-is-selected">The projected total debt shown below is just for this program and does not include prior student loans; if you have other student debt, include that in your calculations.</span></p>
 
     {{ number_callout.render({
             'header': 'Projected total debt',
@@ -22,14 +22,15 @@
     </div>
 
     {{ number_callout.render({
-            'header': 'Median salary of this school’s recent students',
+            'header': 'Median salary of this <span data-state-based-visibility="no-program-selected">school\'s recent students</span><span data-state-based-visibility="program-is-selected">program\'s graduates</span>' | safe,
             'data_attribute': 'data-financial-item="salary_annual"',
             'additional_classes': 'number-callout__large',
             'value': '$0'
-        }) 
+        })
     }}
     
-    <p> Median earnings of students working and not enrolled 6 years after starting at this school—includes students who did not graduate</p>
+    <p data-state-based-visibility="no-program-selected">Median earnings of students working and not enrolled 6 years after starting at this school—includes students who did not graduate</p>
+    <p data-state-based-visibility="program-is-selected">Median first-year earnings of federally-aided program graduates who were working and not enrolled during the first year following graduation</p>
 
     <h4>Your projected debt vs. the median salary of recent students</h4>
     
@@ -39,8 +40,8 @@
         {{ notification.render(
             'caution',
             true,
-            'Your projected total debt is more than the median first-year salary of this school’s graduates. Consider whether this plan is right for you.' | safe,
-            'Your projected total debt is <span data-financial-item="other_debtGuideDifference">$XXXX</span> higher than the median first-year salary of this school&apos;s graduates. Your actual salary will depend on factors like your field of work and where you live. <a href="https://www.bls.gov/bls/blswage.htm" target="_blank" class="external-link" rel="noreferrer noopener">Visit the BLS Wage Data site for more information.</a>' | safe
+            'Your projected total debt is more than the <span data-state-based-visibility="no-program-selected">median first-year salary of this school\'s graduates</span><span data-state-based-visibility="program-is-selected">first year salary of this program\'s graduates</span>. Consider whether this plan is right for you.' | safe,
+            'Your projected total debt is <span data-financial-item="other_debtGuideDifference">$XXXX</span> higher than the <span data-state-based-visibility="no-program-selected">median first-year salary of this school\'s graduates</span><span data-state-based-visibility="program-is-selected">first year salary of this program\'s graduates</span>. Your actual salary will depend on factors like your field of work and where you live. <a href="https://www.bls.gov/bls/blswage.htm" target="_blank" class="external-link" rel="noreferrer noopener">Visit the BLS Wage Data site for more information.</a>' | safe
         ) }}
     </div>
 
@@ -48,7 +49,7 @@
         {{ notification.render(
             'default',
             true,
-            'Your projected total debt is not higher than the median salary of this school\'s recent students.',
+            'Your projected total debt is not higher than the <span data-state-based-visibility="no-program-selected">median first-year salary of this school\'s graduates</span><span data-state-based-visibility="program-is-selected">first year salary of this program\'s graduates</span>'  | safe,
             'Your actual salary will depend on factors like your field of work and where you live. <a href="https://www.bls.gov/bls/blswage.htm" target="_blank" class="external-link" rel="noreferrer noopener">Visit the BLS Wage Data site for more information.</a>' | safe
         ) }}        
     </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/12-affording-your-loan.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/12-affording-your-loan.html
@@ -61,13 +61,25 @@
         }}
         <p>Your payment will depend on your total debt and your repayment plan. This estimate assumes a standard plan, where you pay the same amount every month for 10 years; other plans with lower monthly payments (and higher total costs of borrowing) are available.</p>
 
-        {{ number_callout.render({
-                'header': 'Monthly median first year salary for this school\'s graduates',
-                'data_attribute': 'data-financial-item="salary_monthly"',
-                'additional_classes': 'number-callout__large number-callout__border-top',
-                'value': '$0.00'
-            })
-        }}
+        <div data-state-based-visibility="no-program-selected">
+            {{ number_callout.render({
+                    'header': 'Monthly median salary for this school\'s recent students',
+                    'data_attribute': 'data-financial-item="salary_monthly"',
+                    'additional_classes': 'number-callout__large number-callout__border-top',
+                    'value': '$0.00'
+                })
+            }}
+        </div>
+        <div data-state-based-visibility="program-is-selected">
+            {{ number_callout.render({
+                    'header': 'Monthly median first-year salary for this program\'s graduates',
+                    'data_attribute': 'data-financial-item="salary_monthly"',
+                    'additional_classes': 'number-callout__large number-callout__border-top',
+                    'value': '$0.00'
+                })
+            }}
+        </div>
+
 
         <p>Your actual monthly salary will depend on many different factors, including your field of work and where you will live. To get more information about the salary levels of different careers, visit the <a href="https://dev2.demo.cfpb.gov/paying-for-college-beta/college-costs/" class="link-external">BLS Wage Data website</a>.</p>
 

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/14-summary.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/14-summary.html
@@ -253,7 +253,7 @@
                         })
                     }}
                 </div>
-                <div class="undergrad">
+                <div class="undergrad-content">
                     {{
                         text_item.render({
                             'label': 'Median salary of this school\'s recent students',
@@ -263,7 +263,7 @@
                         })
                     }}
                 </div>
-                <div data-state-based-visibility="school-no-programs no-program-selected">
+                <div data-state-based-visibility="no-program-selected">
                     {{
                         text_item.render({
                             'label': 'Median first-year salary of this program\'s graduates',
@@ -333,7 +333,7 @@
                         })
                     }}
                 </div>
-                <div class="undergrad">
+                <div class="undergrad-content">
                     {{
                         text_item.render({
                             'label': 'Median monthly salary of this school\'s recent students',
@@ -343,7 +343,7 @@
                         })
                     }}
                 </div>
-                <div data-state-based-visibility="school-no-programs no-program-selected">
+                <div data-state-based-visibility="no-program-selected">
                     {{
                         text_item.render({
                             'label': 'Median monthly first-year salary of this program\'s graduates',
@@ -368,94 +368,73 @@
                         'type': 'text',
                         'data_attribute': 'data-expenses-item="total_remainder"'
                     })
-                }} 
+                }}
                    
             {% endcall %}
-        </div>
-    </div>
-    <div class="block block__mid undergrad-content">
-         <div class="o-expandable-group">
             {% set expandable_settings = {
                 'label': 'Worth your investment?',
-                'value': '',
-                'data_attribute': 'data-state-item="what_goes_here"'
+                'value': ''
             } %}
             {% call() expandable(expandable_settings) %}
-                {{
-                    text_item.render({
-                        'label': 'Graduation rate',
-                        'value': '',
-                        'type': 'text',
-                        'data_attribute': 'data-school-item="rateGraduationText"'
-                    })
-                }}
-                <div class="community-college-content">
+                <div class="undergrad-content">
                     {{
                         text_item.render({
-                            'label': 'Transfer to graduation rate',
+                            'label': 'Graduation rate',
                             'value': '',
                             'type': 'text',
-                            'data_attribute': 'data-school-item="???"'
+                            'data_attribute': 'data-school-item="rateGraduationText"'
+                        })
+                    }}
+                    <div class="community-college-content">
+                        {{
+                            text_item.render({
+                                'label': 'Transfer to graduation rate',
+                                'value': '',
+                                'type': 'text',
+                                'data_attribute': 'data-school-item="???"'
+                            })
+                        }}
+                    </div>
+                    {{
+                        text_item.render({
+                            'label': 'Default rate',
+                            'value': '',
+                            'type': 'text',
+                            'data_attribute': 'data-school-item="defaultRateText"'
+                        })
+                    }}
+                    {{
+                        text_item.render({
+                            'label': 'Repayment rate',
+                            'value': '',
+                            'type': 'text',
+                            'data_attribute': 'data-school-item="rateRepay3yrText"'
                         })
                     }}
                 </div>
-                {{
-                    text_item.render({
-                        'label': 'Default rate',
-                        'value': '',
-                        'type': 'text',
-                        'data_attribute': 'data-school-item="defaultRateText"'
-                    })
-                }}
-                {{
-                    text_item.render({
-                        'label': 'Repayment rate',
-                        'value': '',
-                        'type': 'text',
-                        'data_attribute': 'data-school-item="rateRepay3yrText"'
-                    })
-                }}
-            {% endcall %}
-        </div>
-    </div>
-    <div class="block block__mid graduate-content">
-         <div class="o-expandable-group">
-            {% set expandable_settings = {
-                'label': 'Worth your investment?',
-                'value': '',
-                'data_attribute': 'data-state-item="what_goes_here"'
-            } %}
-            {% call() expandable(expandable_settings) %}
-                {{
-                    text_item.render({
-                        'label': 'Graduation rate',
-                        'value': 'Ask the school.',
-                        'type': 'text'
-                    })
-                }}
-                <div class="community-college-content">
+                <div class="graduate-content">
                     {{
                         text_item.render({
-                            'label': 'Transfer to graduation rate',
+                            'label': 'Graduation rate',
+                            'value': 'Ask the school.',
+                            'type': 'text'
+                        })
+                    }}
+                    {{
+                        text_item.render({
+                            'label': 'Default rate',
+                            'value': 'Ask the school.',
+                            'type': 'text'
+                        })
+                    }}
+                    {{
+                        text_item.render({
+                            'label': 'Repayment rate',
                             'value': 'Ask the school.',
                             'type': 'text'
                         })
                     }}
                 </div>
-                {{
-                    text_item.render({
-                        'label': 'Default rate',
-                        'value': 'Ask the school.',
-                        'type': 'text'
-                    })
-                }}
-                {{
-                    text_item.render({
-                        'label': 'Repayment rate',
-                        'value': 'Ask the school.',
-                        'type': 'text'
-                    })
-                }}
             {% endcall %}
         </div>
     </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/14-summary.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/14-summary.html
@@ -29,6 +29,14 @@
         }}
         {{
             text_item.render({
+                'label': 'Program name',
+                'value': '[program name]',
+                'type': 'text',
+                'data_attribute': 'data-state-item="programName"'
+            })
+        }}
+        {{
+            text_item.render({
                 'label': 'Number of years',
                 'value': '[program length]',
                 'type': 'text',
@@ -212,9 +220,9 @@
         <h3 class="summary_header">Affording your loans</h3>
         <div class="o-expandable-group">
             {% set expandable_settings = {
-                'label': 'Could this be too much debt? How does the projected total debt compare to the median first-year salary?',
+                'label': 'Could this be too much debt? How does the projected total debt compare to the median salary?',
                 'value': '',
-                'note': 'The projected total debt is <span class="inline" data-financial-item="other_debtGuideDifference">$0</span> <span data-state-based-visibility="debt-rule-violation">more</span><span data-state-based-visibility="debt-rule-passed">less</span> than the median first-year salary. ',
+                'note': 'The projected total debt is <span class="inline" data-financial-item="other_debtGuideDifference">$0</span> <span data-state-based-visibility="debt-rule-violation">more</span><span data-state-based-visibility="debt-rule-passed">less</span> than the median salary. ',
                 'data_attribute': ''
             } %}
             {% call() expandable(expandable_settings) %}
@@ -235,14 +243,36 @@
                         'data_attribute': 'data-state-item="repayParentPlus"'
                     })
                 }}
-                {{
-                    text_item.render({
-                        'label': 'Median first-year salary of this school\'s graduates',
-                        'value': '$0',
-                        'type': 'text',
-                        'data_attribute': 'data-financial-item="salary_annual"'
-                    })
-                }}   
+                <div data-state-based-visibility="program-is-selected">
+                    {{
+                        text_item.render({
+                            'label': 'Median first-year salary of this program\'s graduates',
+                            'value': '$0',
+                            'type': 'text',
+                            'data_attribute': 'data-financial-item="salary_annual"'
+                        })
+                    }}
+                </div>
+                <div class="undergrad">
+                    {{
+                        text_item.render({
+                            'label': 'Median salary of this school\'s recent students',
+                            'value': '$0',
+                            'type': 'text',
+                            'data_attribute': 'data-financial-item="salary_annual"'
+                        })
+                    }}
+                </div>
+                <div data-state-based-visibility="school-no-programs no-program-selected">
+                    {{
+                        text_item.render({
+                            'label': 'Median first-year salary of this program\'s graduates',
+                            'value': 'Ask the school for salary data',
+                            'type': 'text',
+                            'data_attribute': ''
+                        })
+                    }}
+                </div>
             {% endcall %}
 
             {% set expandable_settings = {
@@ -293,14 +323,36 @@
                         'data_attribute': 'data-financial-item="debt_tenYearMonthly"'
                     })
                 }}
-                {{
-                    text_item.render({
-                        'label': 'Monthly median first-year salary for this school\'s graduates',
-                        'value': '$0',
-                        'type': 'text',
-                        'data_attribute': 'data-financial-item="salary_monthly"'
-                    })
-                }}
+                <div data-state-based-visibility="program-is-selected">
+                    {{
+                        text_item.render({
+                            'label': 'Median monthly first-year salary of this program\'s graduates',
+                            'value': '$0',
+                            'type': 'text',
+                            'data_attribute': 'data-financial-item="salary_monthly"'
+                        })
+                    }}
+                </div>
+                <div class="undergrad">
+                    {{
+                        text_item.render({
+                            'label': 'Median monthly salary of this school\'s recent students',
+                            'value': '$0',
+                            'type': 'text',
+                            'data_attribute': 'data-financial-item="salary_monthly"'
+                        })
+                    }}
+                </div>
+                <div data-state-based-visibility="school-no-programs no-program-selected">
+                    {{
+                        text_item.render({
+                            'label': 'Median monthly first-year salary of this program\'s graduates',
+                            'value': 'Ask the school for salary data',
+                            'type': 'text',
+                            'data_attribute': ''
+                        })
+                    }}
+                </div>
                 {{
                     text_item.render({
                         'label': 'Average (or estimated) monthly expenses',
@@ -361,6 +413,47 @@
                         'value': '',
                         'type': 'text',
                         'data_attribute': 'data-school-item="rateRepay3yrText"'
+                    })
+                }}
+            {% endcall %}
+        </div>
+    </div>
+    <div class="block block__mid graduate-content">
+         <div class="o-expandable-group">
+            {% set expandable_settings = {
+                'label': 'Worth your investment?',
+                'value': '',
+                'data_attribute': 'data-state-item="what_goes_here"'
+            } %}
+            {% call() expandable(expandable_settings) %}
+                {{
+                    text_item.render({
+                        'label': 'Graduation rate',
+                        'value': 'Ask the school.',
+                        'type': 'text'
+                    })
+                }}
+                <div class="community-college-content">
+                    {{
+                        text_item.render({
+                            'label': 'Transfer to graduation rate',
+                            'value': 'Ask the school.',
+                            'type': 'text'
+                        })
+                    }}
+                </div>
+                {{
+                    text_item.render({
+                        'label': 'Default rate',
+                        'value': 'Ask the school.',
+                        'type': 'text'
+                    })
+                }}
+                {{
+                    text_item.render({
+                        'label': 'Repayment rate',
+                        'value': 'Ask the school.',
+                        'type': 'text'
                     })
                 }}
             {% endcall %}

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
@@ -161,14 +161,23 @@ main.college-costs {
 			display: inline;
 		}
 	}
-	&:not( [data-state_pid] ) {
+	&[data-state_programtype="graduate"]:not( [data-state_pid] ) {
 		[data-state-based-visibility="no-program-selected"] {
 			display: block;
 		}
 		span[data-state-based-visibility="no-program-selected"] {
 			display: inline;
-		}	
+		}
+
+		.college-costs_tool-section.college-costs_tool-section__affording .affording-loans-choices {
+			display: none;
+		}
+
+		[data-state-based-visibility="expenses-hourly-wages"] {
+			display: block;
+		}
 	}
+
 
 	&[data-state_costsquestion] {
 		#costs_inputs-section {

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
@@ -135,6 +135,41 @@ main.college-costs {
 		}
 	}
 
+	// Program selection visibility
+	&[data-state_schoolhasprograms="yes"][data-state_programtype="graduate"] {
+		[data-state-based-visibility="school-has-programs"] {
+			display: block;
+		}
+		span[data-state-based-visibility="school-has-programs"] {
+			display: inline;
+		}
+	}
+	&[data-state_schoolhasprograms="no"][data-state_programtype="graduate"] {
+		[data-state-based-visibility="school-no-programs"] {
+			display: block;
+		}
+		span[data-state-based-visibility="school-no-programs"] {
+			display: inline;
+		}
+	}
+
+	&[data-state_pid] {
+		[data-state-based-visibility="program-is-selected"] {
+			display: block;
+		}
+		span[data-state-based-visibility="program-is-selected"] {
+			display: inline;
+		}
+	}
+	&:not( [data-state_pid] ) {
+		[data-state-based-visibility="no-program-selected"] {
+			display: block;
+		}
+		span[data-state-based-visibility="no-program-selected"] {
+			display: inline;
+		}	
+	}
+
 	&[data-state_costsquestion] {
 		#costs_inputs-section {
 			display: block;

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-api-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-api-values.js
@@ -25,9 +25,14 @@ const getApi = function( url ) {
  * @returns {Object} Promise
  */
 const schoolSearch = function( searchTerm ) {
-  const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
-    '/api/search-schools.json?q=' + searchTerm;
-  return getApi( url );
+  searchTerm = searchTerm.trim();
+  if ( searchTerm.length > 2 ) {
+    const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
+      '/api/search-schools.json?q=' + searchTerm;
+    return getApi( url );
+  }
+  return Promise.reject( new Error( 'Failure - search term too short' ) );
+
 };
 
 /**

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-api-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-api-values.js
@@ -1,13 +1,12 @@
 import { promiseRequest } from '../util/promise-request';
 
 /**
- * schoolSearch - search for schools based on searchTerm
- * @param {String} searchTerm - Term to be searched for
+ * getApi - Make an API request to the endpoint specified with parameters specified
+ * @param {string} url - URL of API endpoint
+ * @param {string} parameter - Additional parameter, if applicable
  * @returns {Object} Promise
  */
-const schoolSearch = function( searchTerm ) {
-  const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
-    '/api/search-schools.json?q=' + searchTerm;
+const getApi = function( url ) {
   return new Promise( function( resolve, reject ) {
     promiseRequest( 'GET', url )
       .then( function( resp ) {
@@ -17,7 +16,18 @@ const schoolSearch = function( searchTerm ) {
         reject( new Error( error ) );
         console.log( 'An error occurred!', error );
       } );
-  } );
+  } );  
+}
+
+/**
+ * schoolSearch - search for schools based on searchTerm
+ * @param {String} searchTerm - Term to be searched for
+ * @returns {Object} Promise
+ */
+const schoolSearch = function( searchTerm ) {
+  const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
+    '/api/search-schools.json?q=' + searchTerm;
+  return getApi( url );
 };
 
 /**
@@ -27,16 +37,7 @@ const schoolSearch = function( searchTerm ) {
 const getConstants = function() {
   const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
     '/api/constants/';
-  return new Promise( function( resolve, reject ) {
-    promiseRequest( 'GET', url )
-      .then( function( resp ) {
-        resolve( resp );
-      } )
-      .catch( function( error ) {
-        reject( new Error( error ) );
-        // console.log( 'An error occurred!', error );
-      } );
-  } );
+  return getApi( url );
 };
 
 /**
@@ -46,16 +47,7 @@ const getConstants = function() {
 const getExpenses = function() {
   const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
     '/api/expenses/';
-  return new Promise( function( resolve, reject ) {
-    promiseRequest( 'GET', url )
-      .then( function( resp ) {
-        resolve( resp );
-      } )
-      .catch( function( error ) {
-        reject( new Error( error ) );
-        // console.log( 'An error occurred!', error );
-      } );
-  } );
+  return getApi( url );
 };
 
 /**
@@ -67,19 +59,10 @@ const getSchoolData = function( iped ) {
   const url = '/paying-for-college2/understanding-your-financial-aid-offer' +
     '/api/school/' + iped;
 
-  const xhr = new XMLHttpRequest();
-
-  return new Promise( function( resolve, reject ) {
-    promiseRequest( 'GET', url )
-      .then( function( resp ) {
-        resolve( resp );
-      } )
-      .catch( function( error ) {
-        reject( new Error( error ) );
-        // console.log( 'An error occurred!', error );
-      } );
-  } );
+  return getApi( url );
 };
+
+
 
 export {
   getConstants,

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-api-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-api-values.js
@@ -16,8 +16,8 @@ const getApi = function( url ) {
         reject( new Error( error ) );
         console.log( 'An error occurred!', error );
       } );
-  } );  
-}
+  } );
+};
 
 /**
  * schoolSearch - search for schools based on searchTerm
@@ -61,7 +61,6 @@ const getSchoolData = function( iped ) {
 
   return getApi( url );
 };
-
 
 
 export {

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
@@ -8,50 +8,6 @@ import { financialModel } from '../models/financial-model.js';
 import { schoolModel } from '../models/school-model.js';
 import { stateModel } from '../models/state-model.js';
 
-/**
- * getFinancialValue - get the value of 'name' from the financialModel
- * @param {string} name - Name of the property to retrieve
- * @returns {number} value of the property
- */
-function getFinancialValue( name ) {
-  return financialModel.values[name];
-}
-
-/**
- * getSchoolValue - get the value of 'name' from the schoolModel
- * @param {string} name - Name of the property to retrieve
- * @returns {(number|string)} value of the property
- */
-function getSchoolValue( name ) {
-  return schoolModel.values[name];
-}
-
-/**
- * getExpensesValue - get the value of 'name' from the expensesModel
- * @param {string} name - Name of the property to retrieve
- * @returns {number} value of the property
- */
-function getExpensesValue( name ) {
-  return expensesModel.values[name];
-}
-
-/**
- * getConstantsValue - get the value of 'name' from the constantsModel
- * @param {string} name - Name of the property to retrieve
- * @returns {(number|string)} value of the property
- */
-function getConstantsValue( name ) {
-  return constantsModel.values[name];
-}
-
-/**
- * getStateValue - gets the property from the application state model
- * @param {string} prop - The property name
- * @returns {string} The value of the property in the stateModel Object
- */
-function getStateValue( prop ) {
-  return stateModel.values[prop];
-}
 
 /**
  * getAllStateValues - retrieves the entire values property (object) of the stateModel
@@ -61,12 +17,84 @@ function getAllStateValues() {
   return { ...stateModel.values };
 }
 
+/**
+ * getConstantsValue - get the value of 'name' from the constantsModel
+ * @param {string} name - Name of the property to retrieve
+ * @returns {(number|string|boolean)} value of the property, false if undefined
+ */
+function getConstantsValue( name ) {
+  if ( constantsModel.values.hasOwnProperty( name) ) {
+    return constantsModel.values[name];
+  } else {
+    return false;
+  }
+}
+
+/**3
+ * getExpensesValue - get the value of 'name' from the expensesModel
+ * @param {string} name - Name of the property to retrieve
+ * @returns {number} value of the property
+ */
+function getExpensesValue( name ) {
+  return expensesModel.values[name];
+}
+
+/**
+ * getFinancialValue - get the value of 'name' from the financialModel
+ * @param {string} name - Name of the property to retrieve
+ * @returns {number|booleab} value of the property, or false if undefined
+ */
+function getFinancialValue( name ) {
+  if ( financialModel.values.hasOwnProperty( name ) ) {
+    return financialModel.values[name];    
+  } else {
+    return false;
+  }
+}
+
+/**
+ * getProgramList - retrieve an alphabetical list of programs
+ * from the schoolModel
+ * @param {string} level - program level - 'undergrad' or 'graduate'
+ * @returns {array} an arry of objects containing program data
+ */
+function getProgramList( level ) {
+  return schoolModel.getAlphbeticalProgramList( level );
+}
+
+/**
+ * getSchoolValue - get the value of 'name' from the schoolModel
+ * @param {string} name - Name of the property to retrieve
+ * @returns {(number|string|boolean)} value of the property, or false if undefined
+ */
+function getSchoolValue( name ) {
+  if ( schoolModel.values.hasOwnProperty( name ) ) {
+    return schoolModel.values[name];
+  } else {
+    return false;
+  }
+}
+
+/**
+ * getStateValue - gets the property from the application state model
+ * @param {string} prop - The property name
+ * @returns {stringboolean} The value of the property in the stateModel Object, or
+ *    false if undefined
+ */
+function getStateValue( prop ) {
+  if ( stateModel.values.hasOwnProperty( prop ) ) {
+    return stateModel.values[prop];    
+  } else {
+    return false;
+  }
+}
 
 export {
-  getFinancialValue,
-  getSchoolValue,
+  getAllStateValues,
   getConstantsValue,
   getExpensesValue,
-  getAllStateValues,
+  getFinancialValue,
+  getProgramList,
+  getSchoolValue,
   getStateValue
 };

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
@@ -63,6 +63,15 @@ function getProgramList( level ) {
 }
 
 /**
+ * getProgramInfo - retrieve info based on pid
+ * @param {string} pid - Program ID
+ * @returns {object} Values of the program
+ */
+function getProgramInfo( pid ) {
+  return schoolModel.getProgramInfo( pid );
+}
+
+/**
  * getSchoolValue - get the value of 'name' from the schoolModel
  * @param {string} name - Name of the property to retrieve
  * @returns {(number|string|boolean)} value of the property, or false if undefined
@@ -94,6 +103,7 @@ export {
   getConstantsValue,
   getExpensesValue,
   getFinancialValue,
+  getProgramInfo,
   getProgramList,
   getSchoolValue,
   getStateValue

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
@@ -81,7 +81,6 @@ function getSchoolValue( name ) {
     return schoolModel.values[name];
   }
   return false;
-
 }
 
 /**

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/get-model-values.js
@@ -23,14 +23,14 @@ function getAllStateValues() {
  * @returns {(number|string|boolean)} value of the property, false if undefined
  */
 function getConstantsValue( name ) {
-  if ( constantsModel.values.hasOwnProperty( name) ) {
+  if ( constantsModel.values.hasOwnProperty( name ) ) {
     return constantsModel.values[name];
-  } else {
-    return false;
   }
+  return false;
+
 }
 
-/**3
+/** 3
  * getExpensesValue - get the value of 'name' from the expensesModel
  * @param {string} name - Name of the property to retrieve
  * @returns {number} value of the property
@@ -46,10 +46,10 @@ function getExpensesValue( name ) {
  */
 function getFinancialValue( name ) {
   if ( financialModel.values.hasOwnProperty( name ) ) {
-    return financialModel.values[name];    
-  } else {
-    return false;
+    return financialModel.values[name];
   }
+  return false;
+
 }
 
 /**
@@ -70,9 +70,9 @@ function getProgramList( level ) {
 function getSchoolValue( name ) {
   if ( schoolModel.values.hasOwnProperty( name ) ) {
     return schoolModel.values[name];
-  } else {
-    return false;
   }
+  return false;
+
 }
 
 /**
@@ -83,10 +83,10 @@ function getSchoolValue( name ) {
  */
 function getStateValue( prop ) {
   if ( stateModel.values.hasOwnProperty( prop ) ) {
-    return stateModel.values[prop];    
-  } else {
-    return false;
+    return stateModel.values[prop];
   }
+  return false;
+
 }
 
 export {

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
@@ -9,7 +9,7 @@ import { getSchoolData } from '../dispatchers/get-api-values.js';
 import { schoolModel } from '../models/school-model.js';
 import { stateModel } from '../models/state-model.js';
 import { stringToNum } from '../util/number-utils.js';
-import { getConstantsValue, getSchoolValue, getStateValue } from '../dispatchers/get-model-values.js';
+import { getConstantsValue, getProgramInfo, getSchoolValue, getStateValue } from '../dispatchers/get-model-values.js';
 import { updateGradMeterChart, updateRepaymentMeterChart, updateSchoolView } from './update-view.js';
 
 const _urlParamsToModelVars = {
@@ -172,6 +172,18 @@ const updateSchoolData = function( iped ) {
 
         for ( const key in data ) {
           schoolModel.setValue( key, data[key] );
+        }
+
+        // Create objects of programs keyed by program ID
+        schoolModel.createProgramLists();
+
+        // If we have a pid, validate it
+        const pid = getStateValue( 'pid' );
+        if ( pid !== false && pid !== null ) {
+          const programInfo = getProgramInfo( pid );
+          if ( programInfo === false ) {
+            stateModel.setValue( 'pid', false );
+          }
         }
 
         // Some values must migrate to the financial model

--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
@@ -14,9 +14,9 @@ import { updateGradMeterChart, updateRepaymentMeterChart, updateSchoolView } fro
 
 const _urlParamsToModelVars = {
   'iped': 'schoolModel.schoolID',
-  'pid': 'schoolModel.PID',
   'oid': 'schoolModel.oid',
 
+  'pid': 'stateModel.pid',
   'houp': 'stateModel.programHousing',
   'typp': 'stateModel.programType',
   'lenp': 'stateModel.programLength',
@@ -115,7 +115,7 @@ function initializeFinancialValues() {
   * @param {Boolean} updateView - (defaults true) should view be updated?
   */
 function updateFinancial( name, value, updateView ) {
-  financialModel.setValue( name, value );
+  financialModel.setValue( name, value, updateView );
 }
 
 /**
@@ -176,7 +176,6 @@ const updateSchoolData = function( iped ) {
 
         // Some values must migrate to the financial model
         financialModel.setValue( 'salary_annual', stringToNum( getSchoolValue( 'medianAnnualPay6Yr' ) ) );
-        financialModel.setValue( 'salary_monthly', stringToNum( getSchoolValue( 'medianAnnualPay6Yr' ) ) / 12 );
 
         updateSchoolView();
 
@@ -235,18 +234,17 @@ function updateModelsFromQueryString( queryObj ) {
       const match = _urlParamsToModelVars[key].split( '.' );
       modelMatch[match[0]]( match[1], queryObj[key], false );
 
-      // If there's an iped, do a fetch of the schoolData
-      if ( key === 'iped' ) {
-        updateSchoolData( queryObj[key] );
-      }
-
-      // Also put programLength into the financial model
+      // Copy programLength into the financial model
       if ( key === 'lenp' ) {
         financialModel.setValue( 'other_programLength', stringToNum( queryObj[key], false ) );
       }
     }
   }
 
+  // If there's an iped, do a fetch of the schoolData
+  if ( getSchoolValue( 'schoolID' ) ) {
+    updateSchoolData( getSchoolValue( 'schoolID' ) );
+  }
 }
 
 export {

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
@@ -56,7 +56,7 @@ const financialModel = {
 
     // Debt Guide Difference
     financialModel.values.other_debtGuideDifference =
-        financialModel.values.debt_totalAtGrad - financialModel.values.salary_annual;
+        Math.abs( financialModel.values.debt_totalAtGrad - financialModel.values.salary_annual );
   },
 
   /**

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
@@ -47,6 +47,10 @@ const financialModel = {
     financialModel._updateRates();
     financialModel._calculateTotals();
     debtCalculator();
+
+    // set monthly salary value
+    financialModel.values.salary_monthly = financialModel.values.salary_annual / 12;
+
     recalculateExpenses();
     financialModel._updateStateWithFinancials();
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
@@ -166,7 +166,7 @@ const financialModel = {
     }
 
     // unsubCap is actually the 'unsubCap' minus any subsidized loans.
-    const unsubCap = Math.max( 
+    const unsubCap = Math.max(
       getConstantsValue( unsubCapKey ) - financialModel.values.fedLoan_directSub,
       0 );
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/school-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/school-model.js
@@ -4,7 +4,9 @@ import { updateState } from '../dispatchers/update-state.js';
 import { updateUrlQueryString } from '../dispatchers/update-view.js';
 
 const schoolModel = {
-  values: {},
+  values: {
+  },
+
   textPercents: [ 'defaultRate', 'rateGraduation', 'rateRepay3yr' ],
 
   setValue: function( name, value ) {
@@ -21,6 +23,30 @@ const schoolModel = {
     }
 
     updateUrlQueryString();
+  },
+
+  /**
+   * Returns an array of Objects which is alphabetized
+   * by program name
+   * @param {string} level - program level - 'undergrad' or 'graduate'
+   * @returns {array} an array of objects containing program data
+   */
+  getAlphbeticalProgramList: function( level ) {
+    let list = [];
+    if ( !schoolModel.values.hasOwnProperty( 'programCodes' ) ) return list;
+    if ( !schoolModel.values.programCodes.hasOwnProperty( level ) ) return list;
+
+    list = schoolModel.values.programCodes[level].sort( ( a, b ) => {
+      if ( a.name < b.name ) return -1;
+      else if ( a.name > b.name ) return 1;
+      else if ( b.name === a.name ) {
+        if ( a.level < b.level ) return -1;
+        else if ( a.level > b.level ) return 1;
+      }
+      else return 0;
+    } ); 
+
+    return list;
   }
 
 };

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/school-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/school-model.js
@@ -1,5 +1,6 @@
 // This model contains school information
 import { decimalToPercentString } from '../util/number-utils.js';
+import { getStateValue } from '../dispatchers/get-model-values.js';
 import { updateState } from '../dispatchers/update-state.js';
 import { updateUrlQueryString } from '../dispatchers/update-view.js';
 
@@ -26,6 +27,28 @@ const schoolModel = {
   },
 
   /**
+   * Reformats the programCodes array into an Object keyed by program ID
+   */
+  createProgramLists: function() {
+    schoolModel.values.programList = {};
+    if ( schoolModel.values.hasOwnProperty( 'programCodes' ) ) {
+      const programCodes = schoolModel.values.programCodes;
+      for ( const key in programCodes ) {
+        schoolModel.values.programList[key] = {};
+        if ( programCodes[key].length > 0 ) {
+          programCodes[key].forEach( elem => {
+            schoolModel.values.programList[key][elem.code] = {
+              name: elem.name,
+              level: elem.level,
+              salary: elem.salary
+            };
+          } );
+        }
+      }
+    }
+  },
+
+  /**
    * Returns an array of Objects which is alphabetized
    * by program name
    * @param {string} level - program level - 'undergrad' or 'graduate'
@@ -45,6 +68,23 @@ const schoolModel = {
     } );
 
     return list;
+  },
+
+  /**
+   * getProgramInfo - retrieve info based on program id
+   * @param {string} pid - Program ID
+   * @returns {object|boolean} Values of the program, or false if undefined
+   */
+  getProgramInfo: function( pid ) {
+    const level = getStateValue( 'programLevel' );
+    if ( level === null || level === false ) {
+      return false;
+    }
+    if ( !schoolModel.values.programList[level].hasOwnProperty( pid ) ) {
+      return false;
+    }
+
+    return schoolModel.values.programList[level][pid];
   }
 
 };

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/school-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/school-model.js
@@ -37,14 +37,12 @@ const schoolModel = {
     if ( !schoolModel.values.programCodes.hasOwnProperty( level ) ) return list;
 
     list = schoolModel.values.programCodes[level].sort( ( a, b ) => {
-      if ( a.name < b.name ) return -1;
-      else if ( a.name > b.name ) return 1;
-      else if ( b.name === a.name ) {
+      if ( a.name < b.name ) { return -1; } else if ( a.name > b.name ) { return 1; } else if ( b.name === a.name ) {
         if ( a.level < b.level ) return -1;
         else if ( a.level > b.level ) return 1;
       }
-      else return 0;
-    } ); 
+      return 0;
+    } );
 
     return list;
   }

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/state-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/state-model.js
@@ -3,6 +3,7 @@
  * which tracks the current app state and allows the views to update based on
  * state.
 */
+import { getProgramInfo } from '../dispatchers/get-model-values.js';
 import { recalculateFinancials } from '../dispatchers/update-models.js';
 import { updateFinancialViewAndFinancialCharts, updateNavigationView, updateSchoolItems, updateStateInDom, updateUrlQueryString } from '../dispatchers/update-view.js';
 import { bindEvent } from '../../../../js/modules/util/dom-events';
@@ -10,14 +11,15 @@ import { bindEvent } from '../../../../js/modules/util/dom-events';
 const stateModel = {
   stateDomElem: null,
   values: {
-    activeSection: null,
-    schoolSelected: null,
+    activeSection: false,
+    schoolSelected: false,
     gotStarted: false,
     costsQuestion: false,
-    programType: null,
-    programLength: null,
-    programRate: null,
-    programHousing: null
+    programType: false,
+    programLength: false,
+    programLevel: false,
+    programRate: false,
+    programHousing: false
   },
   textVersions: {
     programType: {
@@ -105,8 +107,15 @@ const stateModel = {
       stateModel.values[key] = stateModel.textVersions[name][value];
       updateSchoolItems();
     }
+
     // When program values are updated, recalculate, updateView
     if ( name.indexOf( 'program' ) === 0 ) {
+      if ( name === 'programType' && value === 'graduate' ) {
+        stateModel.values.programLevel = 'graduate';
+      } else if ( name === 'programType' ) {
+        stateModel.values.programLevel = 'undergrad';
+      }
+
       recalculateFinancials();
       updateFinancialViewAndFinancialCharts();
     }

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/state-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/state-model.js
@@ -111,9 +111,9 @@ const stateModel = {
     // When program values are updated, recalculate, updateView
     if ( name.indexOf( 'program' ) === 0 ) {
       if ( name === 'programType' && value === 'graduate' ) {
-        stateModel.values.programLevel = 'graduate';
+        stateModel.setValue( 'programLevel', 'graduate' );
       } else if ( name === 'programType' ) {
-        stateModel.values.programLevel = 'undergrad';
+        stateModel.setValue( 'programLevel', 'undergrad' );
       }
 
       recalculateFinancials();

--- a/cfgov/unprocessed/apps/paying-for-college/js/util/number-utils.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/number-utils.js
@@ -8,9 +8,7 @@
 function stringToNum( numberString ) {
   if ( typeof numberString === 'number' ) {
     return numberString;
-  } else if ( typeof numberString === 'undefined' ) {
-    return 0;
-  } else if ( typeof numberString === 'object' ) {
+  } else if ( typeof numberString !== 'string' ) {
     return 0;
   }
   let signMaker = 1;

--- a/cfgov/unprocessed/apps/paying-for-college/js/util/url-parameter-utils.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/url-parameter-utils.js
@@ -39,9 +39,9 @@ function buildUrlQueryString() {
      update-models.js file. */
   const variables = {
     'iped': schoolValues.schoolID,
-    'pid': schoolValues.pid,
     'oid': schoolValues.oid,
 
+    'pid': stateValues.pid,
     'houp': stateValues.programHousing,
     'typp': stateValues.programType,
     'lenp': stateValues.programLength,

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/chart-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/chart-view.js
@@ -472,7 +472,7 @@ const chartView = {
     const salary = getFinancialValue( 'salary_annual' );
     const max = Math.max( totalDebt * 1.1, salary * 1.1 );
 
-    const text = 'Median salary of<br>this school\'s recent<br>' + numberToMoney( { amount: salary, decimalPlaces: 0 } );
+    const text = 'Median salary<br>' + numberToMoney( { amount: salary, decimalPlaces: 0 } );
 
     chartView.maxDebtChart.yAxis[0].update( {
       min: 0,

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/financial-view.js
@@ -129,6 +129,9 @@ const financialView = {
         const isFee = prop.substr( 0, 4 ) === 'fee_';
         const isNumber = elem.dataset.isNumber === 'true';
         let val = getFinancialValue( prop );
+
+        // Prevent improper property values from presenting on the page 
+        if  ( val === false || val === null || isNaN( val ) ) val = 0;
         if ( isFee ) {
           val = decimalToPercentString( val, 3 );
         } else if ( isRate ) {

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/financial-view.js
@@ -130,8 +130,8 @@ const financialView = {
         const isNumber = elem.dataset.isNumber === 'true';
         let val = getFinancialValue( prop );
 
-        // Prevent improper property values from presenting on the page 
-        if  ( val === false || val === null || isNaN( val ) ) val = 0;
+        // Prevent improper property values from presenting on the page
+        if ( val === false || val === null || isNaN( val ) ) val = 0;
         if ( isFee ) {
           val = decimalToPercentString( val, 3 );
         } else if ( isRate ) {

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -127,7 +127,6 @@ const schoolView = {
     const prop = input.getAttribute( 'name' );
     const value = input.value;
     updateState.byProperty( prop, value );
-    schoolView._updateProgramList();
 
     // schoolView._checkRadioButtonCount();
   },
@@ -146,7 +145,10 @@ const schoolView = {
 
       const prop = elem.dataset.schoolItem;
       let val = getSchoolValue( prop );
-      if ( typeof val === 'undefined' ) val = '';
+      // Prevent improper values from being displayed on the page
+      if ( typeof val === 'undefined' || val === false || val === null ) {
+        val = '';
+      }
 
       elem.innerText = val;
 
@@ -155,7 +157,8 @@ const schoolView = {
     this._stateItems.forEach( elem => {
       const prop = elem.dataset.stateItem;
       let val = getStateValue( prop );
-      if ( typeof val === 'undefined' ) {
+      // Prevent improper values from being displayed on the page
+      if ( typeof val === 'undefined' || val === false || val === null ) {
         val = '';
       }
       elem.innerText = val;

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -5,7 +5,7 @@ import { schoolSearch } from '../dispatchers/get-api-values';
 import { bindEvent } from '../../../../js/modules/util/dom-events';
 import { updateFinancial, updateSchoolData } from '../dispatchers/update-models.js';
 import { updateState } from '../dispatchers/update-state.js';
-import { getSchoolValue, getStateValue, getProgramList } from '../dispatchers/get-model-values.js';
+import { getProgramList, getSchoolValue, getStateValue } from '../dispatchers/get-model-values.js';
 import { updateFinancialView, updateGradMeterChart, updateRepaymentMeterChart } from '../dispatchers/update-view.js';
 
 
@@ -43,7 +43,7 @@ const schoolView = {
 
     const programSelectEvents = {
       change: schoolView._handleProgramSelectChange
-    }
+    };
     bindEvent( schoolView._programSelect, programSelectEvents );
   },
 
@@ -171,19 +171,19 @@ const schoolView = {
 
     if ( list.length > 0 ) {
       let html = '<option selected="selected" value="null">Select...</option>';
-      list.forEach( ( elem ) => {
+      list.forEach( elem => {
         html += '\n<option data-program-salary="' + elem.salary + '"';
         html += ' value="' + elem.code + '">';
         html += elem.level + ' - ' + elem.name;
-        html += '</option>'; 
+        html += '</option>';
       } );
       html += '<option value="null">My program is not listed here.</option>';
       schoolView._programSelect.innerHTML = html;
 
-      // If there's a program id in the state, select that program
-      if ( getStateValue( 'pid' ) ) {
+      /* If there's a program id in the state, select that program
+         if ( getStateValue( 'pid' ) ) { */
 
-      }
+      // }
     }
   },
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -47,19 +47,6 @@ const schoolView = {
     bindEvent( schoolView._programSelect, programSelectEvents );
   },
 
-  /**
-   * _checkRadioButtonCount: if all radio buttons are clicked, enable the next button
-   */
-  _checkRadioButtonCount: function( ) {
-    const checkedCount = schoolView._schoolInfo
-      .querySelectorAll( 'input[checked="true"]' ).length;
-    const questionCount = schoolView._schoolInfo
-      .querySelectorAll( '.program-question' ).length;
-    if ( checkedCount === questionCount ) {
-      document.querySelector( 'button.btn__next-step' ).removeAttribute( 'disabled' );
-    }
-  },
-
   _formatSearchResults: function( responseText ) {
     const obj = JSON.parse( responseText );
     let html = '<ul>';
@@ -86,9 +73,10 @@ const schoolView = {
   },
 
   _handleProgramSelectChange: function( event ) {
-    const salary = event.target.options[event.target.selectedIndex].dataset.programSalary;
-    const programName = event.target.options[event.target.selectedIndex].innerText;
-    let pid = event.target.value;
+    const target = event.target; 
+    const salary = target.options[target.selectedIndex].dataset.programSalary;
+    const programName = target.options[target.selectedIndex].innerText;
+    let pid = target.value;
     if ( pid === 'null' ) {
       pid = false;
     }
@@ -127,8 +115,6 @@ const schoolView = {
     const prop = input.getAttribute( 'name' );
     const value = input.value;
     updateState.byProperty( prop, value );
-
-    // schoolView._checkRadioButtonCount();
   },
 
   updateSchoolView: () => {
@@ -181,12 +167,12 @@ const schoolView = {
     if ( list.length > 0 ) {
       let html = '<option selected="selected" value="null">Select...</option>';
       list.forEach( elem => {
-        html += '\n<option data-program-salary="' + elem.salary + '"';
-        html += ' value="' + elem.code + '">';
-        html += elem.level + ' - ' + elem.name;
-        html += '</option>';
+        html += `
+          <option data-program-salary="${elem.salary}" value="${elem.code}">
+                ${elem.level} - ${elem.name}
+          </option>`;
       } );
-      html += '<option value="null">My program is not listed here.</option>';
+      html += '\n<option value="null">My program is not listed here.</option>';
       schoolView._programSelect.innerHTML = html;
 
       // If there's a program id in the state, select that program
@@ -213,8 +199,6 @@ const schoolView = {
       }
     } );
 
-    schoolView._checkRadioButtonCount();
-
   },
 
   clickRadioButton: ( name, value ) => {
@@ -223,8 +207,6 @@ const schoolView = {
       const label = closest( input, '.m-form-field__radio' ).querySelector( 'LABEL' );
       label.click();
     }
-
-    schoolView._checkRadioButtonCount();
   },
 
   init: body => {

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -87,7 +87,13 @@ const schoolView = {
 
   _handleProgramSelectChange: function( event ) {
     const salary = event.target.options[event.target.selectedIndex].dataset.programSalary;
-    updateState.byProperty( 'pid', event.target.value );
+    const programName = event.target.options[event.target.selectedIndex].innerText;
+    let pid = event.target.value;
+    if ( pid === 'null' ) {
+      pid = false;
+    }
+    updateState.byProperty( 'pid', pid );
+    updateState.byProperty( 'programName', programName );
     updateFinancial( 'salary_annual', salary );
   },
 
@@ -121,9 +127,9 @@ const schoolView = {
     const prop = input.getAttribute( 'name' );
     const value = input.value;
     updateState.byProperty( prop, value );
+    schoolView._updateProgramList();
 
-    schoolView._checkRadioButtonCount();
-    schoolView.updateSchoolView();
+    // schoolView._checkRadioButtonCount();
   },
 
   updateSchoolView: () => {
@@ -180,10 +186,10 @@ const schoolView = {
       html += '<option value="null">My program is not listed here.</option>';
       schoolView._programSelect.innerHTML = html;
 
-      /* If there's a program id in the state, select that program
-         if ( getStateValue( 'pid' ) ) { */
-
-      // }
+      // If there's a program id in the state, select that program
+      if ( getStateValue( 'pid' ) ) {
+        document.querySelector( '#program-select' ).value = getStateValue( 'pid' );
+      }
     }
   },
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -68,12 +68,14 @@ const schoolView = {
       schoolSearch( searchTerm )
         .then( resp => {
           schoolView._formatSearchResults( resp.responseText );
+        }, error => {
+          console.log( error );
         } );
     }, 500 );
   },
 
   _handleProgramSelectChange: function( event ) {
-    const target = event.target; 
+    const target = event.target;
     const salary = target.options[target.selectedIndex].dataset.programSalary;
     const programName = target.options[target.selectedIndex].innerText;
     let pid = target.value;
@@ -168,8 +170,8 @@ const schoolView = {
       let html = '<option selected="selected" value="null">Select...</option>';
       list.forEach( elem => {
         html += `
-          <option data-program-salary="${elem.salary}" value="${elem.code}">
-                ${elem.level} - ${elem.name}
+          <option data-program-salary="${ elem.salary }" value="${ elem.code }">
+                ${ elem.level } - ${ elem.name }
           </option>`;
       } );
       html += '\n<option value="null">My program is not listed here.</option>';

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -117,6 +117,9 @@ const schoolView = {
     const prop = input.getAttribute( 'name' );
     const value = input.value;
     updateState.byProperty( prop, value );
+    if ( prop === 'programType' ) {
+      schoolView._updateProgramList();
+    }
   },
 
   updateSchoolView: () => {

--- a/cfgov/unprocessed/apps/teachers-digital-plaform/css/main.less
+++ b/cfgov/unprocessed/apps/teachers-digital-plaform/css/main.less
@@ -5,27 +5,27 @@
 // Import Capital Framework by reference so that variables and mixins are
 // available, but the whole output doesn't duplicate what we're already getting
 // from cfgov-refresh.
-@import (reference) 'cf-core.less';
-@import (reference) 'cf-icons.less';
-@import (reference) 'cf-buttons.less';
-@import (reference) 'cf-forms.less';
-@import (reference) 'cf-grid.less';
-@import (reference) 'cf-layout.less';
-@import (reference) 'cf-typography.less';
-@import (reference) 'cf-notifications.less';
-@import (reference) 'cf-pagination.less';
-@import (reference) 'cf-expandables.less';
-@import (reference) 'cf-tables.less';
+// @import (reference) 'cf-core.less';
+// @import (reference) 'cf-icons.less';
+// @import (reference) 'cf-buttons.less';
+// @import (reference) 'cf-forms.less';
+// @import (reference) 'cf-grid.less';
+// @import (reference) 'cf-layout.less';
+// @import (reference) 'cf-typography.less';
+// @import (reference) 'cf-notifications.less';
+// @import (reference) 'cf-pagination.less';
+// @import (reference) 'cf-expandables.less';
+// @import (reference) 'cf-tables.less';
 
 // TODO: Add (reference) back in for notifications/icons and remove temp/button-links.less once this PR is merged:
 // https://github.com/cfpb/cfgov-refresh/pull/3887/
-// @import 'temp/button-links.less';
+// // @import 'temp/button-links.less';
 
 // Project specific Less goes here or you can break it up into discrete files.
-@import 'atoms/icon.less';
-@import 'molecules/form-fields.less';
-@import 'molecules/search-hero.less';
-@import 'organisms/expandable-facets.less';
-@import 'organisms/tour.less';
-@import 'pages/activity-search.less';
-@import 'utilities/hide-on.less';
+// @import 'atoms/icon.less';
+// @import 'molecules/form-fields.less';
+// @import 'molecules/search-hero.less';
+// @import 'organisms/expandable-facets.less';
+// @import 'organisms/tour.less';
+// @import 'pages/activity-search.less';
+// @import 'utilities/hide-on.less';

--- a/cfgov/unprocessed/apps/teachers-digital-plaform/css/main.less
+++ b/cfgov/unprocessed/apps/teachers-digital-plaform/css/main.less
@@ -5,27 +5,27 @@
 // Import Capital Framework by reference so that variables and mixins are
 // available, but the whole output doesn't duplicate what we're already getting
 // from cfgov-refresh.
-// @import (reference) 'cf-core.less';
-// @import (reference) 'cf-icons.less';
-// @import (reference) 'cf-buttons.less';
-// @import (reference) 'cf-forms.less';
-// @import (reference) 'cf-grid.less';
-// @import (reference) 'cf-layout.less';
-// @import (reference) 'cf-typography.less';
-// @import (reference) 'cf-notifications.less';
-// @import (reference) 'cf-pagination.less';
-// @import (reference) 'cf-expandables.less';
-// @import (reference) 'cf-tables.less';
+@import (reference) 'cf-core.less';
+@import (reference) 'cf-icons.less';
+@import (reference) 'cf-buttons.less';
+@import (reference) 'cf-forms.less';
+@import (reference) 'cf-grid.less';
+@import (reference) 'cf-layout.less';
+@import (reference) 'cf-typography.less';
+@import (reference) 'cf-notifications.less';
+@import (reference) 'cf-pagination.less';
+@import (reference) 'cf-expandables.less';
+@import (reference) 'cf-tables.less';
 
 // TODO: Add (reference) back in for notifications/icons and remove temp/button-links.less once this PR is merged:
 // https://github.com/cfpb/cfgov-refresh/pull/3887/
-// // @import 'temp/button-links.less';
+// @import 'temp/button-links.less';
 
 // Project specific Less goes here or you can break it up into discrete files.
-// @import 'atoms/icon.less';
-// @import 'molecules/form-fields.less';
-// @import 'molecules/search-hero.less';
-// @import 'organisms/expandable-facets.less';
-// @import 'organisms/tour.less';
-// @import 'pages/activity-search.less';
-// @import 'utilities/hide-on.less';
+@import 'atoms/icon.less';
+@import 'molecules/form-fields.less';
+@import 'molecules/search-hero.less';
+@import 'organisms/expandable-facets.less';
+@import 'organisms/tour.less';
+@import 'pages/activity-search.less';
+@import 'utilities/hide-on.less';


### PR DESCRIPTION
This pull request adds program selection and handling of program-specific salaries for graduate students (where data is available). 

## Additions/Changes
- A dropdown menu that appears when school data is available
- Content that appears when a program is selected, or when program data is unavailable
- Fix content for undergraduates with regards to salary figures
- Fix empty/short calls to the API

## How to test this PR
1. Pull down the PR and fire up `cfgov-refresh` locally.
2. Get the latest data loaded in there (`refresh-data.sh`)!
3. navigate to `localhost/paying-for-college/your-financial-path-to-graduation/`
4. Try out different graduate programs. Schools where we have program data (try George Washington University) should allow you to select a program and show a different salary than if you select undergrad. Schools with no program data should inform you of that.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentialy one or more of:

