### PR TITLE
Reports as Webpages: Connect Jenkins API

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -210,6 +210,16 @@ export WATCHMAN_TOKENS=''
 #export NEW_RELIC_LICENSE_KEY=<new relic license key>
 #export NEW_RELIC_APP_NAME="cf.gov <your username here> python"
 
+###############################################################
+# Jenkins API (optional) - Used for processing research reports
+###############################################################
+
+#export JENKINS_API_ENABLED=True
+#export JENKINS_API_URL=<jenkins_api_url>
+#export JENKINS_API_USER=<jenkins_api_username>
+#export JENKINS_API_TOKEN=<jenkins_api_token>
+#export RESEARCH_REPORT_JENKINS_JOB='cf.gov-parse-research-report'
+
 ###############################################
 # Project configuration - set up working state.
 ###############################################

--- a/cfgov/research_reports/management/commands/parse_research_report.py
+++ b/cfgov/research_reports/management/commands/parse_research_report.py
@@ -1,5 +1,6 @@
 import re
 
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
 import pypandoc
@@ -22,6 +23,17 @@ def document_as_beautifulsoup(report_page):
     print(" *** converting the report to html... ***")
     output = pypandoc.convert_text(raw_report, format='docx', to='html')
     return BeautifulSoup(output, 'html.parser')
+
+
+def save_page(report_page):
+    print(" *** saving the page... ***")
+    report_page.process_report = False
+    try:
+        bot_user = User.objects.get(username='bot.user')
+    except User.DoesNotExist:
+        bot_user = None
+    report_page.save_revision(user=bot_user)
+    report_page.save()
 
 
 def targeted_string(target, soup):
@@ -59,10 +71,7 @@ def run(report_page):
     # Footnotes
     report_page.footnotes = footnotes(soup)
 
-    print(" *** saving the page... ***")
-    report_page.process_report = False
-    report_page.save_revision()  # future: add user= keyword
-    report_page.save()
+    save_page(report_page)
 
 
 # To invoke this command from the cfgov-refresh root:

--- a/cfgov/research_reports/management/commands/parse_research_report.py
+++ b/cfgov/research_reports/management/commands/parse_research_report.py
@@ -1,6 +1,6 @@
 import re
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
 import pypandoc
@@ -28,6 +28,7 @@ def document_as_beautifulsoup(report_page):
 def save_page(report_page):
     print(" *** saving the page... ***")
     report_page.process_report = False
+    User = get_user_model()
     try:
         bot_user = User.objects.get(username='bot.user')
     except User.DoesNotExist:

--- a/cfgov/research_reports/management/commands/trigger_jenkins_build.py
+++ b/cfgov/research_reports/management/commands/trigger_jenkins_build.py
@@ -1,0 +1,35 @@
+import os
+
+from django.core.management.base import BaseCommand
+
+import requests
+
+
+# To invoke this command from the cfgov-refresh root:
+#     cfgov/manage.py trigger_jenkins_build [report_page_id]
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('report_page_id', type=int)
+
+    def handle(self, *args, **options):
+        report_id = options['report_page_id']
+
+        jenkins_address = os.environ.get('JENKINS_API_URL')
+        jenkins_user = os.environ.get('JENKINS_API_USER')
+        jenkins_token = os.environ.get('JENKINS_API_TOKEN')
+        job_name = os.environ.get('RESEARCH_REPORT_JENKINS_JOB')
+
+        with requests.Session() as s:
+            # Two-step authentication process. Step 1: Request crumb
+            s.auth = (jenkins_user, jenkins_token)
+            initial_request = f'{jenkins_address}/crumbIssuer/api/json'
+            crumb_response = s.get(initial_request).json()
+
+            # Step 2: Use crumb to make the API request
+            crumb_header = crumb_response['crumbRequestField']
+            crumb_value = crumb_response['crumb']
+            s.post(
+                f'{jenkins_address}/job/{job_name}/buildWithParameters',
+                headers={crumb_header: crumb_value},
+                data={'REPORT_PAGE_ID': report_id}
+            )

--- a/cfgov/research_reports/models.py
+++ b/cfgov/research_reports/models.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.core import management
 from django.db import models
@@ -188,14 +190,9 @@ class ResearchReportPage(CFGOVPage):
     def parse_report_file(self):
         if self.report_file and self.process_report:
             deploy_env = _get_deploy_environment()
-            if deploy_env == "build":
-                # TODO: trigger the jenkins job on Zusa
-                pass
-            elif deploy_env == "production":
-                # TODO: trigger the jenkins job on EXT Jenkins
-                pass
-            elif deploy_env == 'local' or deploy_env.find('dev') >= 0:
-                # if running locally or on a DEV server, run command locally
+            if os.environ.get("JENKINS_API_ENABLED"):
+                management.call_command('trigger_jenkins_build', self.id)
+            elif deploy_env == 'local':
                 management.call_command('parse_research_report', self.id)
             else:
                 # deployed to another environment where s3 isn't configured


### PR DESCRIPTION
🚧  This is a Reports as Webpages PR, not going into cfgov-refresh yet 🚧 

---

Two changes here:

1. On Build and Production, use the Jenkins API to trigger the report processing job remotely
    - I've opened a PR to our ansible repo to supply values for the given environment variables in the Build and Production envs.
    - Unfortunately there's not a good way to locally test this change. I tested by using my personal Jenkins credentials and setting `RESEARCH_REPORT_JENKINS_JOB` to a test job I put up on our test jenkins server. 
    - Once this branch is merged in to the main branch and deployed to Build, it'll be testable there.

2. When saving the draft of a report, associate a user with the revision, to make revision history more understandable. Previously the associated user was `None`.
    - You can test this change by running the report processing locally and seeing that the revision created by the process is called `bot.user`.