### PR TITLE
Validate our static assets in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,6 +12,7 @@ jobs:
         toxenv:
           - lint-current
           - validate-migrations
+          - validate-assets
           - unittest-current
           - unittest-future
 

--- a/frontend.sh
+++ b/frontend.sh
@@ -89,7 +89,7 @@ fake_fonts() {
 
     # 1. Use grep to find all .woff and .woff2 files referenced in CSS files.
     # 2. Reduce these to a list of unique webfont filenames.
-    # 3. Touch each filename in static.in/0/fonts, causing it to be created as
+    # 3. Touch each filename in static.in/fake-fonts/fonts, causing it to be created as
     # an empty file if it doesn't exist already.
     grep -Eho \
         '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}.woff2?' \

--- a/frontend.sh
+++ b/frontend.sh
@@ -63,11 +63,42 @@ install() {
   fi
 }
 
-
 # Run tasks to build the project for distribution.
 build() {
   echo "Building project…"
   yarn run gulp build
+}
+
+# Fake our font files, if necessary, in public CI
+fake_fonts() {
+  if [ ! -d static.in/cfgov-fonts/fonts ]; then
+    echo "Faking font files…"
+    # We want to test Django collectstatic, but we might not have our webfont 
+    # files if this script is running somewhere public. Because cfgov-refresh
+    # uses the Django ManifestStaticFilesStorage backend, the collectstatic 
+    # command will fail if any referenced files are missing.
+    #
+    # Builds generated with webfont files place them in a static.in/0/fonts
+    # subdirectory. Builds generated without these files don't have this 
+    # directory.
+    #
+    # If we don't have the webfont files, we create empty files with the same 
+    # name to allow collectstatic to run successfully. If the files already 
+    # exist, these commands do nothing.
+    mkdir -p static.in/fake-fonts/fonts
+
+    # 1. Use grep to find all .woff and .woff2 files referenced in CSS files.
+    # 2. Reduce these to a list of unique webfont filenames.
+    # 3. Touch each filename in static.in/0/fonts, causing it to be created as
+    # an empty file if it doesn't exist already.
+    grep -Eho \
+        '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}.woff2?' \
+        cfgov/static_built/css/*.css \
+        | sort \
+        | uniq \
+        | sed 's|^|static.in/fake-fonts/fonts/|' \
+        | xargs touch
+  fi
 }
 
 # Execute requested (or all) functions.
@@ -76,6 +107,11 @@ if [ "$1" == "init" ]; then
   install
 elif [ "$1" == "build" ]; then
   build
+elif [ "$1" == "ci" ]; then
+  init "production"
+  install
+  build
+  fake_fonts
 else
   init "$1"
   install

--- a/tox.ini
+++ b/tox.ini
@@ -223,7 +223,7 @@ setenv=
     DJANGO_STATIC_ROOT={toxinidir}/collectstatic
     ALLOWED_HOSTS=["*"]
 commands=
-    {toxinidir}/frontend.sh production
+    {toxinidir}/frontend.sh ci
     {toxinidir}/cfgov/manage.py collectstatic --noinput
 
 


### PR DESCRIPTION
We've had a `validate-assets` tox environment for ages that collects our assets and then runs Django's `collectstatic` on them. Because we use `ManifestStaticFileStorage` in production, if static assets are missing, this `collectstatic` will fail.

Because our webfonts are not public, we have not been able to run this in CI.  I've pulled in [a workaround for this] (https://github.com/cfpb/cfgov-refresh/pull/5110/files#diff-300249821afbbfcb945e6fbe141d0bb8R32-R55) created by @chosak in another context in #5110.

I think the `frontend.sh` file is right place for this to live, but I'm open to moving it.

This PR is in draft so we can see it run.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)