### PR TITLE
Temporarily fetch all tags and branches when checking coverage

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -68,8 +68,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -50,8 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v1


### PR DESCRIPTION
For some reason, our existing attempt to checkout the master branch in the coverage checks to compare coverage of the current branch against master stopped working.

So that coverage checks stop failing, this change fetches all branches and tags in that job. It seems to add about 40s to the run time.

**This is temporary** until we can find a way to checkout  just the current branch and master in this job. This will stop our coverage check from erroring. 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
