### PR TITLE
Pin cryptography temporarily to 2.9.2

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -2,6 +2,12 @@
 backports.csv==1.0.7
 beautifulsoup4==4.8.2
 boto3==1.7.80
+# Temporarily pin cryptography here. 
+# edgegrid-python has an open-ended dependency on PyOpenSSL, which in turn 
+# has an open-ended dependency on cryptography. cryptography 3.0 currently 
+# doesn't build in our build environment. This pins the last release that 
+# does until we can solve that problem.
+cryptography==2.9.2
 dj-database-url==0.5.0
 djangorestframework==3.9.1
 django-csp==3.4


### PR DESCRIPTION
This change temporarily pins cryptography to 2.9.2. Akamai's edgegrid-python has an open-ended dependency on PyOpenSSL, which in turn has an open-ended dependency on cryptography. cryptography 3.0 currently doesn't build in our build environment. This pins the last release that  does until we can solve that problem.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Future todos are captured in comments and/or tickets
