### PR TITLE
Deprecate signed_redirect, unsigned_redirect tags

### DIFF
--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -3,16 +3,14 @@ from jinja2.ext import Extension
 
 from core.templatetags.richtext import richtext_isempty
 from core.templatetags.svg_icon import svg_icon
-from core.utils import signed_redirect, slugify_unique, unsigned_redirect
+from core.utils import slugify_unique
 
 
 class CoreExtension(Extension):
     def __init__(self, environment):
         super(CoreExtension, self).__init__(environment)
         self.environment.globals.update({
-            'signed_redirect': signed_redirect,
             'svg_icon': svg_icon,
-            'unsigned_redirect': unsigned_redirect,
         })
 
         self.environment.filters.update({

--- a/cfgov/core/templatetags/signed_redirect.py
+++ b/cfgov/core/templatetags/signed_redirect.py
@@ -2,16 +2,8 @@ from django import template
 from django.template.defaultfilters import stringfilter
 from django.utils.html import urlize
 
-from core.utils import signed_redirect as signed_redirect_fn
-
 
 register = template.Library()
-
-
-@register.filter
-@stringfilter
-def signed_redirect(url):
-    return signed_redirect_fn(url)
 
 
 @register.filter

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -72,11 +72,6 @@ def signed_redirect(url):
     return ("{0}?{1}".format(reverse("external-site"), urlencode(query_args)))
 
 
-def unsigned_redirect(url):
-    query_args = {'ext_url': url}
-    return ("{0}?{1}".format(reverse("external-site"), urlencode(query_args)))
-
-
 def extract_answers_from_request(request):
     answers = [(param.split('_')[1], value) for param, value in
                request.POST.items() if param.startswith('questionid')]

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -66,7 +66,7 @@
                             several approved agencies in your area.
                             There is also a
                             <a class="a-link a-link__icon"
-                               href="{{ signed_redirect( 'https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm' ) }}">
+                               href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm">
                                 <span class="a-link_text">list of nationwide HUD-approved counseling agencies</span>
                                 {{ svg_icon( 'external-link' ) }}</a>.
                         </p>
@@ -122,7 +122,7 @@
                                                 <p>
                                                     This tool is powered by
                                                     <a class="a-link a-link__icon"
-                                                       href="{{ signed_redirect( 'https://data.hud.gov/housing_counseling.html' ) }}">
+                                                       href="https://data.hud.gov/housing_counseling.html">
                                                         <span class="a-link_text">HUD's</span>
                                                         {{ svg_icon( 'external-link' ) }}</a>
                                                     official list of housing counselors.
@@ -215,7 +215,7 @@
 
                                                     {% if counselor.weburl %}
                                                     <a class="a-link a-link__icon"
-                                                       href="{{ signed_redirect( counselor.weburl ) }}">
+                                                       href="{{ counselor.weburl }}">
                                                         <span class="a-link_text"><b itemprop="name">{{ counselor.nme }}</b></span>
                                                         {{ svg_icon( 'external-link' ) }}
                                                     </a>
@@ -242,7 +242,7 @@
                                                     <dt>Website:</dt>
                                                     <dd>
                                                     <a class="a-link a-link__icon"
-                                                       href="{{ signed_redirect( counselor.weburl ) }}"
+                                                       href="{{ counselor.weburl }}"
                                                        itemprop="url">
                                                         <span class="a-link_text">{{ counselor.weburl }}</span>
                                                         {{ svg_icon( 'external-link' ) }}
@@ -318,7 +318,7 @@
                                     number. The OMB control number for this
                                     collection is
                                     <a class="a-link a-link__icon"
-                                       href="{{ signed_redirect( 'https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025' ) }}">
+                                       href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025">
                                         <span class="a-link_text" aria-label="The OMB control number for this collection is 3170-0025">3170-0025</span>
                                         {{ svg_icon( 'external-link' ) }}</a>.
                                     It expires on 04/30/2016. Using this tool

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -92,23 +92,23 @@
         {% set facebook_account = 'CFPBespanol' if language == 'es' else 'cfpb' %}
         {% set facebook_info = {
             'name': 'Facebook',
-            'homepage': unsigned_redirect('https://facebook.com/' ~ facebook_account),
-            'share_url': signed_redirect('https://www.facebook.com/dialog/share?app_id=210516218981921&display=page&href=' ~ parsed_url ~ '&redirect_uri=' ~ parsed_url),
+            'homepage': 'https://facebook.com/' ~ facebook_account,
+            'share_url': 'https://www.facebook.com/dialog/share?app_id=210516218981921&display=page&href=' ~ parsed_url ~ '&redirect_uri=' ~ parsed_url,
             'icon': 'facebook'
         } %}
 
         {% set twitter_account = 'CFPBespanol' if language == 'es' else 'cfpb' %}
         {% set twitter_info = {
             'name': 'Twitter',
-            'homepage': unsigned_redirect('https://twitter.com/' ~ twitter_account),
-            'share_url': signed_redirect(_share_twitter_url(parsed_url, twitter_text, value)|trim),
+            'homepage': 'https://twitter.com/' ~ twitter_account,
+            'share_url': _share_twitter_url(parsed_url, twitter_text, value) | trim,
             'icon': 'twitter'
         } %}
 
         {% set linkedin_info = {
             'name': 'LinkedIn',
-            'homepage': unsigned_redirect('https://www.linkedin.com/company/consumer-financial-protection-bureau'),
-            'share_url': signed_redirect('https://www.linkedin.com/shareArticle?mini=true&url=' ~ parsed_url ~ '&title=' ~ linkedin_title ~ '&summary=' ~ linkedin_text),
+            'homepage': 'https://www.linkedin.com/company/consumer-financial-protection-bureau',
+            'share_url': 'https://www.linkedin.com/shareArticle?mini=true&url=' ~ parsed_url ~ '&title=' ~ linkedin_title ~ '&summary=' ~ linkedin_text,
             'icon': 'linkedin'
         } %}
 
@@ -120,13 +120,13 @@
 
         {% set youtube_info = {
             'name': 'YouTube',
-            'homepage': unsigned_redirect('https://www.youtube.com/user/cfpbvideo'),
+            'homepage': 'https://www.youtube.com/user/cfpbvideo',
             'icon': 'youtube'
         } %}
 
         {% set flickr_info = {
             'name': 'Flickr',
-            'homepage': unsigned_redirect('https://www.flickr.com/photos/cfpbphotos'),
+            'homepage': 'https://www.flickr.com/photos/cfpbphotos',
             'icon': 'flickr'
         } %}
 

--- a/cfgov/jinja2/v1/blog/blog_page.html
+++ b/cfgov/jinja2/v1/blog/blog_page.html
@@ -22,12 +22,12 @@
             Join the conversation. Follow CFPB on
             <a class="a-link
                       a-link__icon"
-               href="{{ unsigned_redirect('https://twitter.com/CFPB') }}">
+               href="https://twitter.com/CFPB">
                 <span class="a-link_text">Twitter</span>
             </a> and
             <a class="a-link
                       a-link__icon"
-               href="{{ unsigned_redirect('https://www.facebook.com/CFPB') }}">
+               href="https://www.facebook.com/CFPB">
                 <span class="a-link_text">Facebook</span></a>.
         </p>
     </div>


### PR DESCRIPTION
This commit deprecates the definition and use of two template tags: `signed_redirect` and `unsigned_redirect`. These template tags are used to modify external linked URLs so that they go through an interstitial view. Because we apply URL rewrite logic globally through [middleware that processes all Django requests](https://github.com/cfpb/cfgov-refresh/blob/d48b4a5af6e928bf35fe982f7eeb96793c497e46/cfgov/cfgov/settings/base.py#L118), using these tags in templates is  redundant and can be misleading; for example, using `unsigned_redirect` in a template gets converted to a signed_redirect in the middleware.

It turns out that `unsigned_redirect` isn't really used: anywhere that we redirect through the interstitial, we want to sign the URL so that we only redirect to intended destinations. So this commit also removes that method.

## How to test this PR

Run  a local server and verify that pages using the modified templates still properly wrap their external links:

- http://localhost:8000/find-a-housing-counselor/?zipcode=18020#hud_search_container
   - the links to "list of nationwide HUD-approved counseling agencies" and "HUD's" go to .gov URLs, and [we don't use the interstitial page for those](https://github.com/cfpb/cfgov-refresh/blob/d48b4a5af6e928bf35fe982f7eeb96793c497e46/cfgov/core/utils.py#L106-L113).
   - links to non-gov housing counselors should go through the interstitial.
   - link in the footer to "3170-0025" also goes to a .gov URL and thus should not be wrapped.
   - social media links below the page content ("SHARE THIS") should go through an interstitial before trying to share on Facebook, Twitter, LinkedIn, or as an email.
   - social media links in the footer properly use the interstitial to go to CFPB's Facebook, Twitter, LinkedIn, YouTube, and Flickr pages.
- http://localhost:8000/about-us/blog/guide-covid-19-economic-stimulus-checks/
   - Links  in "Join the conversation. Follow CFPB on Twitter and Facebook." before the page footer properly go through the page interstitial.

Also confirm that no other active CFPB code uses these tags besides the files changed here ([1](https://github.com/search?q=user%3Acfpb+signed_redirect&type=Code), [2](https://github.com/search?q=user%3Acfpb+unsigned_redirect&type=Code)).

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)