### PR TITLE
Adds the new FedRAMP-compliant APM collector endpoint

### DIFF
--- a/cfgov/newrelic.ini
+++ b/cfgov/newrelic.ini
@@ -304,3 +304,6 @@ transaction_events.enabled = true
 # then no attributes will be sent to transaction events regardless on how
 # this configuration setting (transaction_events.attributes.enabled) is set.
 transaction_events.attributes.enabled = true
+
+# This is the FedRAMP-compliant collector endpoint
+host = gov-collector.newrelic.com


### PR DESCRIPTION
This is documented at https://docs.newrelic.com/docs/fedramp-compliant-endpoints

APPOPS-994

We are required to use the FedRAMP endpoints for all New Relic connectivity
