### PR TITLE
Fix name of Page Metadata in admin tests

### DIFF
--- a/test/cypress/pages/admin/admin.js
+++ b/test/cypress/pages/admin/admin.js
@@ -193,7 +193,7 @@ export class AdminPage {
 
   getPageMetadataReports() {
     this.openNavigationTab( 'Reports' );
-    this.selectSubMenu( 'Page metadata' );
+    this.selectSubMenu( 'Page Metadata' );
     return cy.get( '.listing' ).find( 'tr' );
   }
 


### PR DESCRIPTION
Correct the name of the "Page Metadata" menu item in the admin functional test for the page metadata reports.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
