### PR TITLE
Move to generic docker label to expand jenkins agent options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 // GHE repo: app-ops/app-ops-jenkins-shared-libraries
 pipeline {
     agent {
-        label 'docker-agent'
+        label 'docker'
     }
 
     environment {


### PR DESCRIPTION
Moves to a shared label between the docker-agent and docker-backup-agent. This will double the number of executors we can run on.