### PR TITLE
Restore tox venv update plugin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-# tox_pip_extensions_ext_venv_update=True
+tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
 envlist=lint-{current}, validate-migrations, unittest-{current,future}
 


### PR DESCRIPTION
We had the tox venv update plugin commented out. This change uncomments to restore it to use.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
