### PR TITLE
Paying for College - Fix campaign tracking

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
@@ -28,6 +28,10 @@ const _urlParamsToModelVars = {
   'iqof': 'stateModel.impactOffer',
   'iqlo': 'stateModel.impactLoans',
 
+  'utm_source': 'stateModel.utmSource',
+  'utm_medium': 'stateModel.utm_medium',
+  'utm_campaign': 'stateModel.utm_campaign',
+
   'tuit': 'financialModel.dirCost_tuition',
   'hous': 'financialModel.dirCost_housing',
   'diro': 'financialModel.dirCost_other',

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
@@ -260,7 +260,6 @@ const financialModel = {
 
     updateState.byProperty( 'excessFunding',
       ( financialModel.values.total_excessFunding > 0 ).toString() );
-    console.log( 'ex', financialModel.values.total_excessFunding, ( financialModel.values.total_excessFunding > 0 ).toString() );
 
     updateState.byProperty( 'debtRuleViolation',
       ( financialModel.values.debt_totalAtGrad > financialModel.values.salary_annual ).toString() );

--- a/cfgov/unprocessed/apps/paying-for-college/js/util/url-parameter-utils.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/url-parameter-utils.js
@@ -51,6 +51,9 @@ function buildUrlQueryString() {
     'regs': stateValues.expensesRegion,
     'iqof': stateValues.impactOffer,
     'iqlo': stateValues.impactLoans,
+    'utm_source': stateValues.utmSource,
+    'utm_medium': stateValues.utm_medium,
+    'utm_campaign': stateValues.utm_campaign,
 
     'tuit': financialValues.dirCost_tuition,
     'hous': financialValues.dirCost_housing,


### PR DESCRIPTION
This is a small and quick fix. The url tracking parameters (things like ?utm_source=press%20release&utm_medium=email&utm_campaign=gradpath) are being overwritten by this app's URL rewrite code _before_ they go to analytics. This fix stores those values and puts them back into the URL.

## Additions
- Add url parameters to preserve so that campaign tracking works properly


## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

