### PR TITLE
Separate out check for missing migrations in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         toxenv:
           - lint-current
+          - validate-migrations
           - unittest-current
           - unittest-future
 
@@ -46,7 +47,6 @@ jobs:
           tox -e ${{ matrix.toxenv }}
         env: 
           TEST_RUNNER: cfgov.test.StdoutCapturingTestRunner 
-          CI_CHECK_MIGRATIONS: "./manage.py makemigrations --dry-run --check"
 
       - name: Prepare test coverage
         if: matrix.toxenv == 'unittest-current'

--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -65,6 +65,8 @@ These default environments are:
 
 - `lint`, which runs our [linting](#linting) tools. We require this
   environment to pass in CI.
+- `validate-migrations`, which checks for any missing Django migrations. 
+  We require this environment to pass in CI.
 - `unittest`, which runs unit tests against the current production
   versions of Python, Django, and Wagtail. We require this environment to
   pass in CI.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-{current}, unittest-{current,future}
+envlist=lint-{current}, validate-migrations, unittest-{current,future}
 
 
 [testenv]
@@ -225,3 +225,19 @@ setenv=
 commands=
     {toxinidir}/frontend.sh production
     {toxinidir}/cfgov/manage.py collectstatic --noinput
+
+
+[testenv:validate-migrations]
+# Invoke with: tox -e validate-migrations
+# Ensure that we're not missing any migations
+recreate=False
+envdir={toxworkdir}/unittest-current
+changedir={[unittest-config]changedir}
+basepython={[current-config]basepython}
+deps=-r{toxinidir}/requirements/base.txt
+setenv=
+    DJANGO_SETTINGS_MODULE=cfgov.settings.production
+    DJANGO_STATIC_ROOT={toxinidir}/collectstatic
+    ALLOWED_HOSTS=["*"]
+commands=
+    python manage.py makemigrations --dry-run --check


### PR DESCRIPTION
This change removes our custom env-var based migrations check that only occurs in CI and moves it to a separate tox env that can be invoked along side linting and unit testing. It also runs the migrations check only against the production settings, so it only catches apps that we use in production.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)