### PR TITLE
Update crtool to 2.0.1

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -47,4 +47,4 @@ https://github.com/cfpb/retirement/releases/download/0.13.0/retirement-0.13.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.0/ccdb5_api-1.5.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.2.1/ccdb5_ui-2.2.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.1/comparisontool-1.15.1-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.0/crtool-2.0.0-py3-none-any.whl
+https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.1/crtool-2.0.1-py3-none-any.whl


### PR DESCRIPTION
2.0.1 fixes a lingering call to a now-missing, unnecessary JS file.


## Changes

- Upgrade curriculum-review-tool requirement to 2.0.1


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)