### PR TITLE
Remove broken feed from legacy base template

### DIFF
--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -85,7 +85,6 @@
 
     <!-- Feeds -->
     <link rel="alternate" type="application/rss+xml" title="Consumer Financial Protection Bureau &raquo; Feed" href="/feed/" />
-    <link rel="alternate" type="application/rss+xml" title="Consumer Financial Protection Bureau &raquo; Comments Feed" href="/comments/feed/" />
     {% block page_feeds %}
     {% endblock %}
 


### PR DESCRIPTION
The legacy base_update.html template currently includes a header link to a [/comments/feed/](https://www.consumerfinance.gov/comments/feed/) URL that no longer exists and returns 410 gone.

An example live page that uses this template is https://www.consumerfinance.gov/data-research/consumer-complaints/.

This commit removes the link to this feed.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)