### PR TITLE
ParseLinksMiddleware shouldn't error if responses don't contain Content-Type

### DIFF
--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -60,7 +60,10 @@ class ParseLinksMiddleware(object):
 
     def __call__(self, request):
         response = self.get_response(request)
-        if self.should_parse_links(request.path, response['content-type']):
+        if self.should_parse_links(
+            request.path,
+            response.get('Content-Type', '')
+        ):
             response.content = parse_links(
                 response.content,
                 request.path,

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -47,6 +47,12 @@ class TestShouldParseLinks(TestCase):
             response_content_type='application/json'
         ))
 
+    def test_should_not_parse_links_if_empty(self):
+        self.assertFalse(ParseLinksMiddleware.should_parse_links(
+            request_path='/foo/bar',
+            response_content_type=''
+        ))
+
     def test_should_parse_links_if_html(self):
         self.assertTrue(ParseLinksMiddleware.should_parse_links(
             request_path='/foo/bar',


### PR DESCRIPTION
Prevents 500s when content-type is mysteriously unset