### PR TITLE
Update isort to 5.x and reorder library imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -8,7 +8,6 @@ use_parentheses=1
 known_django=django,haystack
 known_wagtail=wagtail,wagtailsharing
 known_future_library=future
-known_standard_library=six
 known_first_party=
     agreements,
     alerts,

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,7 +3,6 @@ combine_as_imports=1
 lines_after_imports=2
 multi_line_output=5
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django,haystack
 known_wagtail=wagtail,wagtailsharing

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -782,8 +782,8 @@ class AnswerPageTestCase(TestCase):
         self.assertTrue(get_answer_preview(page).endswith("word word ..."))
 
     def test_english_page_context(self):
-        from v1.models.snippets import ReusableText
         from ask_cfpb.models.pages import get_reusable_text_snippet
+        from v1.models.snippets import ReusableText
 
         rt = ReusableText(title="About us (For consumers)")
         rt.save()

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -35,8 +35,8 @@ class AskSearchSafetyCase(unittest.TestCase):
 
 class AnswerPagePreviewCase(TestCase):
     def setUp(self):
-        from v1.models import HomePage
         from ask_cfpb.models import Answer
+        from v1.models import HomePage
 
         self.ROOT_PAGE = HomePage.objects.get(slug="cfgov")
         self.english_parent_page = get_or_create_page(

--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -9,11 +9,12 @@ from cfgov import urls
 
 
 try:
-    from django.urls import re_path, URLPattern, URLResolver
+    from django.urls import URLPattern, URLResolver, re_path
 except ImportError:
     from django.conf.urls import url as re_path
-    from django.core.urlresolvers import RegexURLPattern as URLPattern
-    from django.core.urlresolvers import RegexURLResolver as URLResolver
+    from django.core.urlresolvers import (
+        RegexURLPattern as URLPattern, RegexURLResolver as URLResolver
+    )
 
 
 # Allowlist is a list of *strings* that match the beginning of a regex string.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -40,11 +40,13 @@ from v1.views.documents import DocumentServeView
 
 
 try:
-    from flags.urls import flagged_re_path
     from django.urls import include, re_path
+
+    from flags.urls import flagged_re_path
 except ImportError:
-    from flags.urls import flagged_url as flagged_re_path
     from django.conf.urls import include, url as re_path
+
+    from flags.urls import flagged_url as flagged_re_path
 
 
 def flagged_wagtail_template_view(flag_name, template_name):

--- a/cfgov/core/tests/test_management_inactive_users.py
+++ b/cfgov/core/tests/test_management_inactive_users.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from datetime import timedelta
 from io import StringIO
 

--- a/cfgov/data_research/tests/management/commands/test_conference_export.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_export.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import tempfile
 
 from django.core.management import call_command

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import io
 from csv import DictReader as cdr
 

--- a/cfgov/paying_for_college/tests/test_load_programs.py
+++ b/cfgov/paying_for_college/tests/test_load_programs.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from unittest.mock import mock_open, patch
 
 import django

--- a/cfgov/paying_for_college/tests/test_models.py
+++ b/cfgov/paying_for_college/tests/test_models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf8 -*-
-
 import datetime
 import smtplib
 import unittest

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import re
 from datetime import date
 

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import datetime
 import json
 import unittest

--- a/cfgov/regulations3k/tests/test_resolver.py
+++ b/cfgov/regulations3k/tests/test_resolver.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import datetime
 
 from django.test import TestCase, override_settings

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -1,6 +1,5 @@
 import re
 
-# from django.http import Http404
 from django.shortcuts import redirect
 
 from dateutil import parser

--- a/cfgov/scripts/test_data.py
+++ b/cfgov/scripts/test_data.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import User
 from wagtail.core.blocks import StreamValue
 
 from scripts import _atomic_helpers as atomic
-
 from v1.models import (
     BlogPage, BrowseFilterablePage, BrowsePage, SublandingFilterablePage
 )

--- a/cfgov/scripts/tests/test_create_careers_pages.py
+++ b/cfgov/scripts/tests/test_create_careers_pages.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from wagtail.core.models import Page
 
 from scripts import create_careers_pages
-
 from v1.tests.wagtail_pages.helpers import save_page
 
 

--- a/cfgov/scripts/tests/test_export_enforcement_actions.py
+++ b/cfgov/scripts/tests/test_export_enforcement_actions.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 from wagtail.core.models import Page, Site
 
 from scripts.export_enforcement_actions import assemble_output
-
 from v1.models.learn_page import EnforcementActionPage
 from v1.tests.wagtail_pages.helpers import save_new_page
 from v1.util.migrations import set_stream_data

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -3,6 +3,7 @@ import unittest
 
 import mock
 import requests
+
 from scripts import static_asset_smoke_test
 from scripts.http_smoke_test import (
     ALLOWED_TIMEOUTS, FALLBACK_URLS, check_urls, get_full_list

--- a/cfgov/scripts/tests/test_unpublish_closed_jobs.py
+++ b/cfgov/scripts/tests/test_unpublish_closed_jobs.py
@@ -5,11 +5,11 @@ from django.test import TestCase
 
 import requests
 from mock import Mock, patch
-from scripts import unpublish_closed_jobs
 
 from jobmanager.models.django import ApplicantType, JobCategory
 from jobmanager.models.pages import JobListingPage
 from jobmanager.models.panels import USAJobsApplicationLink
+from scripts import unpublish_closed_jobs
 from v1.tests.wagtail_pages import helpers
 
 

--- a/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -7,7 +7,6 @@ from wagtail.tests.utils import WagtailPageTests
 
 import mock
 from model_bakery import baker
-from scripts import _atomic_helpers as atomic
 from teachers_digital_platform.models import (
     ActivityAgeRange, ActivityBloomsTaxonomyLevel, ActivityBuildingBlock,
     ActivityCouncilForEconEd, ActivityDuration, ActivityGradeLevel,
@@ -16,6 +15,7 @@ from teachers_digital_platform.models import (
     ActivityTeachingStrategy, ActivityTopic, ActivityType
 )
 
+from scripts import _atomic_helpers as atomic
 from v1.models import HomePage
 from v1.tests.wagtail_pages.helpers import publish_page
 

--- a/cfgov/v1/tests/atomic_elements/organisms/test_email_signup.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_email_signup.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
 from scripts import _atomic_helpers as atomic
-
 from v1.models import BlogPage, LearnPage, NewsroomPage, SublandingPage
 from v1.tests.wagtail_pages.helpers import publish_changes, publish_page
 from v1.util.migrations import set_stream_data

--- a/cfgov/v1/tests/atomic_elements/organisms/test_filterable_list.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_filterable_list.py
@@ -5,8 +5,8 @@ from django.test import TestCase
 from wagtail.core.blocks import StreamValue
 
 from pytz import timezone
-from scripts._atomic_helpers import filter_controls as controls
 
+from scripts._atomic_helpers import filter_controls as controls
 from v1.atomic_elements.organisms import FilterableList
 from v1.models import BlogPage, BrowseFilterablePage
 from v1.models.learn_page import AbstractFilterPage, EventPage

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -6,7 +6,6 @@ from wagtail.core.models import Site
 from wagtail.images.tests.utils import get_test_image_file
 
 from scripts import _atomic_helpers as atomic
-
 from v1.atomic_elements.organisms import (
     FeaturedContent, InfoUnitGroup, TableBlock, VideoPlayer
 )

--- a/cfgov/v1/tests/atomic_elements/test_molecules.py
+++ b/cfgov/v1/tests/atomic_elements/test_molecules.py
@@ -4,7 +4,6 @@ from django.test import SimpleTestCase, TestCase
 from wagtail.core.blocks import StreamValue
 
 from scripts import _atomic_helpers as atomic
-
 from v1.atomic_elements.molecules import (
     ContactEmail, ContactHyperlink, RSSFeed, TextIntroduction
 )

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -5,8 +5,8 @@ from django.test import Client, TestCase, override_settings
 from wagtail.core.blocks import StreamValue
 
 from mock import patch
-from scripts import _atomic_helpers as atomic
 
+from scripts import _atomic_helpers as atomic
 from v1.models.blog_page import BlogPage
 from v1.models.browse_filterable_page import BrowseFilterablePage
 from v1.tests.wagtail_pages.helpers import publish_page

--- a/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
+++ b/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 from wagtail.core.blocks import StreamValue
 
 from scripts import _atomic_helpers as atomic
-
 from v1.management.commands.update_chart_block_dates import get_inquiry_month
 from v1.models.browse_page import BrowsePage
 from v1.tests.wagtail_pages.helpers import publish_page

--- a/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
+++ b/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from wagtail.core.blocks import StreamValue
 
 from scripts import _atomic_helpers as atomic
-
 from v1.models.browse_page import BrowsePage
 from v1.tests.wagtail_pages.helpers import publish_page
 

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from unittest import skipIf
 
 from django.test import TestCase

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -4,8 +4,8 @@ from unittest import TestCase
 from wagtail.core.blocks import StreamValue
 
 import mock
-import scripts._atomic_helpers as atomic
 
+from scripts import _atomic_helpers as atomic
 from v1.models import AbstractFilterPage, BrowseFilterablePage, SublandingPage
 from v1.tests.wagtail_pages import helpers
 

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -28,7 +28,7 @@ def get_unique_id(prefix='', suffix=''):
 
 
 def instanceOfBrowseOrFilterablePages(page):
-    from ..models import BrowsePage, BrowseFilterablePage
+    from ..models import BrowseFilterablePage, BrowsePage
     pages = (BrowsePage, BrowseFilterablePage)
     return isinstance(page, pages)
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -18,9 +18,8 @@ from wagtail.contrib.modeladmin.options import (
 from wagtail.core import hooks
 from wagtail.core.whitelist import attribute_rule
 
-from scripts import export_enforcement_actions
-
 from ask_cfpb.models.snippets import GlossaryTerm
+from scripts import export_enforcement_actions
 from v1.admin_views import ExportFeedbackView, manage_cdn
 from v1.models.banners import Banner
 from v1.models.portal_topics import PortalCategory, PortalTopic

--- a/tox.ini
+++ b/tox.ini
@@ -77,10 +77,10 @@ commands=
 # To run Python linting.
 deps=
     flake8
-    isort == 4.3.21
+    isort
 commands=
     flake8
-    isort --check-only --diff --recursive cfgov
+    isort --check-only --diff cfgov
 
 
 [unittest-config]


### PR DESCRIPTION
isort 5 introduced breaking changes when released on July 4

Remove the deprecated not_skip configuration in `.isort.cfg`

Remove the deprecated --recursive flag from isort command in `tox.ini`

https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/

## How to test this PR

1. tox -e lint


## Checklist

_[Feel free to delete any checkboxes that are not applicable to this PR.]_

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentialy one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code documentation on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

_[When new or significantly modified front-end functionality is present, the following things should be tested. Feel free to delete this section if not applicable to this PR.]_

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

[Further guidance on browser support](https://github.com/cfpb/development/blob/master/guides/browser-support.md)

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
