### PR TITLE
Remove unused Django URL for KBYO page

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -360,11 +360,6 @@ urlpatterns = [
         template_name='jobmanager/technology-innovation-fellows.html'),
         name='technology_innovation_fellows'),
 
-    # credit cards KBYO
-
-    re_path(r'^credit-cards/knowbeforeyouowe/$', TemplateView.as_view(
-        template_name='knowbeforeyouowe/creditcards/tool.html'),
-        name='cckbyo'),
     # Form csrf token provider for JS form submission
     re_path(r'^token-provider/', token_provider, name='csrf-token-provider'),
 


### PR DESCRIPTION
The Django URLs have an entry for [/credit-cards/knowbeforeyouowe/](https://www.consumerfinance.gov/credit-cards/knowbeforeyouowe/), which renders a nonexistent tool.html template. This URL is already being handled by Apache redirects [here](https://github.com/cfpb/cfgov-refresh/blob/2c7440bc23c3c74bfd1f449b98128b79176fce0c/cfgov/apache/conf.d/redirects.conf#L521), which returns a permanent redirect to [/data-research/credit-card-data/know-you-owe-credit-cards/](https://www.consumerfinance.gov/data-research/credit-card-data/know-you-owe-credit-cards/). Thus, this URL can be removed from urls.py.

## How to test this PR

If you visit http://localhost:8000/credit-cards/knowbeforeyouowe/ using the Django dev server, it will 404, but that's okay. If you visit it using an Apache setup (like Docker), it should redirect properly.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)