### PR TITLE
Ignore Visual Studio Code workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ cfgov/paying_for_college/fixtures/national_stats_backup.json
 # IDE Specifc #
 ###############
 *.idea
+.vscode
 
 # Auto-generated service workers #
 ##################################


### PR DESCRIPTION
This commit adds the .vscode folder to .gitignore so that Visual Studio Code workspace settings aren't tracked in source control.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)