### PR TITLE
Turn autocomplete off on multiselect's typeahead input

### DIFF
--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -149,12 +149,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     } );
 
     _searchDom = create( 'input', {
-      className:      BASE_CLASS + '_search ' + TEXT_INPUT_CLASS,
-      type:           'text',
-      placeholder:    _placeholder || 'Choose up to five',
-      inside:         _headerDom,
-      id:             _name,
-      'autocomplete': 'off'
+      className:    BASE_CLASS + '_search ' + TEXT_INPUT_CLASS,
+      type:         'text',
+      placeholder:  _placeholder || 'Choose up to five',
+      inside:       _headerDom,
+      id:           _name,
+      autocomplete: 'off'
     } );
 
     _fieldsetDom = create( 'fieldset', {

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -149,11 +149,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     } );
 
     _searchDom = create( 'input', {
-      className:   BASE_CLASS + '_search ' + TEXT_INPUT_CLASS,
-      type:        'text',
-      placeholder: _placeholder || 'Choose up to five',
-      inside:      _headerDom,
-      id:          _name
+      className:      BASE_CLASS + '_search ' + TEXT_INPUT_CLASS,
+      type:           'text',
+      placeholder:    _placeholder || 'Choose up to five',
+      inside:         _headerDom,
+      id:             _name,
+      'autocomplete': 'off'
     } );
 
     _fieldsetDom = create( 'fieldset', {


### PR DESCRIPTION
Right now, there's no autocomplete attribute set on the multiselect's typeahead text input, which means that a browser's autocomplete interface can pop up and obscure the multiselect checkboxes until you dismiss the autocomplete suggestions. Since the multiselect's text input is meant as a typeahead way to filter the options to find what you're looking for, turning the autocomplete off doesn't take away from the intent of that field.

See GHE/CFGOV/platform/issues/3568 for more details.

---

## Additions

- `autocomplete="off"` attribute to the multiselect's typeahead text input

## How to test this PR

1. In production (or locally on the main branch), visit a page with a multiselect. Any filterable list page with the topics field will do (the blog landing page, for example).
2. Enter a term in the multiselect text input but don't check any of the suggested items in the multiselect's checklist interface, and submit the form (hit "apply filters").
3. Refresh the page or visit another page with the same kind of multiselect.
4. Focus in the multiselect and note that the browser's autocomplete UI appears on top of the multiselect's checklist UI.
5. Repeat the same steps in this branch and make sure the autocomplete UI no longer pops up when focusing in the typeahead field.

## Screenshots

Production | This PR
---- | ----
![production](https://user-images.githubusercontent.com/1862695/88594016-78ae8e00-d02e-11ea-9afc-9ae954dbb213.png) | ![pr](https://user-images.githubusercontent.com/1862695/88594022-7c421500-d02e-11ea-84f9-460031fafaa0.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)