### PR TITLE
Fix clipped tooltips in the rate explorer

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -155,6 +155,7 @@
 
     // this is shameful, but this is needed to force
     // highcharts to display overflowing tooltips
+    .chart-area,
     .highcharts-container {
         overflow: visible !important;
     }


### PR DESCRIPTION
Somewhere in some update it looks like Highcharts started adding `overflow: hidden` to the top-level chart container in addition to the Highcharts-specific container. That caused tooltips and chart labels that ran over the bounds of the chart to get clipped. This change fixes that.

See GHE/CFGOV/platform/issues/3603 for more info.

## Additions

- Added the `.chart-area` container to the `overflow: visible !important` rule

## How to test this PR

1. In production, check rates for a state that has a rate bar with nine or 10 results. (With the current data, Illinois has a bar with 10 results.) Note how some or all of the tooltip for those bars is clipped and all of the label for bars with 10 results is clipped.
2. Check the same rates locally in this branch and confirm that the tooltip and bar labels are fully visible for tall bars.

## Screenshots

Production | This PR
---- | ----
![production](https://user-images.githubusercontent.com/1862695/88416194-c799c080-cdad-11ea-8e8d-f6dfb1e72470.png) | ![pr](https://user-images.githubusercontent.com/1862695/88416204-cbc5de00-cdad-11ea-9a8a-60a475a26745.png)

## Notes and todos

- There are probably other ways to keep the tooltip and label from being clipped, but since we already had an `overflow: visible !important` rule that looks like it was doing the same thing previously, I just added the top-level container there.
- I also noticed that the "download chart" button sits on top of any tooltips that would overlay that button. That looks like it's always been the case, though, and doesn't have a super easy solution (z-indexes are hard!), so I'm leaving that as a separate issue to fix later.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets

### Front-end testing

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens