### PR TITLE
Update curriculum-review-tool to 2.0.2

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -50,4 +50,4 @@ https://github.com/cfpb/retirement/releases/download/0.13.0/retirement-0.13.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.2.3/ccdb5_ui-2.2.3-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.1/comparisontool-1.15.1-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.1/crtool-2.0.1-py3-none-any.whl
+https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.2/crtool-2.0.2-py3-none-any.whl


### PR DESCRIPTION
Eliminates a warning about an unused dependency.


## Changes

- Updates crtool package to 2.0.2


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)