### PR TITLE
Change Cypress Default Command Timeout to 25s

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,5 @@
     "pluginsFile": "test/cypress/plugins",
     "supportFile": "test/cypress/support",
     "componentFolder": "test/cypress/component",
-    "defaultCommandTimeout": 15000
+    "defaultCommandTimeout": 25000
 }


### PR DESCRIPTION
Alters the default command timeout for Cypress from 15s to 25s. This will alleviate potential failures due to long searches


---


## Changes

- Default Command Timeout from 15s to 25s.


## How to test this PR

1. Run Cypress Tests


## Checklist

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance