### PR TITLE
Remove the comparisontool URL include

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -269,7 +269,27 @@ urlpatterns = [
         'transcripts'),
         namespace='transcripts')),
 
-    re_path(r'^paying-for-college/', include('comparisontool.urls')),
+    re_path(
+        r'^paying-for-college/choose-a-student-loan/$',
+        TemplateView.as_view(
+            template_name='comparisontool/choose_a_loan.html'
+        ),
+        name='pfc-choose'
+    ),
+    re_path(
+        r'^paying-for-college/manage-your-college-money/$',
+        TemplateView.as_view(
+            template_name='comparisontool/manage_your_money.html'
+        ),
+        name='pfc-manage'
+    ),
+    re_path(
+        r'^paying-for-college/repay-student-debt/$',
+        TemplateView.as_view(
+            template_name='comparisontool/repay_student_debt.html'
+        ),
+        name='pfc-repay'
+    ),
 
     re_path(
         r'^paying-for-college2/',


### PR DESCRIPTION
In order to let Wagtail take over serving the paying-for-college
landing page, we need to remove the URL entry that sent PFC requests 
to comparisontool.

We need to retain three downstream comparisontool pages for now, so
this patch adds explicit URL entries for those pages.

## Testing
After checking out the branch, make sure these pages render properly:
- http://localhost:8000/paying-for-college/ should show the new wagtail landing page:

<img width="1262" alt="pfc_new" src="https://user-images.githubusercontent.com/515885/87368771-979c2300-c54c-11ea-8d8c-bf82fbe3e2c1.png">

These three pages should be unchanged, and show a hero with pencils:
- http://localhost:8000/paying-for-college/repay-student-debt/
- http://localhost:8000/paying-for-college/choose-a-student-loan/
- http://localhost:8000/paying-for-college/manage-your-college-money/

<img width="1023" alt="pfc_old" src="https://user-images.githubusercontent.com/515885/87368783-a256b800-c54c-11ea-9639-7bb8e3b3d1a1.png">
