### PR TITLE
Aligns ToC with eyebrow, fixes ToC indent and report body header priority

### DIFF
--- a/cfgov/research_reports/jinja2/index.html
+++ b/cfgov/research_reports/jinja2/index.html
@@ -26,26 +26,26 @@
 
 {% macro report_part(sections, is_appendix) %}
   {% for section in sections -%}
-    <h3 class="report-header">
+    <h2 class="report-header">
       <a
         style="color:black;"
         id="{{section.url[1:]}}"
         href="{{section.url}}">
           {{('Appendix ' if is_appendix else '') + section.numbering + section.title}}
       </a>
-    </h3>
+    </h2>
 
     {{ section.body | safe }}
 
     {% for subsection in section.children -%}
-      <h4 class="report-header">
+      <h3 class="report-header">
         <a
           style="color:black;"
           id="{{subsection.url[1:]}}"
           href="{{subsection.url}}">
             {{subsection.numbering + subsection.title}}
         </a>
-      </h4>
+      </h3>
 
       {{ subsection.body | safe}}
     {%- endfor %}
@@ -73,7 +73,7 @@
 
     {{report_part(report_sections)}}
 
-    <h2>Appendices</h2>
+    <h2 class="appendix-header">Appendices</h2>
     {{report_part(report_appendices, True)}}
 
     <div class="block block__flush-top">

--- a/cfgov/unprocessed/apps/research-reports/css/main.less
+++ b/cfgov/unprocessed/apps/research-reports/css/main.less
@@ -5,6 +5,10 @@
     margin: 30px 0 30px 0;
   }
 
+  .appendix-header {
+    margin: 0.83em 0;
+  }
+
 }
 
 .o-report-sidenav {
@@ -16,13 +20,9 @@
   display: block;
   overflow-y: scroll;
   height: 100%;
-  h3 {
-    margin-top: 0.25em;
-  }
   & > ul {
     a {
-      text-indent: -1.1em;
-      padding-left: 2em;
+      padding-left: 0.75em;
     }
   }
   .m-nav-link.current-section {

--- a/cfgov/unprocessed/apps/research-reports/js/index.js
+++ b/cfgov/unprocessed/apps/research-reports/js/index.js
@@ -9,14 +9,14 @@ const top = sidenav.offsetTop;
 const headerOffset = 224
 const headers = document.querySelectorAll( '.content_main .report-header' )
 let offsets = [];
-let offsetIsH3 = [];
+let primaryOffsets = [];
 let set = 0;
 let lastTargetIndex;
 
 (function(){
   for(let i=0; i<headers.length; i++){
     offsets.push(headers[i].offsetTop + headerOffset)
-    offsetIsH3.push(headers[i].tagName === 'H3')
+    primaryOffsets.push(headers[i].tagName === 'H2')
   }
 })();
 
@@ -38,7 +38,7 @@ function stickIfNeeded() {
 
 function getParentHeader(index){
   for(let i=index; i>=0; i--){
-    if(offsetIsH3[i]) return tocHeaders[i].parentNode
+    if(primaryOffsets[i]) return tocHeaders[i].parentNode
   }
 }
 


### PR DESCRIPTION
PR against reports-as-webpages branch

Closes:
GHE/CFPB/super-regular/issues/108
GHE/CFPB/super-regular/issues/109
GHE/CFPB/super-regular/issues/119
GHE/CFPB/super-regular/issues/120

(switches headers to h2/h3 instead if h3/h4 for the former two, and compare the screenshots in the latter two issues with the attached one)
<img width="537" alt="Screen Shot 2020-07-28 at 5 16 00 PM" src="https://user-images.githubusercontent.com/1558033/88742091-1751f200-d0f6-11ea-90ae-f96e54b8bef3.png">

