### PR TITLE
Bump Jinja2 version from 2.10.1 to 2.11.2

### DIFF
--- a/cfgov/v1/jinja2_environment.py
+++ b/cfgov/v1/jinja2_environment.py
@@ -1,5 +1,6 @@
 import os.path
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.template.defaultfilters import linebreaksbr, pluralize, slugify
@@ -61,6 +62,32 @@ class JinjaTranslations(object):
 
 
 def environment(**options):
+    # If running Django in debug mode, enable the Jinja2 {% debug %} tag.
+    # We do this here instead of in settings because DEBUG's value may be
+    # not be set until after the default Jinja configuration is defined.
+    #
+    # https://jinja.palletsprojects.com/en/2.11.x/extensions/#debug-extension
+    #
+    # Use of the {% debug %} tag when this extension isn't installed (when
+    # DEBUG is False) will trigger a 500 error with a
+    # jinja2.exceptions.TemplateSyntaxError. In theory we should never be using
+    # this tag for pages in production, but, if we did, we wouldn't want to
+    # accidentally expose debug information, so this seems like sensible
+    # behavior.
+    #
+    # It might be better if {% debug %} would instead work as a no-op and print
+    # nothing in the DEBUG=False case, but that would require writing our own
+    # custom tag. Relatedly, the Django template language's {% debug %} tag is
+    # always defined and always renders debug information regardless of the
+    # value of settings.DEBUG:
+    #
+    # https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#debug
+    if settings.DEBUG:
+        extensions = options.setdefault('extensions', [])
+        debug_extension = 'jinja2.ext.debug'
+        if debug_extension not in extensions:
+            extensions.append(debug_extension)
+
     env = RelativeTemplatePathEnvironment(**options)
     env.autoescape = True
 

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -23,7 +23,7 @@ django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 govdelivery==1.3
-Jinja2==2.10.1
+Jinja2==2.11.2
 jsonfield==2.0.2
 lxml==4.2.5
 Markdown==3.2.1


### PR DESCRIPTION
This change bumps the version of the Jinja2 package we use from 2.10.2 to 2.11.2, released on 4/13/2020.

See changelog here: https://jinja.palletsprojects.com/en/2.11.x/changelog/

There are various changes; the one in particular motivating me to make this change is the addition of the `{% debug %}` tag which makes it easier to debug template context. Use of this tag prints out a bunch of template debugger context as a JSON blob:

https://jinja.palletsprojects.com/en/2.11.x/extensions/#debug-extension

Because we don't want to accidentally do this in production, I've set this up so that this extension only gets turned on when DEBUG is True. See the code comment for a little more detail.

Another nice change in this release is greater flexibility around using logic like


`{{ 'foo' if bar }}`

instead of

`{{ 'foo' if  bar else '' }}`

## How to test this PR

All tests pass with this change.

To see how `{% debug %}` works, try sticking into some Jinja template, and see the output when running the server with `settings.DEBUG=True`. Try setting `DEBUG=False`, e.g. by manually editing [this line](https://github.com/cfpb/cfgov-refresh/blob/d48b4a5af6e928bf35fe982f7eeb96793c497e46/cfgov/cfgov/settings/local.py#L20), and notice that trying to use the tag deliberately causes a 500 error.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets