### PR TITLE
Allow any admins to view page metadata report

### DIFF
--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -8,7 +8,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils.html import format_html_join
 
-from wagtail.admin.menu import AdminOnlyMenuItem, MenuItem
+from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text.converters.editor_html import (
     WhitelistRule as AllowlistRule
 )
@@ -248,7 +248,7 @@ def serve_latest_draft_page(page, request, args, kwargs):
 
 @hooks.register('register_reports_menu_item')
 def register_page_metadata_report_menu_item():
-    return AdminOnlyMenuItem(
+    return MenuItem(
         "Page Metadata",
         reverse('page_metadata_report'),
         classnames='icon icon-' + PageMetadataReportView.header_icon,


### PR DESCRIPTION
Previously the Page Metadata report was admin-only. This change ensures anyone with access to the Wagtail Admin can see the page metadata report for live Wagtail pages.

## How to test this PR

1. Login as a user that's not `admin` but does have access to "CFGov" pages in permissions (like "Internal Editor") and observe that the "Reports" menu does not include "Page Metadata"
2. Check out this branch.
3. Refresh, and notice "Page metadata" now appears, can be viewed, and can be exported.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)