### PR TITLE
adjust update_colleges script for grad-program imports

### DIFF
--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -713,12 +713,6 @@ class Program(models.Model):
     def __str__(self):
         return "{} ({})".format(self.program_name, self.institution)
 
-    def get_level(self):
-        level = ''
-        if self.level and str(self.level) in HIGHEST_DEGREES:
-            level = HIGHEST_DEGREES[str(self.level)]
-        return level
-
     def as_json(self):
         ordered_out = OrderedDict()
         dict_out = {


### PR DESCRIPTION
In order to let Wagtail take over serving the paying-for-college
landing page, we need to remove the URL entry that sent PFC requests 
to comparisontool.

We need to retain three downstream comparisontool pages for now, so
this patch adds explicit URL entries for those pages.

## Testing
After checking out the branch, make sure these pages render properly:
- http://localhost:8000/paying-for-college/ should show the new wagtail landing page:

<img width="1262" alt="pfc_new" src="https://user-images.githubusercontent.com/515885/87368771-979c2300-c54c-11ea-8d8c-bf82fbe3e2c1.png">

These three pages should be unchanged, and show a header with pencils:
- http://localhost:8000/paying-for-college/repay-student-debt/
- http://localhost:8000/paying-for-college/choose-a-student-loan/
- http://localhost:8000/paying-for-college/manage-your-college-money/

<img width="1023" alt="pfc_old" src="https://user-images.githubusercontent.com/515885/87368783-a256b800-c54c-11ea-9639-7bb8e3b3d1a1.png">
