### PR TITLE
Fix spacing around iRegs notifications

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -212,63 +212,65 @@
             {{ render_block.render(block, loop.index) }}
         {%- endfor %}
 
-        {% if requested_version != current_version %}
-        <div class="block block__flush-regs3k">
-            <div class="m-full-width-text
-                        m-notification
-                        m-notification__visible
-                        m-notification__warning">
-                {{ svg_icon('warning-round') }}
-                <div class="m-notification_content">
-                    <div class="h4 m-notification_message">This version is not the current regulation.</div>
-                    <p class="m-notification_explanation">
-                        {% if requested_version.effective_date < current_version.effective_date %}
-                            You are viewing a previous version of this regulation with amendments that went into effect on {{ ap_date(requested_version.effective_date) }}.
-                        {% endif %}
-                        {% if requested_version.effective_date > current_version.effective_date %}
-                            You are viewing a future version of this regulation with amendments that will go into effect on {{ ap_date(requested_version.effective_date) }}.
-                        {% endif %}
-                    </p>
+        <div class="block block__flush-bottom block__flush-regs3k">
+            {% if requested_version != current_version %}
+            <div class="block block__sub">
+                <div class="m-full-width-text
+                            m-notification
+                            m-notification__visible
+                            m-notification__warning">
+                    {{ svg_icon('warning-round') }}
+                    <div class="m-notification_content">
+                        <div class="h4 m-notification_message">This version is not the current regulation.</div>
+                        <p class="m-notification_explanation">
+                            {% if requested_version.effective_date < current_version.effective_date %}
+                                You are viewing a previous version of this regulation with amendments that went into effect on {{ ap_date(requested_version.effective_date) }}.
+                            {% endif %}
+                            {% if requested_version.effective_date > current_version.effective_date %}
+                                You are viewing a future version of this regulation with amendments that will go into effect on {{ ap_date(requested_version.effective_date) }}.
+                            {% endif %}
+                        </p>
+                    </div>
                 </div>
             </div>
+            {% endif %}
+
+            <div class="block block__sub">
+                    <ul class="m-list m-list__links m-full-width-text">
+                        {% if requested_version == current_version %}
+                            <li class="m-list_item">
+                                <a class="m-list_link" href="{{ routablepageurl(page, 'section', section_label=sections[0].label) }}">
+                                    View current regulation
+                                </a>
+                            </li>
+                        {% else %}
+                            <li class="m-list_item">
+                                <a class="m-list_link" href="{{ routablepageurl(page, 'section', date_str=date_str, section_label=sections[0].label) }}">
+                                    View this version
+                                </a>
+                            </li>
+                        {% endif %}
+
+                        {% if num_versions > 1 %}
+                            <li class="m-list_item">
+                                <a class="m-list_link" href="{{ routablepageurl(page, 'versions') }}">
+                                    View all versions of this regulation
+                                </a>
+                            </li>
+                        {% endif %}
+
+                        {% if requested_version == current_version %}
+                            <li class="m-list_item">
+                                <a class="m-list_link" href="{{ search_url }}">
+                                    Search this regulation
+                                </a>
+                            </li>
+                        {% endif %}
+                    </ul>
+            </div>
+
+            <div class="a-rule-break m-full-width-text"></div>
         </div>
-        {% endif %}
-
-        <div class="block block__flush-regs3k">
-                <ul class="m-list m-list__links m-full-width-text">
-                    {% if requested_version == current_version %}
-                        <li class="m-list_item">
-                            <a class="m-list_link" href="{{ routablepageurl(page, 'section', section_label=sections[0].label) }}">
-                                View current regulation
-                            </a>
-                        </li>
-                    {% else %}
-                        <li class="m-list_item">
-                            <a class="m-list_link" href="{{ routablepageurl(page, 'section', date_str=date_str, section_label=sections[0].label) }}">
-                                View this version
-                            </a>
-                        </li>
-                    {% endif %}
-
-                    {% if num_versions > 1 %}
-                        <li class="m-list_item">
-                            <a class="m-list_link" href="{{ routablepageurl(page, 'versions') }}">
-                                View all versions of this regulation
-                            </a>
-                        </li>
-                    {% endif %}
-
-                    {% if requested_version == current_version %}
-                        <li class="m-list_item">
-                            <a class="m-list_link" href="{{ search_url }}">
-                                Search this regulation
-                            </a>
-                        </li>
-                    {% endif %}
-                </ul>
-        </div>
-
-        <div class="a-rule-break m-full-width-text"></div>
 
         {% for block in page.content -%}
             {{ render_block.render(block, loop.index) }}

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
@@ -44,5 +44,4 @@
 // Helper class to correct regs3k notifications alignment
 .block__flush-regs3k {
     margin-top: -30px;
-    margin-bottom: 30px;
 }


### PR DESCRIPTION
Currently, there's no bottom margin between the notification on an iRegs landing page and the links that follow it. There should be a 30px margin between the notification and links.

See GHE/CFGOV/platform/issues/3513 for more details.

---

## Changes

- Change the HTML and CSS that control the margin between notifications and the list of links on iRegs landing pages

## How to test this PR

1. Visit the landing page of a previous or future version of a regulation in production, like https://www.consumerfinance.gov/policy-compliance/rulemaking/regulations/1005/2019-04-01/. Note the lack of margin between the "This version is not the current regulation" notification and the link list below it.
2. Visit the same regulation landing page in this branch and make sure there's 30 px margin between the notification and the link list. That margin should be 30 px at all screen sizes.

## Screenshots

Production | This PR
---- | ----
![production](https://user-images.githubusercontent.com/1862695/88854169-e689bf80-d1be-11ea-92b2-f69dc946cc50.png) | ![pr](https://user-images.githubusercontent.com/1862695/88854166-e5f12900-d1be-11ea-8135-7e2c3a0648bf.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)