### PR TITLE
Research Reports Appendix Level Two

### DIFF
--- a/cfgov/research_reports/jinja2/index.html
+++ b/cfgov/research_reports/jinja2/index.html
@@ -24,14 +24,14 @@
 {% set researchers = get_researchers() %}
 
 
-{% macro report_part(sections) %}
+{% macro report_part(sections, is_appendix) %}
   {% for section in sections -%}
     <h3 class="report-header">
       <a
         style="color:black;"
         id="{{section.url[1:]}}"
         href="{{section.url}}">
-          {{section.numbering + section.title}}
+          {{('Appendix ' if is_appendix else '') + section.numbering + section.title}}
       </a>
     </h3>
 
@@ -74,7 +74,7 @@
     {{report_part(report_sections)}}
 
     <h2>Appendices</h2>
-    {{report_part(report_appendices)}}
+    {{report_part(report_appendices, True)}}
 
     <div class="block block__flush-top">
       {{ page.footnotes | safe }}

--- a/cfgov/research_reports/models.py
+++ b/cfgov/research_reports/models.py
@@ -38,12 +38,12 @@ def get_report_parts(is_appendix=False):
             'title': section.header,
             'body': section.body,
             'url': format('#section-{}', i),
-            'numbering': format('{}. ', i),
+            'numbering': format('{}: ' if is_appendix else '{}. ', i),
             'children': [{
                 'title': subsection.sub_header,
                 'body': subsection.sub_body,
                 'url': format('#section-{}.{}', i, j),
-                'numbering': format('{}.{}. ', i, j)
+                'numbering': '' if is_appendix else format('{}.{} ', i, j)
             } for j, subsection in enumerate(
                 section.report_subsections.all().order_by('pk')
             )]


### PR DESCRIPTION
PR against `reports-as-webpages` branch

Adjusts research report appendix labelling according to GHE/CFPB/super-regular/issues/57

<img width="284" alt="Screen Shot 2020-07-24 at 12 53 48 PM" src="https://user-images.githubusercontent.com/1558033/88430208-e481c400-cdac-11ea-8a77-0e81a23f67cd.png">

All linking between the ToC and headers should still function appropriately.