### PR TITLE
Move where we add the documents url

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -83,7 +83,7 @@ def empty_200_response(request, *args, **kwargs):
 
 urlpatterns = [
 
-    re_path(r'^documents/', include(wagtaildocs_urls))
+    re_path(r'^documents/', include(wagtaildocs_urls)),
 
     re_path(r'^rural-or-underserved-tool/$', TemplateView.as_view(
         template_name='rural-or-underserved/index.html'),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -82,6 +82,9 @@ def empty_200_response(request, *args, **kwargs):
 
 
 urlpatterns = [
+
+    re_path(r'^documents/', include(wagtaildocs_urls))
+
     re_path(r'^rural-or-underserved-tool/$', TemplateView.as_view(
         template_name='rural-or-underserved/index.html'),
         name='rural-or-underserved'),
@@ -726,7 +729,6 @@ if settings.ALLOW_ADMIN_URL:
         ),
         re_path(r'^admin/autocomplete/', include(autocomplete_admin_urls)),
         re_path(r'^admin/', include(wagtailadmin_urls)),
-        re_path(r'^documents/', include(wagtaildocs_urls))
 
     ]
 


### PR DESCRIPTION
Originally added the documents route to a section that was only loaded if we enable the admin, this moves it to always be provided.

---


## Changes

- Where we define the document URL.


## How to test this PR

1.


## Screenshots


## Notes and todos

- Resovles a production issue with some links.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance