### PR TITLE
Link Spanish pages to Spanish social media

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -63,6 +63,7 @@
 {% set linkedin_title = ( value.linkedin_title or blurb ) | urlencode %}
 {% set linkedin_text = ( value.linkedin_text or '' ) | urlencode %}
 {% set twitter_text = ( value.twitter_text or blurb ) | urlencode %}
+{% set language = language | default( 'en' ) %}
 
 <div class="m-social-media
             m-social-media__{{ 'share' if is_share_view else 'follow' }}">
@@ -88,16 +89,18 @@
                m-list__horizontal
                m-social-media_icons">
 
+        {% set facebook_account = 'CFPBespanol' if language == 'es' else 'cfpb' %}
         {% set facebook_info = {
             'name': 'Facebook',
-            'homepage': unsigned_redirect('https://facebook.com/cfpb'),
+            'homepage': unsigned_redirect('https://facebook.com/' ~ facebook_account),
             'share_url': signed_redirect('https://www.facebook.com/dialog/share?app_id=210516218981921&display=page&href=' ~ parsed_url ~ '&redirect_uri=' ~ parsed_url),
             'icon': 'facebook'
         } %}
 
+        {% set twitter_account = 'CFPBespanol' if language == 'es' else 'cfpb' %}
         {% set twitter_info = {
             'name': 'Twitter',
-            'homepage': unsigned_redirect('https://twitter.com/cfpb'),
+            'homepage': unsigned_redirect('https://twitter.com/' ~ twitter_account),
             'share_url': signed_redirect(_share_twitter_url(parsed_url, twitter_text, value)|trim),
             'icon': 'twitter'
         } %}


### PR DESCRIPTION
When used in its non-sharing configuration, our social media molecule links to the Bureau's English Facebook (cfpb) and Twitter (cfpb) accounts. On Spanish pages, these links should go to the appropriate Spanish Facebook (CFPBespanol) and Twitter (CFPBespanol) accounts.

We always import this social-media template `with context` so it should have the proper `language` variable set.

## How to test this PR

To test, run a local server and visit these pages, and observe the links in the footer. These should be English:

- http://localhost:8000/
- http://localhost:8000/about-us/blog/receive-your-unemployment-benefits-options/

And these will be Spanish:

- http://localhost:8000/es/
- http://localhost:8000/about-us/blog/opciones-recibir-beneficios-desempleo/

## Notes and todos

There's some additional potential work to be done here when the social media molecule is used for sharing, for example around the default text, but that is not covered here.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets