### PR TITLE
Update openpyxl from 2.5.8 to 3.0.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -28,7 +28,7 @@ jsonfield==2.0.2
 lxml==4.2.5
 Markdown==3.2.1
 ntplib==0.3.4
-openpyxl==2.6.0
+openpyxl==3.0.3
 psycopg2==2.7.3.2
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -28,7 +28,7 @@ jsonfield==2.0.2
 lxml==4.2.5
 Markdown==3.2.1
 ntplib==0.3.4
-openpyxl==2.5.8
+openpyxl==2.6.0
 psycopg2==2.7.3.2
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3


### PR DESCRIPTION
In order to prepare to support Wagtail 2.10 openpyxl version needs to be newer than 2.5.8

Refer to https://openpyxl.readthedocs.io/en/stable/changes.html#id9 for the bug fixes