### PR TITLE
Restore push and cron triggers for GitHub code scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,12 @@
 name: "Code scanning - action"
 
 on:
+  push:
+    branches:
+      - 'master'
   pull_request:
+  schedule:
+    - cron: '0 7 * * *'
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
I think the lack of one or both of these may have been preventing results from being stored.

Currently, one of the code scanning checks on PRs is always erroring with messages like this:

![Missing analysis for base commit 847593d5f22a550b39ede65964661e88862b475a](https://user-images.githubusercontent.com/1044670/88098113-405b0b80-cb67-11ea-8805-bf2c726186a2.png)

My theory is that this is because there was no on-push trigger that caused a scan on the master branch after a PR is merged and no on-schedule trigger to create one on a regular basis otherwise.


## Additions

- Trigger to run code scans on pushes to master
- Trigger to run code scans nightly at 7 a.m. UTC


## How to test this PR

1. Merge it and see what happens!


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
