### PR TITLE
Mega Menu: Fix issue with updating menu state

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -75,7 +75,7 @@ function MegaMenuDesktop( baseClass, menus ) {
     this.dispatchEvent( 'triggerClick', { target: this } );
     const menu = event.target;
     if ( menu.isAnimating() ) { return; }
-    _updateMenuState( menu, event.type );
+    _updateMenuState( menu );
   }
 
   /**
@@ -112,21 +112,24 @@ function MegaMenuDesktop( baseClass, menus ) {
     // If we've clicked outside the parent of the current menu, close it.
     if ( !_firstLevelDom.contains( event.target ) ||
          event.target.parentNode.classList.contains( `${ baseClass }_content-1-list` ) ) {
-      _updateMenuState( null, event.type );
+      _updateMenuState( null );
     }
   }
 
   /**
    * Cleanup state and set the currently active menu.
    * @param {FlyoutMenu} menu - The menu currently being activated.
-   * @param {string} type - The event type that is calling this method.
    */
-  function _updateMenuState( menu, type ) {
+  function _updateMenuState( menu ) {
     if ( menu === null || _activeMenu === menu ) {
-      // A menu is closed.
-      _activeMenu.getTransition().animateOn();
-      _activeMenu.collapse();
-      _activeMenu = null;
+      // A menu is closed or the menu is suspended.
+
+      // If we've ever opened the menu, _activeMenu has to be cleared.
+      if ( _activeMenu ) {
+        _activeMenu.getTransition().animateOn();
+        _activeMenu.collapse();
+        _activeMenu = null;
+      }
 
       // Clean up listeners
       _bodyDom.removeEventListener( 'click', _handleBodyClick );


### PR DESCRIPTION
https://github.com/cfpb/cfgov-refresh/pull/5770 neglected the case where the user resized without ever opening a menu, which meant `_activeMenu` was null and was throwing an error when its state was updated. This PR adds logic to check that `_activeMenu` has a value before resetting its state.

Additionally, the new mega menu added in https://github.com/cfpb/cfgov-refresh/pull/5550 does not use `type` in the `_updateMenuState` method any more, so that parameter has been removed in this PR.

## Changes

- Checks `_activeMenu` value before resetting its state.
- Removes unused `type` parameter from `_updateMenuState` method.


## How to test this PR

1. Pull branch and build.
2. View the site at desktop size and resize to mobile without opening the menu. There should be no JS error (this will produce an error on production currently).
3. View the site at desktop size, click the menu, and resize to mobile. There should be no JS error.
