### PR TITLE
Import get_document_model from its new location in Wagtail 2.8+

### DIFF
--- a/cfgov/scripts/fix_links_in_tableblocks.py
+++ b/cfgov/scripts/fix_links_in_tableblocks.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404
 
 from wagtail.core.models import Page
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 
 from bs4 import BeautifulSoup
 

--- a/cfgov/v1/tests/views/test_documents.py
+++ b/cfgov/v1/tests/views/test_documents.py
@@ -3,7 +3,7 @@ from django.http import Http404, StreamingHttpResponse
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import resolve, reverse
 
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 
 from v1.views.documents import DocumentServeView
 

--- a/cfgov/v1/views/documents.py
+++ b/cfgov/v1/views/documents.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import View
 
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 from wagtail.documents.views.serve import serve as wagtail_serve
 
 


### PR DESCRIPTION
[`get_document_model` moved in Wagtail 2.8](https://docs.wagtail.io/en/latest/releases/2.8.html#wagtail-documents-models-get-document-model-has-moved) from `wagtail.documents.models` to `wagtail.documents`, and importing it from `wagtail.documents.models` is deprecated and will be removed in Wagail 2.10 

I've changed all the places where we import it from the deprecated location.

This will fix warnings like:

```
 RemovedInWagtail210Warning: wagtail.documents.models.get_document_model has been moved to wagtail.documents.get_document_model 
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
