### PR TITLE
Update library requirements post-TDP rename

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -14,11 +14,8 @@ django-csp==3.4
 django-extensions==2.1.3
 django-flags==4.2.4
 django-haystack==2.8.1
-# django-js-asset is required by teachers-digital-platform
-django-js-asset==1.1.0
 # django-localflavor is required by django-college-costs-comparison
 django-localflavor==2.2
-# django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-storages==1.7.1
 django-treebeard==4.2.0


### PR DESCRIPTION
1. Now that the teachers_digital_platform app has been moved into this repo, the django-mptt package is now [required by cfgov-refresh](https://github.com/cfpb/cfgov-refresh/search?q=mptt&unscoped_q=mptt).
2. The django-js-asset package is no longer needed by TDP (now renamed to [curriculum-review-tool](https://github.com/cfpb/curriculum-review-tool)), so this entry can be removed. See https://github.com/cfpb/curriculum-review-tool/pull/399.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)